### PR TITLE
Add sqlclient-ci-managed-instance CI pipeline

### DIFF
--- a/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml
+++ b/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml
@@ -109,6 +109,26 @@ jobs:
 
     steps:
 
+      # Check out the repo with full history so the working tree can be aligned to the exact commit
+      # that produced the consumed sqlclient-ci-package artifact (see the next step).
+      - checkout: self
+        fetchDepth: 0
+
+      # Align the working-tree source with the commit that built the downloaded package, so the test
+      # projects compile against the matching (internal) API surface.  This only repoints the
+      # built/tested source; the running pipeline definition and its @self templates were compiled
+      # from the triggered branch tip at queue time and are unaffected.  When the resource commit is
+      # unavailable (e.g. some manual runs), the checked-out source is used as-is.
+      - pwsh: |
+          $sha = "$(resources.pipeline.sqlclient-ci-package.sourceCommit)"
+          if ([string]::IsNullOrWhiteSpace($sha)) {
+              Write-Host "No sqlclient-ci-package sourceCommit available; using checked-out source as-is."
+          } else {
+              Write-Host "Aligning source to sqlclient-ci-package commit $sha"
+              git checkout --force $sha
+          }
+        displayName: Align Source With Package Commit
+
       # Download the SqlClient driver packages published by the triggering sqlclient-ci-package
       # pipeline, stage them into the local NuGet feed, and resolve their exact versions into the
       # sqlClient/sqlServer/abstractions/logging/azure PackageVersion variables.

--- a/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml
+++ b/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml
@@ -56,13 +56,9 @@ parameters:
       - Linux
       - Windows
 
-  # The list of .NET Framework runtimes to test against.
-  - name: netFrameworkTestRuntimes
-    type: object
-
-  # The list of .NET runtimes to test against.
-  - name: netTestRuntimes
-    type: object
+  # The .NET runtime (TFM) to build and run the tests for.
+  - name: targetFramework
+    type: string
 
   # The timeout, in minutes, for this job.
   - name: timeout
@@ -116,7 +112,12 @@ jobs:
       # Download the SqlClient driver packages published by the triggering sqlclient-ci-package
       # pipeline, stage them into the local NuGet feed, and resolve their exact versions into the
       # sqlClient/sqlServer/abstractions/logging/azure PackageVersion variables.
+      #
+      # sqlServerVersionOverride pins Microsoft.SqlServer.Server to the released stable 1.0.0 to
+      # avoid an NU1605 downgrade against the >= 1.0.0 dependency from Microsoft.SqlServer.Types.
       - template: /eng/pipelines/common/steps/download-driver-packages-step.yml@self
+        parameters:
+          sqlServerVersionOverride: 1.0.0
 
       # Install the .NET SDK and the runtimes needed to execute the test frameworks.
       - template: /eng/pipelines/common/steps/install-dotnet.yml@self
@@ -182,48 +183,25 @@ jobs:
       - pwsh: Write-Host '##vso[task.setvariable variable=setupSucceeded]true'
         displayName: 'Gate: Mark Setup Succeeded'
 
-      # Build and run the Unit, Functional, and Manual test suites for each .NET runtime.  A blank
-      # testSet lets build.proj run all manual tests (its default), matching the Classic pipeline.
-      - ${{ each runtime in parameters.netTestRuntimes }}:
-        - template: /eng/pipelines/common/templates/steps/run-all-tests-step.yml@self
-          parameters:
-            debug: ${{ parameters.debug }}
-            targetFramework: ${{ runtime }}
-            buildConfiguration: ${{ parameters.buildConfiguration }}
-            referenceType: Package
-            testSet: ''
-            operatingSystem: ${{ parameters.operatingSystem }}
-            abstractionsPackageVersion: $(abstractionsPackageVersion)
-            loggingPackageVersion: $(loggingPackageVersion)
-            mdsPackageVersion: $(sqlClientPackageVersion)
-            sqlServerPackageVersion: $(sqlServerPackageVersion)
+      # Build and run the Unit, Functional, and Manual test suites for this job's .NET runtime.  A
+      # blank testSet lets build.proj run all manual tests (its default), matching the Classic
+      # pipeline.
+      - template: /eng/pipelines/common/templates/steps/run-all-tests-step.yml@self
+        parameters:
+          debug: ${{ parameters.debug }}
+          targetFramework: ${{ parameters.targetFramework }}
+          buildConfiguration: ${{ parameters.buildConfiguration }}
+          referenceType: Package
+          testSet: ''
+          operatingSystem: ${{ parameters.operatingSystem }}
+          abstractionsPackageVersion: $(abstractionsPackageVersion)
+          loggingPackageVersion: $(loggingPackageVersion)
+          mdsPackageVersion: $(sqlClientPackageVersion)
+          sqlServerPackageVersion: $(sqlServerPackageVersion)
 
-        - template: /eng/pipelines/common/templates/steps/publish-test-results-step.yml@self
-          parameters:
-            debug: ${{ parameters.debug }}
-            targetFramework: ${{ runtime }}
-            operatingSystem: ${{ parameters.operatingSystem }}
-            buildConfiguration: ${{ parameters.buildConfiguration }}
-
-      # Build and run the test suites for each .NET Framework runtime (Windows only).  A blank
-      # testSet lets build.proj run all manual tests (its default), matching the Classic pipeline.
-      - ${{ each runtime in parameters.netFrameworkTestRuntimes }}:
-        - template: /eng/pipelines/common/templates/steps/run-all-tests-step.yml@self
-          parameters:
-            debug: ${{ parameters.debug }}
-            targetFramework: ${{ runtime }}
-            buildConfiguration: ${{ parameters.buildConfiguration }}
-            referenceType: Package
-            testSet: ''
-            operatingSystem: ${{ parameters.operatingSystem }}
-            abstractionsPackageVersion: $(abstractionsPackageVersion)
-            loggingPackageVersion: $(loggingPackageVersion)
-            mdsPackageVersion: $(sqlClientPackageVersion)
-            sqlServerPackageVersion: $(sqlServerPackageVersion)
-
-        - template: /eng/pipelines/common/templates/steps/publish-test-results-step.yml@self
-          parameters:
-            debug: ${{ parameters.debug }}
-            targetFramework: ${{ runtime }}
-            operatingSystem: ${{ parameters.operatingSystem }}
-            buildConfiguration: ${{ parameters.buildConfiguration }}
+      - template: /eng/pipelines/common/templates/steps/publish-test-results-step.yml@self
+        parameters:
+          debug: ${{ parameters.debug }}
+          targetFramework: ${{ parameters.targetFramework }}
+          operatingSystem: ${{ parameters.operatingSystem }}
+          buildConfiguration: ${{ parameters.buildConfiguration }}

--- a/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml
+++ b/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml
@@ -3,14 +3,14 @@
 # file to you under the MIT license.  See the LICENSE file in the project root for more information.
 ####################################################################################################
 
-# This job builds and runs the SqlClient Unit, Functional, and Manual test suites against an Azure
-# SQL Managed Instance.  The SqlClient NuGet packages produced by the sqlclient-ci-package pipeline
-# are downloaded into the local NuGet feed (packages/) and the test projects are built in "Package"
-# mode (ReferenceType=Package) against the exact package versions produced by that pipeline.
+# This job builds and runs the SqlClient Manual test suite against an Azure SQL Managed Instance.
+# The SqlClient NuGet packages produced by the sqlclient-ci-package pipeline are downloaded into the
+# local NuGet feed (packages/) and the test project is built in "Package" mode
+# (ReferenceType=Package) against the exact package versions produced by that pipeline.
 #
-# The Managed Instance connection strings are provided by the "ADO Test Configuration Properties"
-# variable group (SQL_MI_TCP_CONN_STRING and SQL_MI_NP_CONN_STRING).  This job runs on the
-# Managed-Instance-pool, whose agents have network line-of-sight to the Managed Instance.
+# The Managed Instance TCP connection string is provided by the "ADO Test Configuration Properties"
+# variable group (SQL_MI_TCP_CONN_STRING).  This job runs on the Managed-Instance-pool, whose agents
+# have network line-of-sight to the Managed Instance.
 #
 # This template defines a job named 'managed_instance_tests_job_<suffix>' that can be depended on by
 # downstream jobs.
@@ -85,17 +85,9 @@ jobs:
 
     variables:
 
-      # Import the variable group that provides the Managed Instance connection strings
-      # (SQL_MI_TCP_CONN_STRING and SQL_MI_NP_CONN_STRING) and other test configuration.
+      # Import the variable group that provides the Managed Instance TCP connection string
+      # (SQL_MI_TCP_CONN_STRING) and other test configuration.
       - group: ADO Test Configuration Properties
-
-      # Path to the strong-name key used to sign the test assemblies.  The sqlclient-ci-package
-      # driver assemblies are signed and grant InternalsVisibleTo to the test assemblies signed with
-      # the dedicated test key's public key, so the tests must be signed with that key.  build.proj
-      # reads this from the environment and forwards it to the unit-test build (TestSigningKeyPath);
-      # the value is populated by the 'Download Test Signing Key' step below.
-      - name: TestSigningKeyPath
-        value: $(testSigningKey.secureFilePath)
 
     # The Managed-Instance-pool agents have network line-of-sight to the Managed Instance.
     pool:
@@ -133,16 +125,6 @@ jobs:
       - task: NuGetAuthenticate@1
         displayName: Authenticate NuGet feeds
 
-      # Download the dedicated test strong-name key so the test assemblies can be signed with the
-      # key whose public key the signed sqlclient-ci-package driver assemblies grant
-      # InternalsVisibleTo to.  The downloaded path is surfaced via the TestSigningKeyPath variable
-      # above.
-      - task: DownloadSecureFile@1
-        displayName: Download Test Signing Key
-        name: testSigningKey
-        inputs:
-          secureFile: sqlclient-test-key.snk
-
       # Write the config.jsonc file pointing the tests at the Managed Instance.  Integrated security
       # and managed identity are not supported against the Managed Instance, and IsManagedInstance
       # opts the test suite into Managed-Instance-specific behavior.
@@ -153,7 +135,8 @@ jobs:
           # password is used here; pass an empty string for the required saPassword parameter.
           saPassword: ''
           TCPConnectionString: $(SQL_MI_TCP_CONN_STRING)
-          NPConnectionString: $(SQL_MI_NP_CONN_STRING)
+          # Azure SQL Managed Instance exposes TDS over TCP and does not support Named Pipes.
+          NPConnectionString: ''
           SupportsIntegratedSecurity: false
           ManagedIdentitySupported: false
           IsManagedInstance: true
@@ -170,24 +153,29 @@ jobs:
       - pwsh: Write-Host '##vso[task.setvariable variable=setupSucceeded]true'
         displayName: 'Gate: Mark Setup Succeeded'
 
-      # Build and run the Unit, Functional, and Manual test suites for this job's .NET runtime.  A
-      # blank testSet lets build.proj run all manual tests (its default), matching the Classic
-      # pipeline.
-      - template: /eng/pipelines/common/templates/steps/run-all-tests-step.yml@self
-        parameters:
-          debug: ${{ parameters.debug }}
-          dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
-          targetFramework: ${{ parameters.runtime }}
-          buildConfiguration: ${{ parameters.buildConfiguration }}
-          referenceType: Package
-          testSet: ''
-          operatingSystem: ${{ parameters.operatingSystem }}
-          abstractionsPackageVersion: $(abstractionsPackageVersion)
-          loggingPackageVersion: $(loggingPackageVersion)
-          mdsPackageVersion: $(sqlClientPackageVersion)
-          sqlServerPackageVersion: $(sqlServerPackageVersion)
-          # The Managed Instance pipeline does not run the quarantined flaky tests.
-          runFlakyTests: false
+      # Run ManualTests sets 1, 2, and 3 against the Managed Instance using the exact upstream
+      # package versions.  UnitTests and FunctionalTests do not exercise the configured instance.
+      # Set AE is omitted because this pipeline does not provision its separate AE, enclave, and AKV
+      # resources.  build.proj's default filter also excludes failing, flaky, and interactive tests.
+      - task: DotNetCoreCLI@2
+        displayName: Run Managed Instance Tests
+        condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
+        inputs:
+          command: build
+          projects: build.proj
+          arguments: >-
+            --verbosity ${{ parameters.dotnetVerbosity }}
+            -t:TestSqlClientManual
+            -p:TestFramework=${{ parameters.runtime }}
+            -p:TestSet=123
+            -p:ReferenceType=Package
+            -p:Configuration=${{ parameters.buildConfiguration }}
+            -p:PackageVersionAbstractions=$(abstractionsPackageVersion)
+            -p:PackageVersionLogging=$(loggingPackageVersion)
+            -p:PackageVersionSqlClient=$(sqlClientPackageVersion)
+            -p:PackageVersionSqlServer=$(sqlServerPackageVersion)
+            -p:TestResultsFolderPath=TestResults
+        retryCountOnTaskFailure: 2
 
       - template: /eng/pipelines/common/templates/steps/publish-test-results-step.yml@self
         parameters:

--- a/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml
+++ b/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml
@@ -93,6 +93,14 @@ jobs:
       # (SQL_MI_TCP_CONN_STRING and SQL_MI_NP_CONN_STRING) and other test configuration.
       - group: ADO Test Configuration Properties
 
+      # Path to the strong-name key used to sign the test assemblies.  The sqlclient-ci-package
+      # driver assemblies are signed and grant InternalsVisibleTo to the test assemblies signed with
+      # the dedicated test key's public key, so the tests must be signed with that key.  build.proj
+      # reads this from the environment and forwards it to the unit-test build (TestSigningKeyPath);
+      # the value is populated by the 'Download Test Signing Key' step below.
+      - name: TestSigningKeyPath
+        value: $(testSigningKey.secureFilePath)
+
     # The Managed-Instance-pool agents have network line-of-sight to the Managed Instance.
     pool:
       name: Managed-Instance-pool
@@ -119,6 +127,16 @@ jobs:
       # fetched through the ADO Artifacts feed.
       - task: NuGetAuthenticate@1
         displayName: Authenticate NuGet feeds
+
+      # Download the dedicated test strong-name key so the test assemblies can be signed with the
+      # key whose public key the signed sqlclient-ci-package driver assemblies grant
+      # InternalsVisibleTo to.  The downloaded path is surfaced via the TestSigningKeyPath variable
+      # above.
+      - task: DownloadSecureFile@1
+        displayName: Download Test Signing Key
+        name: testSigningKey
+        inputs:
+          secureFile: sqlclient-test-key.snk
 
       # Write the config.jsonc file pointing the tests at the Managed Instance.  Integrated security
       # and managed identity are not supported against the Managed Instance, and IsManagedInstance

--- a/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml
+++ b/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml
@@ -72,6 +72,7 @@ parameters:
   # True to use managed SNI on Windows.  Ignored on non-Windows, where managed SNI is always used.
   - name: useManagedSNI
     type: boolean
+    default: false
 
   # The pool VM image to use.  The Managed-Instance-pool must provide an image with this name.
   #

--- a/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml
+++ b/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml
@@ -198,6 +198,8 @@ jobs:
           loggingPackageVersion: $(loggingPackageVersion)
           mdsPackageVersion: $(sqlClientPackageVersion)
           sqlServerPackageVersion: $(sqlServerPackageVersion)
+          # The Managed Instance pipeline does not run the quarantined flaky tests.
+          runFlakyTests: false
 
       - template: /eng/pipelines/common/templates/steps/publish-test-results-step.yml@self
         parameters:

--- a/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml
+++ b/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml
@@ -28,11 +28,8 @@ parameters:
   - name: debug
     type: boolean
 
-  # The prefix to prepend to the job's display name:
-  #
-  #   [<prefix>] Run Managed Instance Tests
-  #
-  - name: displayNamePrefix
+  # The job's display name.
+  - name: displayName
     type: string
 
   # The verbosity level for the dotnet CLI commands.
@@ -80,7 +77,7 @@ parameters:
 
 jobs:
   - job: managed_instance_tests_job_${{ parameters.jobNameSuffix }}
-    displayName: '[${{ parameters.displayNamePrefix }}] Run Managed Instance Tests'
+    displayName: ${{ parameters.displayName }}
     timeoutInMinutes: ${{ parameters.timeout }}
 
     variables:

--- a/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml
+++ b/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml
@@ -36,11 +36,11 @@ parameters:
   - name: dotnetVerbosity
     type: string
     values:
-    - quiet
-    - minimal
-    - normal
-    - detailed
-    - diagnostic
+      - quiet
+      - minimal
+      - normal
+      - detailed
+      - diagnostic
 
   # The suffix to append to the job name.
   - name: jobNameSuffix
@@ -54,13 +54,13 @@ parameters:
       - Windows
 
   # The .NET runtime (TFM) to build and run the tests for.
-  - name: targetFramework
+  - name: runtime
     type: string
 
   # The timeout, in minutes, for this job.
   - name: timeout
     type: number
-    default: 120
+    default: 90
 
   # True to use managed SNI on Windows.  Ignored on non-Windows, where managed SNI is always used.
   - name: useManagedSNI
@@ -79,6 +79,9 @@ jobs:
   - job: managed_instance_tests_job_${{ parameters.jobNameSuffix }}
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: ${{ parameters.timeout }}
+
+    workspace:
+      clean: all
 
     variables:
 
@@ -156,19 +159,6 @@ jobs:
           IsManagedInstance: true
           UseManagedSNIOnWindows: ${{ parameters.useManagedSNI }}
 
-      # On Windows, start the SQL Browser service so that named-pipes connections can be resolved.
-      - ${{ if eq(parameters.operatingSystem, 'Windows') }}:
-        - pwsh: |
-            $svc_name = "SQLBrowser"
-            if ((Get-Service -Name "$svc_name" -ErrorAction SilentlyContinue) -ne $null) {
-                Get-Service $svc_name | Select-Object -Property Name, StartType, Status
-                Set-Service -StartupType Automatic $svc_name
-                net start $svc_name
-                Get-Service $svc_name | Select-Object -Property Name, StartType, Status
-            }
-          displayName: Start Sql Browser
-          condition: eq(variables['Agent.OS'], 'Windows_NT')
-
       # Ensure the TestResults directory exists so publish steps don't fail when tests are skipped
       # due to a setup failure.
       - pwsh: New-Item -ItemType Directory -Path TestResults -Force | Out-Null
@@ -186,7 +176,8 @@ jobs:
       - template: /eng/pipelines/common/templates/steps/run-all-tests-step.yml@self
         parameters:
           debug: ${{ parameters.debug }}
-          targetFramework: ${{ parameters.targetFramework }}
+          dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          targetFramework: ${{ parameters.runtime }}
           buildConfiguration: ${{ parameters.buildConfiguration }}
           referenceType: Package
           testSet: ''
@@ -201,6 +192,6 @@ jobs:
       - template: /eng/pipelines/common/templates/steps/publish-test-results-step.yml@self
         parameters:
           debug: ${{ parameters.debug }}
-          targetFramework: ${{ parameters.targetFramework }}
+          targetFramework: ${{ parameters.runtime }}
           operatingSystem: ${{ parameters.operatingSystem }}
           buildConfiguration: ${{ parameters.buildConfiguration }}

--- a/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml
+++ b/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml
@@ -109,25 +109,9 @@ jobs:
 
     steps:
 
-      # Check out the repo with full history so the working tree can be aligned to the exact commit
-      # that produced the consumed sqlclient-ci-package artifact (see the next step).
-      - checkout: self
-        fetchDepth: 0
-
-      # Align the working-tree source with the commit that built the downloaded package, so the test
-      # projects compile against the matching (internal) API surface.  This only repoints the
-      # built/tested source; the running pipeline definition and its @self templates were compiled
-      # from the triggered branch tip at queue time and are unaffected.  When the resource commit is
-      # unavailable (e.g. some manual runs), the checked-out source is used as-is.
-      - pwsh: |
-          $sha = "$(resources.pipeline.sqlclient-ci-package.sourceCommit)"
-          if ([string]::IsNullOrWhiteSpace($sha)) {
-              Write-Host "No sqlclient-ci-package sourceCommit available; using checked-out source as-is."
-          } else {
-              Write-Host "Aligning source to sqlclient-ci-package commit $sha"
-              git checkout --force $sha
-          }
-        displayName: Align Source With Package Commit
+      # Check out the repo and align the working-tree source with the commit that built the upstream
+      # sqlclient-ci-package artifacts, so the test projects compile against the matching API surface.
+      - template: /eng/pipelines/common/steps/align-source-with-upstream-step.yml@self
 
       # Download the SqlClient driver packages published by the triggering sqlclient-ci-package
       # pipeline, stage them into the local NuGet feed, and resolve their exact versions into the

--- a/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml
+++ b/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml
@@ -1,0 +1,206 @@
+####################################################################################################
+# Licensed to the .NET Foundation under one or more agreements.  The .NET Foundation licenses this
+# file to you under the MIT license.  See the LICENSE file in the project root for more information.
+####################################################################################################
+
+# This job builds and runs the SqlClient Unit, Functional, and Manual test suites against an Azure
+# SQL Managed Instance.  The SqlClient NuGet packages produced by the sqlclient-ci-package pipeline
+# are downloaded into the local NuGet feed (packages/) and the test projects are built in "Package"
+# mode (ReferenceType=Package) against the exact package versions produced by that pipeline.
+#
+# The Managed Instance connection strings are provided by the "ADO Test Configuration Properties"
+# variable group (SQL_MI_TCP_CONN_STRING and SQL_MI_NP_CONN_STRING).  This job runs on the
+# Managed-Instance-pool, whose agents have network line-of-sight to the Managed Instance.
+#
+# This template defines a job named 'managed_instance_tests_job_<suffix>' that can be depended on by
+# downstream jobs.
+
+parameters:
+
+  # The type of build to produce (Debug or Release).
+  - name: buildConfiguration
+    type: string
+    values:
+      - Debug
+      - Release
+
+  # True to enable debugging steps.
+  - name: debug
+    type: boolean
+
+  # The prefix to prepend to the job's display name:
+  #
+  #   [<prefix>] Run Managed Instance Tests
+  #
+  - name: displayNamePrefix
+    type: string
+
+  # The verbosity level for the dotnet CLI commands.
+  - name: dotnetVerbosity
+    type: string
+    values:
+    - quiet
+    - minimal
+    - normal
+    - detailed
+    - diagnostic
+
+  # The suffix to append to the job name.
+  - name: jobNameSuffix
+    type: string
+
+  # The OS to build and run the tests for.
+  - name: operatingSystem
+    type: string
+    values:
+      - Linux
+      - Windows
+
+  # The list of .NET Framework runtimes to test against.
+  - name: netFrameworkTestRuntimes
+    type: object
+
+  # The list of .NET runtimes to test against.
+  - name: netTestRuntimes
+    type: object
+
+  # The timeout, in minutes, for this job.
+  - name: timeout
+    type: number
+    default: 120
+
+  # True to use managed SNI on Windows.  Ignored on non-Windows, where managed SNI is always used.
+  - name: useManagedSNI
+    type: boolean
+
+  # The pool VM image to use.  The Managed-Instance-pool must provide an image with this name.
+  #
+  # NOTE: This value is evaluated at template-expansion (compile) time to select the pool image, so
+  # it must be a literal and must not contain any runtime expressions (e.g. $(...) macros or
+  # $[...] runtime expressions).
+  - name: vmImage
+    type: string
+
+jobs:
+  - job: managed_instance_tests_job_${{ parameters.jobNameSuffix }}
+    displayName: '[${{ parameters.displayNamePrefix }}] Run Managed Instance Tests'
+    timeoutInMinutes: ${{ parameters.timeout }}
+
+    variables:
+
+      # Import the variable group that provides the Managed Instance connection strings
+      # (SQL_MI_TCP_CONN_STRING and SQL_MI_NP_CONN_STRING) and other test configuration.
+      - group: ADO Test Configuration Properties
+
+    # The Managed-Instance-pool agents have network line-of-sight to the Managed Instance.
+    pool:
+      name: Managed-Instance-pool
+      demands:
+        - imageOverride -equals ${{ parameters.vmImage }}
+
+    steps:
+
+      # Download the SqlClient driver packages published by the triggering sqlclient-ci-package
+      # pipeline, stage them into the local NuGet feed, and resolve their exact versions into the
+      # sqlClient/sqlServer/abstractions/logging/azure PackageVersion variables.
+      - template: /eng/pipelines/common/steps/download-driver-packages-step.yml@self
+
+      # Install the .NET SDK and the runtimes needed to execute the test frameworks.
+      - template: /eng/pipelines/common/steps/install-dotnet.yml@self
+        parameters:
+          debug: ${{ parameters.debug }}
+          runtimes: [8.x, 9.x, 10.x]
+
+      # Restore dotnet CLI tools (e.g. pwsh, apicompat) before building.
+      - template: /eng/pipelines/common/steps/restore-dotnet-tools.yml@self
+
+      # Authenticate with NuGet feeds so that upstream packages (e.g. runtime host packs) can be
+      # fetched through the ADO Artifacts feed.
+      - task: NuGetAuthenticate@1
+        displayName: Authenticate NuGet feeds
+
+      # Write the config.jsonc file pointing the tests at the Managed Instance.  Integrated security
+      # and managed identity are not supported against the Managed Instance, and IsManagedInstance
+      # opts the test suite into Managed-Instance-specific behavior.
+      - template: /eng/pipelines/common/templates/steps/update-config-file-step.yml@self
+        parameters:
+          debug: ${{ parameters.debug }}
+          # The Managed Instance connection strings carry their own credentials, so no local SA
+          # password is used here; pass an empty string for the required saPassword parameter.
+          saPassword: ''
+          TCPConnectionString: $(SQL_MI_TCP_CONN_STRING)
+          NPConnectionString: $(SQL_MI_NP_CONN_STRING)
+          SupportsIntegratedSecurity: false
+          ManagedIdentitySupported: false
+          IsManagedInstance: true
+          UseManagedSNIOnWindows: ${{ parameters.useManagedSNI }}
+
+      # On Windows, start the SQL Browser service so that named-pipes connections can be resolved.
+      - ${{ if eq(parameters.operatingSystem, 'Windows') }}:
+        - pwsh: |
+            $svc_name = "SQLBrowser"
+            if ((Get-Service -Name "$svc_name" -ErrorAction SilentlyContinue) -ne $null) {
+                Get-Service $svc_name | Select-Object -Property Name, StartType, Status
+                Set-Service -StartupType Automatic $svc_name
+                net start $svc_name
+                Get-Service $svc_name | Select-Object -Property Name, StartType, Status
+            }
+          displayName: Start Sql Browser
+          condition: eq(variables['Agent.OS'], 'Windows_NT')
+
+      # Ensure the TestResults directory exists so publish steps don't fail when tests are skipped
+      # due to a setup failure.
+      - pwsh: New-Item -ItemType Directory -Path TestResults -Force | Out-Null
+        displayName: Create TestResults Directory
+
+      # Gate: record that all setup steps completed successfully.  Test steps condition on this
+      # variable so they are skipped when setup fails, yet remain independent of each other's
+      # results.
+      - pwsh: Write-Host '##vso[task.setvariable variable=setupSucceeded]true'
+        displayName: 'Gate: Mark Setup Succeeded'
+
+      # Build and run the Unit, Functional, and Manual test suites for each .NET runtime.  A blank
+      # testSet lets build.proj run all manual tests (its default), matching the Classic pipeline.
+      - ${{ each runtime in parameters.netTestRuntimes }}:
+        - template: /eng/pipelines/common/templates/steps/run-all-tests-step.yml@self
+          parameters:
+            debug: ${{ parameters.debug }}
+            targetFramework: ${{ runtime }}
+            buildConfiguration: ${{ parameters.buildConfiguration }}
+            referenceType: Package
+            testSet: ''
+            operatingSystem: ${{ parameters.operatingSystem }}
+            abstractionsPackageVersion: $(abstractionsPackageVersion)
+            loggingPackageVersion: $(loggingPackageVersion)
+            mdsPackageVersion: $(sqlClientPackageVersion)
+            sqlServerPackageVersion: $(sqlServerPackageVersion)
+
+        - template: /eng/pipelines/common/templates/steps/publish-test-results-step.yml@self
+          parameters:
+            debug: ${{ parameters.debug }}
+            targetFramework: ${{ runtime }}
+            operatingSystem: ${{ parameters.operatingSystem }}
+            buildConfiguration: ${{ parameters.buildConfiguration }}
+
+      # Build and run the test suites for each .NET Framework runtime (Windows only).  A blank
+      # testSet lets build.proj run all manual tests (its default), matching the Classic pipeline.
+      - ${{ each runtime in parameters.netFrameworkTestRuntimes }}:
+        - template: /eng/pipelines/common/templates/steps/run-all-tests-step.yml@self
+          parameters:
+            debug: ${{ parameters.debug }}
+            targetFramework: ${{ runtime }}
+            buildConfiguration: ${{ parameters.buildConfiguration }}
+            referenceType: Package
+            testSet: ''
+            operatingSystem: ${{ parameters.operatingSystem }}
+            abstractionsPackageVersion: $(abstractionsPackageVersion)
+            loggingPackageVersion: $(loggingPackageVersion)
+            mdsPackageVersion: $(sqlClientPackageVersion)
+            sqlServerPackageVersion: $(sqlServerPackageVersion)
+
+        - template: /eng/pipelines/common/templates/steps/publish-test-results-step.yml@self
+          parameters:
+            debug: ${{ parameters.debug }}
+            targetFramework: ${{ runtime }}
+            operatingSystem: ${{ parameters.operatingSystem }}
+            buildConfiguration: ${{ parameters.buildConfiguration }}

--- a/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-pipeline.yml
+++ b/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-pipeline.yml
@@ -1,0 +1,85 @@
+####################################################################################################
+# Licensed to the .NET Foundation under one or more agreements.  The .NET Foundation licenses this
+# file to you under the MIT license.  See the LICENSE file in the project root for more information.
+####################################################################################################
+
+# This pipeline runs the SqlClient Unit, Functional, and Manual test suites against an Azure SQL
+# Managed Instance, building the test projects in "Package" mode against the NuGet packages produced
+# by the sqlclient-ci-package pipeline.  It is triggered by successful runs of that pipeline:
+#
+# ADO.Net project:
+#   Triggering pipeline:  sqlclient-ci-package
+#   Pipeline name:        sqlclient-ci-managed-instance
+#
+# This pipeline is registered in the ADO.Net (internal) project ONLY, because it depends on the
+# Managed Instance connection strings provided by the "ADO Test Configuration Properties" variable
+# group and on the Managed-Instance-pool agents, neither of which exist in the Public project.
+
+# Set the pipeline run name to the day-of-year and the daily run counter.
+name: $(DayOfYear)$(Rev:rr)
+
+# Do not trigger this pipeline for PRs, commits, or schedules.
+pr: none
+trigger: none
+
+# Trigger this pipeline after successful runs of the sqlclient-ci-package pipeline.
+resources:
+  pipelines:
+
+    # Trigger this pipeline when the sqlclient-ci-package pipeline completes successfully.
+    #
+    # 'project' is omitted so the resource resolves to the sqlclient-ci-package pipeline in the
+    # *current* ADO project (ADO.Net), where this pipeline is registered.
+    #
+    # IMPORTANT: 'source' is the bare pipeline name with no folder path.  This REQUIRES the
+    # sqlclient-ci-package name to be UNIQUE within the ADO.Net project.  Azure DevOps only allows
+    # omitting the folder when the name is unambiguous; if a second pipeline with this name is ever
+    # added to the project, this resource will fail to resolve and the folder path must be added.
+    - pipeline: sqlclient-ci-package
+      source: sqlclient-ci-package
+      trigger: true
+
+# Pipeline parameters, visible in the Azure DevOps UI.
+parameters:
+
+  # The build configuration to use when building the; defaults to Release.
+  #
+  # This should match the mode the driver packages we consume were built in - typically Release -
+  # but may vary if we are triggered due to a manual build of sqlclient-ci-package.
+  #
+  - name: buildConfiguration
+    displayName: Test Build Configuration
+    type: string
+    default: Release
+    values:
+      - Debug
+      - Release
+
+  # True to emit debug information and steps.
+  - name: debug
+    displayName: Enable debug output
+    type: boolean
+    default: false
+
+  # Dotnet CLI verbosity level.
+  - name: dotnetVerbosity
+    displayName: dotnet CLI Verbosity
+    type: string
+    default: normal
+    values:
+      - quiet
+      - minimal
+      - normal
+      - detailed
+      - diagnostic
+
+# The stages to run.
+stages:
+
+  # Run the Managed Instance tests.  The target frameworks, .NET Framework runtimes, and SNI
+  # variants are defaulted by the stage template (all TFMs per OS, both SNI variants on Windows).
+  - template: /eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-stage.yml@self
+    parameters:
+      buildConfiguration: ${{ parameters.buildConfiguration }}
+      debug: ${{ parameters.debug }}
+      dotnetVerbosity: ${{ parameters.dotnetVerbosity }}

--- a/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-pipeline.yml
+++ b/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-pipeline.yml
@@ -76,8 +76,8 @@ parameters:
 # The stages to run.
 stages:
 
-  # Run the Managed Instance tests.  The target frameworks, .NET Framework runtimes, and SNI
-  # variants are defaulted by the stage template (all TFMs per OS, both SNI variants on Windows).
+  # Run the Managed Instance tests. The .NET and .NET Framework runtimes are defaulted by the stage
+  # template, which runs both native and managed SNI for .NET on Windows.
   - template: /eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-stage.yml@self
     parameters:
       buildConfiguration: ${{ parameters.buildConfiguration }}

--- a/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-pipeline.yml
+++ b/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-pipeline.yml
@@ -42,7 +42,7 @@ resources:
 # Pipeline parameters, visible in the Azure DevOps UI.
 parameters:
 
-  # The build configuration to use when building the; defaults to Release.
+  # The build configuration to use when building the test projects; defaults to Release.
   #
   # This should match the mode the driver packages we consume were built in - typically Release -
   # but may vary if we are triggered due to a manual build of sqlclient-ci-package.

--- a/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-stage.yml
+++ b/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-stage.yml
@@ -1,0 +1,97 @@
+####################################################################################################
+# Licensed to the .NET Foundation under one or more agreements.  The .NET Foundation licenses this
+# file to you under the MIT license.  See the LICENSE file in the project root for more information.
+####################################################################################################
+
+# This stage builds and runs the SqlClient Unit, Functional, and Manual test suites against an Azure
+# SQL Managed Instance, building the test projects in "Package" mode against the NuGet packages
+# produced by the sqlclient-ci-package pipeline.
+#
+# It fans out to one job per OS:
+#
+#   - Windows: one job per SNI variant requested in useManagedSNI (native and/or managed SNI).
+#   - Linux:   a single job (managed SNI is always used on non-Windows).
+#
+# This template defines a stage named 'managed_instance_tests_stage'.
+
+parameters:
+
+  # The type of build to produce (Debug or Release).
+  - name: buildConfiguration
+    type: string
+    values:
+      - Debug
+      - Release
+
+  # True to enable debugging steps.
+  - name: debug
+    type: boolean
+
+  # The verbosity level for the dotnet CLI commands.
+  - name: dotnetVerbosity
+    type: string
+    values:
+    - quiet
+    - minimal
+    - normal
+    - detailed
+    - diagnostic
+
+  # The list of .NET (core) runtimes to test against.  The same set is used on every OS.
+  - name: netTestRuntimes
+    type: object
+    default: [net8.0, net9.0, net10.0]
+
+  # The list of .NET Framework runtimes to test against on Windows.
+  - name: netFrameworkTestRuntimes
+    type: object
+    default: [net462]
+
+  # The SNI variants to test on Windows.  Values [false, true], [false], or [true] are allowed.
+  # 'false' selects native SNI; 'true' selects managed SNI.  Defaults to both.
+  - name: useManagedSNI
+    type: object
+    default: [false, true]
+
+stages:
+  - stage: managed_instance_tests_stage
+    displayName: Run Managed Instance Tests
+
+    jobs:
+
+    # ----------------------------------------------------------------------------------------------
+    # Build and test on Windows, once per requested SNI variant.
+
+    - ${{ each useManagedSNI in parameters.useManagedSNI }}:
+      - template: /eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml@self
+        parameters:
+          buildConfiguration: ${{ parameters.buildConfiguration }}
+          debug: ${{ parameters.debug }}
+          ${{ if eq(useManagedSNI, true) }}:
+            displayNamePrefix: 'Win : Managed SNI'
+            jobNameSuffix: windows_managed_sni
+          ${{ else }}:
+            displayNamePrefix: 'Win : Native SNI'
+            jobNameSuffix: windows_native_sni
+          dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          operatingSystem: Windows
+          netFrameworkTestRuntimes: ${{ parameters.netFrameworkTestRuntimes }}
+          netTestRuntimes: ${{ parameters.netTestRuntimes }}
+          useManagedSNI: ${{ useManagedSNI }}
+          vmImage: ADO-MMS22-SQL22
+
+    # ----------------------------------------------------------------------------------------------
+    # Build and test on Linux (managed SNI is always used on non-Windows).
+
+    - template: /eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml@self
+      parameters:
+        buildConfiguration: ${{ parameters.buildConfiguration }}
+        debug: ${{ parameters.debug }}
+        displayNamePrefix: Linux
+        jobNameSuffix: linux
+        dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+        operatingSystem: Linux
+        # No .NET Framework runtimes on Linux.
+        netFrameworkTestRuntimes: []
+        netTestRuntimes: ${{ parameters.netTestRuntimes }}
+        vmImage: ADO-UB22-SQL22

--- a/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-stage.yml
+++ b/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-stage.yml
@@ -60,38 +60,54 @@ stages:
     jobs:
 
     # ----------------------------------------------------------------------------------------------
-    # Build and test on Windows, once per requested SNI variant.
+    # Windows: one job per SNI variant and per runtime (both .NET Framework and .NET runtimes).
 
     - ${{ each useManagedSNI in parameters.useManagedSNI }}:
+      - ${{ each runtime in parameters.netFrameworkTestRuntimes }}:
+        - template: /eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml@self
+          parameters:
+            buildConfiguration: ${{ parameters.buildConfiguration }}
+            debug: ${{ parameters.debug }}
+            dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+            operatingSystem: Windows
+            targetFramework: ${{ runtime }}
+            useManagedSNI: ${{ useManagedSNI }}
+            vmImage: ADO-MMS22-SQL22
+            ${{ if eq(useManagedSNI, true) }}:
+              displayNamePrefix: 'Win : Managed SNI : ${{ runtime }}'
+              jobNameSuffix: windows_managed_sni_${{ replace(runtime, '.', '_') }}
+            ${{ else }}:
+              displayNamePrefix: 'Win : Native SNI : ${{ runtime }}'
+              jobNameSuffix: windows_native_sni_${{ replace(runtime, '.', '_') }}
+
+      - ${{ each runtime in parameters.netTestRuntimes }}:
+        - template: /eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml@self
+          parameters:
+            buildConfiguration: ${{ parameters.buildConfiguration }}
+            debug: ${{ parameters.debug }}
+            dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+            operatingSystem: Windows
+            targetFramework: ${{ runtime }}
+            useManagedSNI: ${{ useManagedSNI }}
+            vmImage: ADO-MMS22-SQL22
+            ${{ if eq(useManagedSNI, true) }}:
+              displayNamePrefix: 'Win : Managed SNI : ${{ runtime }}'
+              jobNameSuffix: windows_managed_sni_${{ replace(runtime, '.', '_') }}
+            ${{ else }}:
+              displayNamePrefix: 'Win : Native SNI : ${{ runtime }}'
+              jobNameSuffix: windows_native_sni_${{ replace(runtime, '.', '_') }}
+
+    # ----------------------------------------------------------------------------------------------
+    # Linux: one job per .NET runtime (managed SNI is always used on non-Windows).
+
+    - ${{ each runtime in parameters.netTestRuntimes }}:
       - template: /eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml@self
         parameters:
           buildConfiguration: ${{ parameters.buildConfiguration }}
           debug: ${{ parameters.debug }}
-          ${{ if eq(useManagedSNI, true) }}:
-            displayNamePrefix: 'Win : Managed SNI'
-            jobNameSuffix: windows_managed_sni
-          ${{ else }}:
-            displayNamePrefix: 'Win : Native SNI'
-            jobNameSuffix: windows_native_sni
+          displayNamePrefix: 'Linux : ${{ runtime }}'
+          jobNameSuffix: linux_${{ replace(runtime, '.', '_') }}
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
-          operatingSystem: Windows
-          netFrameworkTestRuntimes: ${{ parameters.netFrameworkTestRuntimes }}
-          netTestRuntimes: ${{ parameters.netTestRuntimes }}
-          useManagedSNI: ${{ useManagedSNI }}
-          vmImage: ADO-MMS22-SQL22
-
-    # ----------------------------------------------------------------------------------------------
-    # Build and test on Linux (managed SNI is always used on non-Windows).
-
-    - template: /eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml@self
-      parameters:
-        buildConfiguration: ${{ parameters.buildConfiguration }}
-        debug: ${{ parameters.debug }}
-        displayNamePrefix: Linux
-        jobNameSuffix: linux
-        dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
-        operatingSystem: Linux
-        # No .NET Framework runtimes on Linux.
-        netFrameworkTestRuntimes: []
-        netTestRuntimes: ${{ parameters.netTestRuntimes }}
-        vmImage: ADO-UB22-SQL22
+          operatingSystem: Linux
+          targetFramework: ${{ runtime }}
+          vmImage: ADO-UB22-SQL22

--- a/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-stage.yml
+++ b/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-stage.yml
@@ -74,10 +74,10 @@ stages:
             useManagedSNI: ${{ useManagedSNI }}
             vmImage: ADO-MMS22-SQL22
             ${{ if eq(useManagedSNI, true) }}:
-              displayNamePrefix: 'Win : Managed SNI : ${{ runtime }}'
+              displayName: 'Win : Managed SNI : ${{ runtime }}'
               jobNameSuffix: windows_managed_sni_${{ replace(runtime, '.', '_') }}
             ${{ else }}:
-              displayNamePrefix: 'Win : Native SNI : ${{ runtime }}'
+              displayName: 'Win : Native SNI : ${{ runtime }}'
               jobNameSuffix: windows_native_sni_${{ replace(runtime, '.', '_') }}
 
       - ${{ each runtime in parameters.netTestRuntimes }}:
@@ -91,10 +91,10 @@ stages:
             useManagedSNI: ${{ useManagedSNI }}
             vmImage: ADO-MMS22-SQL22
             ${{ if eq(useManagedSNI, true) }}:
-              displayNamePrefix: 'Win : Managed SNI : ${{ runtime }}'
+              displayName: 'Win : Managed SNI : ${{ runtime }}'
               jobNameSuffix: windows_managed_sni_${{ replace(runtime, '.', '_') }}
             ${{ else }}:
-              displayNamePrefix: 'Win : Native SNI : ${{ runtime }}'
+              displayName: 'Win : Native SNI : ${{ runtime }}'
               jobNameSuffix: windows_native_sni_${{ replace(runtime, '.', '_') }}
 
     # ----------------------------------------------------------------------------------------------
@@ -105,7 +105,7 @@ stages:
         parameters:
           buildConfiguration: ${{ parameters.buildConfiguration }}
           debug: ${{ parameters.debug }}
-          displayNamePrefix: 'Linux : ${{ runtime }}'
+          displayName: 'Linux : ${{ runtime }}'
           jobNameSuffix: linux_${{ replace(runtime, '.', '_') }}
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
           operatingSystem: Linux

--- a/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-stage.yml
+++ b/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-stage.yml
@@ -9,8 +9,9 @@
 #
 # It fans out to one job per OS:
 #
-#   - Windows: one job per SNI variant requested in useManagedSNI (native and/or managed SNI).
-#   - Linux:   a single job (managed SNI is always used on non-Windows).
+#   - Windows: one native-SNI job per .NET Framework runtime, plus native- and managed-SNI jobs per
+#     .NET runtime.
+#   - Linux: one job per .NET runtime (managed SNI is always used on non-Windows).
 #
 # This template defines a stage named 'managed_instance_tests_stage'.
 
@@ -31,11 +32,11 @@ parameters:
   - name: dotnetVerbosity
     type: string
     values:
-    - quiet
-    - minimal
-    - normal
-    - detailed
-    - diagnostic
+      - quiet
+      - minimal
+      - normal
+      - detailed
+      - diagnostic
 
   # The list of .NET (core) runtimes to test against.  The same set is used on every OS.
   - name: netTestRuntimes
@@ -47,12 +48,6 @@ parameters:
     type: object
     default: [net462]
 
-  # The SNI variants to test on Windows.  Values [false, true], [false], or [true] are allowed.
-  # 'false' selects native SNI; 'true' selects managed SNI.  Defaults to both.
-  - name: useManagedSNI
-    type: object
-    default: [false, true]
-
 stages:
   - stage: managed_instance_tests_stage
     displayName: Run Managed Instance Tests
@@ -60,42 +55,45 @@ stages:
     jobs:
 
     # ----------------------------------------------------------------------------------------------
-    # Windows: one job per SNI variant and per runtime (both .NET Framework and .NET runtimes).
+    # Windows: .NET Framework uses native SNI; .NET runs with both native and managed SNI.
 
-    - ${{ each useManagedSNI in parameters.useManagedSNI }}:
-      - ${{ each runtime in parameters.netFrameworkTestRuntimes }}:
-        - template: /eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml@self
-          parameters:
-            buildConfiguration: ${{ parameters.buildConfiguration }}
-            debug: ${{ parameters.debug }}
-            dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
-            operatingSystem: Windows
-            targetFramework: ${{ runtime }}
-            useManagedSNI: ${{ useManagedSNI }}
-            vmImage: ADO-MMS22-SQL22
-            ${{ if eq(useManagedSNI, true) }}:
-              displayName: 'Win : Managed SNI : ${{ runtime }}'
-              jobNameSuffix: windows_managed_sni_${{ replace(runtime, '.', '_') }}
-            ${{ else }}:
-              displayName: 'Win : Native SNI : ${{ runtime }}'
-              jobNameSuffix: windows_native_sni_${{ replace(runtime, '.', '_') }}
+    - ${{ each runtime in parameters.netFrameworkTestRuntimes }}:
+      - template: /eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml@self
+        parameters:
+          buildConfiguration: ${{ parameters.buildConfiguration }}
+          debug: ${{ parameters.debug }}
+          dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          displayName: 'Win : Native SNI : ${{ runtime }}'
+          jobNameSuffix: windows_native_sni_${{ replace(runtime, '.', '_') }}
+          operatingSystem: Windows
+          runtime: ${{ runtime }}
+          useManagedSNI: false
+          vmImage: ADO-MMS22-SQL22
 
-      - ${{ each runtime in parameters.netTestRuntimes }}:
-        - template: /eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml@self
-          parameters:
-            buildConfiguration: ${{ parameters.buildConfiguration }}
-            debug: ${{ parameters.debug }}
-            dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
-            operatingSystem: Windows
-            targetFramework: ${{ runtime }}
-            useManagedSNI: ${{ useManagedSNI }}
-            vmImage: ADO-MMS22-SQL22
-            ${{ if eq(useManagedSNI, true) }}:
-              displayName: 'Win : Managed SNI : ${{ runtime }}'
-              jobNameSuffix: windows_managed_sni_${{ replace(runtime, '.', '_') }}
-            ${{ else }}:
-              displayName: 'Win : Native SNI : ${{ runtime }}'
-              jobNameSuffix: windows_native_sni_${{ replace(runtime, '.', '_') }}
+    - ${{ each runtime in parameters.netTestRuntimes }}:
+      - template: /eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml@self
+        parameters:
+          buildConfiguration: ${{ parameters.buildConfiguration }}
+          debug: ${{ parameters.debug }}
+          displayName: 'Win : Native SNI : ${{ runtime }}'
+          dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          jobNameSuffix: windows_native_sni_${{ replace(runtime, '.', '_') }}
+          operatingSystem: Windows
+          runtime: ${{ runtime }}
+          useManagedSNI: false
+          vmImage: ADO-MMS22-SQL22
+
+      - template: /eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-job.yml@self
+        parameters:
+          buildConfiguration: ${{ parameters.buildConfiguration }}
+          debug: ${{ parameters.debug }}
+          displayName: 'Win : Managed SNI : ${{ runtime }}'
+          dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          jobNameSuffix: windows_managed_sni_${{ replace(runtime, '.', '_') }}
+          operatingSystem: Windows
+          runtime: ${{ runtime }}
+          useManagedSNI: true
+          vmImage: ADO-MMS22-SQL22
 
     # ----------------------------------------------------------------------------------------------
     # Linux: one job per .NET runtime (managed SNI is always used on non-Windows).
@@ -109,5 +107,5 @@ stages:
           jobNameSuffix: linux_${{ replace(runtime, '.', '_') }}
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
           operatingSystem: Linux
-          targetFramework: ${{ runtime }}
+          runtime: ${{ runtime }}
           vmImage: ADO-UB22-SQL22

--- a/eng/pipelines/ci/stress/sqlclient-ci-stress-job.yml
+++ b/eng/pipelines/ci/stress/sqlclient-ci-stress-job.yml
@@ -208,7 +208,12 @@ jobs:
       # pipeline, stage them into the local NuGet feed, and resolve their exact versions.  The
       # sqlClientPackageVersion and azurePackageVersion variables are consumed by the referenceArgs
       # variable above.
+      #
+      # sqlServerVersionOverride pins Microsoft.SqlServer.Server to the released stable 1.0.0 to
+      # avoid an NU1605 downgrade against the >= 1.0.0 dependency from Microsoft.SqlServer.Types.
       - template: /eng/pipelines/common/steps/download-driver-packages-step.yml@self
+        parameters:
+          sqlServerVersionOverride: 1.0.0
 
       # Authenticate with NuGet feeds so that upstream packages (e.g. runtime host packs) can be
       # fetched through the ADO Artifacts feed.

--- a/eng/pipelines/ci/stress/sqlclient-ci-stress-job.yml
+++ b/eng/pipelines/ci/stress/sqlclient-ci-stress-job.yml
@@ -84,6 +84,9 @@ jobs:
   - job: stress_tests_job_${{ parameters.jobNameSuffix }}
     displayName: '[${{ parameters.displayNamePrefix }}] Run Stress Tests'
 
+    workspace:
+      clean: all
+
     variables:
 
       # Whether this is an internal (ADO.Net project) or public (Public project) build.  Evaluated

--- a/eng/pipelines/ci/stress/sqlclient-ci-stress-job.yml
+++ b/eng/pipelines/ci/stress/sqlclient-ci-stress-job.yml
@@ -99,11 +99,6 @@ jobs:
       # Import the variable group that provides SQL Server test configuration variables.
       - group: ADO Test Configuration Properties
 
-      # The directory where the "- download:" step places the SqlClient-Driver-Packages artifact
-      # published by the triggering sqlclient-ci-package pipeline.
-      - name: packageArtifactDir
-        value: $(Pipeline.Workspace)/sqlclient-ci-package/SqlClient-Driver-Packages
-
       # The top-level project file to build and run.
       - name: project
         value: $(Build.SourcesDirectory)/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Runner/SqlClient.Stress.Runner.csproj
@@ -142,7 +137,7 @@ jobs:
       - name: referenceArgs
         value: >-
           -p:ReferenceType=Package
-          -p:SqlClientPackageVersion=$(mdsPackageVersion)
+          -p:SqlClientPackageVersion=$(sqlClientPackageVersion)
           -p:AzurePackageVersion=$(azurePackageVersion)
 
       # dotnet CLI options for build.
@@ -205,43 +200,10 @@ jobs:
             $content | Out-File -FilePath "config.jsonc"
 
       # Download the SqlClient driver packages published by the triggering sqlclient-ci-package
-      # pipeline into the pipeline workspace.
-      - download: sqlclient-ci-package
-        artifact: SqlClient-Driver-Packages
-        displayName: Download SqlClient Driver Packages
-
-      # Copy the downloaded packages into the local NuGet feed (packages/) and resolve the exact
-      # Microsoft.Data.SqlClient and Microsoft.Data.SqlClient.Extensions.Azure versions from the
-      # .nupkg filenames.  These versions are passed to the build via the referenceArgs variable.
-      - task: PowerShell@2
-        displayName: Stage Packages and Resolve Versions
-        inputs:
-          pwsh: true
-          targetType: inline
-          script: |
-            $ErrorActionPreference = 'Stop'
-            $feed = "$(Build.SourcesDirectory)/packages"
-            New-Item -ItemType Directory -Force -Path $feed | Out-Null
-
-            Copy-Item "$(packageArtifactDir)/*.nupkg" $feed -Force
-            Copy-Item "$(packageArtifactDir)/*.snupkg" $feed -Force -ErrorAction SilentlyContinue
-
-            $mdsPattern = '^Microsoft\.Data\.SqlClient\.(\d[^\\/]*)\.nupkg$'
-            $azurePattern = '^Microsoft\.Data\.SqlClient\.Extensions\.Azure\.(\d[^\\/]*)\.nupkg$'
-
-            $mds = Get-ChildItem "$feed/*.nupkg" | Where-Object { $_.Name -match $mdsPattern } | Select-Object -First 1
-            $azure = Get-ChildItem "$feed/*.nupkg" | Where-Object { $_.Name -match $azurePattern } | Select-Object -First 1
-
-            if (-not $mds) { throw "Microsoft.Data.SqlClient package not found in $feed" }
-            if (-not $azure) { throw "Microsoft.Data.SqlClient.Extensions.Azure package not found in $feed" }
-
-            $mdsVersion = [regex]::Match($mds.Name, $mdsPattern).Groups[1].Value
-            $azureVersion = [regex]::Match($azure.Name, $azurePattern).Groups[1].Value
-
-            Write-Host "Resolved Microsoft.Data.SqlClient version: $mdsVersion"
-            Write-Host "Resolved Microsoft.Data.SqlClient.Extensions.Azure version: $azureVersion"
-            Write-Host "##vso[task.setvariable variable=mdsPackageVersion]$mdsVersion"
-            Write-Host "##vso[task.setvariable variable=azurePackageVersion]$azureVersion"
+      # pipeline, stage them into the local NuGet feed, and resolve their exact versions.  The
+      # sqlClientPackageVersion and azurePackageVersion variables are consumed by the referenceArgs
+      # variable above.
+      - template: /eng/pipelines/common/steps/download-driver-packages-step.yml@self
 
       # Authenticate with NuGet feeds so that upstream packages (e.g. runtime host packs) can be
       # fetched through the ADO Artifacts feed.

--- a/eng/pipelines/ci/stress/sqlclient-ci-stress-job.yml
+++ b/eng/pipelines/ci/stress/sqlclient-ci-stress-job.yml
@@ -176,6 +176,11 @@ jobs:
 
     steps:
 
+      # Check out the repo and align the working-tree source with the commit that built the upstream
+      # sqlclient-ci-package artifacts, so the stress projects compile against the matching API
+      # surface.
+      - template: /eng/pipelines/common/steps/align-source-with-upstream-step.yml@self
+
       # Install the .NET SDK and Runtimes.
       - template: /eng/pipelines/common/steps/install-dotnet.yml@self
         parameters:

--- a/eng/pipelines/common/steps/align-source-with-upstream-step.yml
+++ b/eng/pipelines/common/steps/align-source-with-upstream-step.yml
@@ -1,0 +1,49 @@
+####################################################################################################
+# Licensed to the .NET Foundation under one or more agreements.  The .NET Foundation licenses this
+# file to you under the MIT license.  See the LICENSE file in the project root for more information.
+####################################################################################################
+
+# This template checks out the repository and aligns the working-tree source with the exact commit
+# that produced the artifacts consumed from an upstream (triggering) pipeline resource (e.g.
+# sqlclient-ci-package).  This keeps the source that gets built and tested in lockstep with the
+# upstream artifacts' API surface.
+#
+# IMPORTANT: This only repoints the working-tree files that later steps read (build.proj, test
+# projects, global.json, etc.).  The pipeline definition and all @self templates are compiled from
+# the triggered branch tip at queue time and are NOT affected by the runtime checkout.
+#
+# The consuming pipeline MUST declare the upstream pipeline as a resource whose alias matches the
+# upstreamPipeline parameter, e.g.:
+#
+#   resources:
+#     pipelines:
+#       - pipeline: sqlclient-ci-package
+#         source: sqlclient-ci-package
+#         trigger: true
+
+parameters:
+
+  # The upstream pipeline resource alias whose source commit the working tree should be aligned to.
+  # This must match a resource declared under resources.pipelines in the consuming pipeline.
+  - name: upstreamPipeline
+    type: string
+    default: sqlclient-ci-package
+
+steps:
+
+  # Check out the repo with full history so the working tree can be reset to an arbitrary commit.
+  - checkout: self
+    fetchDepth: 0
+
+  # Align the working-tree source with the commit that built the upstream artifacts, so the projects
+  # compile against the matching (internal) API surface.  When the upstream commit is unavailable
+  # (e.g. some manual runs), the checked-out source is used as-is.
+  - pwsh: |
+      $sha = "$(resources.pipeline.${{ parameters.upstreamPipeline }}.sourceCommit)"
+      if ([string]::IsNullOrWhiteSpace($sha)) {
+          Write-Host "No ${{ parameters.upstreamPipeline }} sourceCommit available; using checked-out source as-is."
+      } else {
+          Write-Host "Aligning source to ${{ parameters.upstreamPipeline }} commit $sha"
+          git checkout --force $sha
+      }
+    displayName: Align Source With Upstream Commit

--- a/eng/pipelines/common/steps/align-source-with-upstream-step.yml
+++ b/eng/pipelines/common/steps/align-source-with-upstream-step.yml
@@ -8,9 +8,10 @@
 # sqlclient-ci-package).  This keeps the source that gets built and tested in lockstep with the
 # upstream artifacts' API surface.
 #
-# IMPORTANT: This only repoints the working-tree files that later steps read (build.proj, test
-# projects, global.json, etc.).  The pipeline definition and all @self templates are compiled from
-# the triggered branch tip at queue time and are NOT affected by the runtime checkout.
+# IMPORTANT: Pipeline definitions and @self templates are compiled from the triggered branch tip at
+# queue time, but file-based tasks still read scripts from the runtime working tree.  After aligning
+# the source, this template restores eng/pipelines from the queued commit so compiled pipeline steps
+# and their scripts remain in lockstep.
 #
 # The consuming pipeline MUST declare the upstream pipeline as a resource whose alias matches the
 # upstreamPipeline parameter, e.g.:
@@ -40,7 +41,10 @@ steps:
   # (e.g. some manual runs), skip this step and use the checked-out source as-is.
   - pwsh: |
       $sha = "$(resources.pipeline.${{ parameters.upstreamPipeline }}.sourceCommit)"
+      $pipelineSourceSha = git rev-parse HEAD
       Write-Host "Aligning source to ${{ parameters.upstreamPipeline }} commit $sha"
       git checkout --force $sha
+      Write-Host "Restoring eng/pipelines from queued pipeline commit $pipelineSourceSha"
+      git checkout --force $pipelineSourceSha -- eng/pipelines
     displayName: Align Source With Upstream Commit
     condition: ne(variables['resources.pipeline.${{ parameters.upstreamPipeline }}.sourceCommit'], '')

--- a/eng/pipelines/common/steps/align-source-with-upstream-step.yml
+++ b/eng/pipelines/common/steps/align-source-with-upstream-step.yml
@@ -34,17 +34,22 @@ steps:
 
   # Check out the repo with full history so the working tree can be reset to an arbitrary commit.
   - checkout: self
+    clean: true
     fetchDepth: 0
 
   # Align the working-tree source with the commit that built the upstream artifacts, so the projects
   # compile against the matching (internal) API surface.  When the upstream commit is unavailable
   # (e.g. some manual runs), skip this step and use the checked-out source as-is.
   - pwsh: |
+      $ErrorActionPreference = 'Stop'
       $sha = "$(resources.pipeline.${{ parameters.upstreamPipeline }}.sourceCommit)"
       $pipelineSourceSha = git rev-parse HEAD
+      if ($LASTEXITCODE -ne 0) { throw "Failed to resolve the queued pipeline commit." }
       Write-Host "Aligning source to ${{ parameters.upstreamPipeline }} commit $sha"
       git checkout --force $sha
+      if ($LASTEXITCODE -ne 0) { throw "Failed to check out upstream commit $sha." }
       Write-Host "Restoring eng/pipelines from queued pipeline commit $pipelineSourceSha"
       git checkout --force $pipelineSourceSha -- eng/pipelines
+      if ($LASTEXITCODE -ne 0) { throw "Failed to restore eng/pipelines from $pipelineSourceSha." }
     displayName: Align Source With Upstream Commit
     condition: ne(variables['resources.pipeline.${{ parameters.upstreamPipeline }}.sourceCommit'], '')

--- a/eng/pipelines/common/steps/align-source-with-upstream-step.yml
+++ b/eng/pipelines/common/steps/align-source-with-upstream-step.yml
@@ -37,13 +37,10 @@ steps:
 
   # Align the working-tree source with the commit that built the upstream artifacts, so the projects
   # compile against the matching (internal) API surface.  When the upstream commit is unavailable
-  # (e.g. some manual runs), the checked-out source is used as-is.
+  # (e.g. some manual runs), skip this step and use the checked-out source as-is.
   - pwsh: |
       $sha = "$(resources.pipeline.${{ parameters.upstreamPipeline }}.sourceCommit)"
-      if ([string]::IsNullOrWhiteSpace($sha)) {
-          Write-Host "No ${{ parameters.upstreamPipeline }} sourceCommit available; using checked-out source as-is."
-      } else {
-          Write-Host "Aligning source to ${{ parameters.upstreamPipeline }} commit $sha"
-          git checkout --force $sha
-      }
+      Write-Host "Aligning source to ${{ parameters.upstreamPipeline }} commit $sha"
+      git checkout --force $sha
     displayName: Align Source With Upstream Commit
+    condition: ne(variables['resources.pipeline.${{ parameters.upstreamPipeline }}.sourceCommit'], '')

--- a/eng/pipelines/common/steps/download-driver-packages-step.yml
+++ b/eng/pipelines/common/steps/download-driver-packages-step.yml
@@ -1,0 +1,110 @@
+####################################################################################################
+# Licensed to the .NET Foundation under one or more agreements.  The .NET Foundation licenses this
+# file to you under the MIT license.  See the LICENSE file in the project root for more information.
+####################################################################################################
+
+# This template downloads the SqlClient driver packages published by the sqlclient-ci-package
+# pipeline, copies them into the local NuGet feed (packages/), and resolves the exact package
+# versions from the .nupkg filenames.  The resolved versions are exposed as job-scoped pipeline
+# variables for use by downstream build/test steps:
+#
+#   sqlClientPackageVersion     Microsoft.Data.SqlClient
+#   sqlServerPackageVersion     Microsoft.SqlServer.Server
+#   abstractionsPackageVersion  Microsoft.Data.SqlClient.Extensions.Abstractions
+#   loggingPackageVersion       Microsoft.Data.SqlClient.Internal.Logging
+#   azurePackageVersion         Microsoft.Data.SqlClient.Extensions.Azure
+#
+# The consuming pipeline MUST declare the triggering pipeline as a resource whose alias matches the
+# pipelineResource parameter, e.g.:
+#
+#   resources:
+#     pipelines:
+#       - pipeline: sqlclient-ci-package
+#         source: sqlclient-ci-package
+#         trigger: true
+
+parameters:
+
+  # The pipeline resource alias to download the packages from.  This must match a resource declared
+  # under resources.pipelines in the consuming pipeline.
+  - name: pipelineResource
+    type: string
+    default: sqlclient-ci-package
+
+  # The name of the artifact published by the triggering pipeline that contains the .nupkg/.snupkg
+  # files.
+  - name: artifactName
+    type: string
+    default: SqlClient-Driver-Packages
+
+  # The local NuGet feed directory to copy the downloaded packages into.
+  - name: feedPath
+    type: string
+    default: $(Build.SourcesDirectory)/packages
+
+steps:
+
+  # Download the SqlClient driver packages published by the triggering pipeline into the pipeline
+  # workspace.
+  - download: ${{ parameters.pipelineResource }}
+    artifact: ${{ parameters.artifactName }}
+    displayName: Download SqlClient Driver Packages
+
+  # Copy the downloaded packages into the local NuGet feed and resolve the exact package versions
+  # from the .nupkg filenames, exposing each as a pipeline variable.
+  - task: PowerShell@2
+    displayName: Stage Packages and Resolve Versions
+    inputs:
+      pwsh: true
+      targetType: inline
+      script: |
+        $ErrorActionPreference = 'Stop'
+        $feed = "${{ parameters.feedPath }}"
+        $artifactDir = "$(Pipeline.Workspace)/${{ parameters.pipelineResource }}/${{ parameters.artifactName }}"
+        New-Item -ItemType Directory -Force -Path $feed | Out-Null
+
+        Copy-Item "$artifactDir/*.nupkg" $feed -Force
+        Copy-Item "$artifactDir/*.snupkg" $feed -Force -ErrorAction SilentlyContinue
+
+        # Resolve the version of a single package from its .nupkg filename in the feed.
+        function Resolve-PackageVersion($feed, $pattern, $name) {
+            $pkg = Get-ChildItem "$feed/*.nupkg" | Where-Object { $_.Name -match $pattern } | Select-Object -First 1
+            if (-not $pkg) { throw "$name package not found in $feed" }
+            return [regex]::Match($pkg.Name, $pattern).Groups[1].Value
+        }
+
+        # Each package's .nupkg filename pattern is anchored so, e.g., the Microsoft.Data.SqlClient
+        # pattern does not also match Microsoft.Data.SqlClient.Extensions.Azure.
+        $packages = @(
+            @{
+                Variable = 'sqlClientPackageVersion';
+                Name = 'Microsoft.Data.SqlClient';
+                Pattern = '^Microsoft\.Data\.SqlClient\.(\d[^\\/]*)\.nupkg$'
+            },
+            @{
+                Variable = 'sqlServerPackageVersion';
+                Name = 'Microsoft.SqlServer.Server';
+                Pattern = '^Microsoft\.SqlServer\.Server\.(\d[^\\/]*)\.nupkg$'
+            },
+            @{
+                Variable = 'abstractionsPackageVersion';
+                Name = 'Microsoft.Data.SqlClient.Extensions.Abstractions';
+                Pattern = '^Microsoft\.Data\.SqlClient\.Extensions\.Abstractions\.(\d[^\\/]*)\.nupkg$'
+            },
+            @{
+                Variable = 'loggingPackageVersion';
+                Name = 'Microsoft.Data.SqlClient.Internal.Logging';
+                Pattern = '^Microsoft\.Data\.SqlClient\.Internal\.Logging\.(\d[^\\/]*)\.nupkg$'
+            },
+            @{
+                Variable = 'azurePackageVersion';
+                Name = 'Microsoft.Data.SqlClient.Extensions.Azure';
+                Pattern = '^Microsoft\.Data\.SqlClient\.Extensions\.Azure\.(\d[^\\/]*)\.nupkg$'
+            }
+        )
+
+        foreach ($p in $packages) {
+            $version = Resolve-PackageVersion $feed $p.Pattern $p.Name
+            Write-Host "Resolved $($p.Name) version: $version"
+            Write-Host "##vso[task.setvariable variable=$($p.Variable)]$version"
+        }

--- a/eng/pipelines/common/steps/download-driver-packages-step.yml
+++ b/eng/pipelines/common/steps/download-driver-packages-step.yml
@@ -42,6 +42,16 @@ parameters:
     type: string
     default: $(Build.SourcesDirectory)/packages
 
+  # Optional override for the Microsoft.SqlServer.Server version.  When set, this value is used for
+  # the sqlServerPackageVersion variable instead of the version resolved from the artifact .nupkg
+  # filename.  Temporary workaround: the CI 'X.Y.Z-ci' prerelease of Microsoft.SqlServer.Server is
+  # treated as a downgrade of the '>= X.Y.Z' stable dependency that Microsoft.SqlServer.Types pulls
+  # in (NU1605); passing the released stable version avoids the downgrade.  Overall package
+  # versioning is being addressed separately.
+  - name: sqlServerVersionOverride
+    type: string
+    default: ''
+
 steps:
 
   # Download the SqlClient driver packages published by the triggering pipeline into the pipeline
@@ -104,7 +114,12 @@ steps:
         )
 
         foreach ($p in $packages) {
-            $version = Resolve-PackageVersion $feed $p.Pattern $p.Name
-            Write-Host "Resolved $($p.Name) version: $version"
+            if ($p.Variable -eq 'sqlServerPackageVersion' -and -not [string]::IsNullOrWhiteSpace('${{ parameters.sqlServerVersionOverride }}')) {
+                $version = '${{ parameters.sqlServerVersionOverride }}'
+                Write-Host "Overriding $($p.Name) version: $version"
+            } else {
+                $version = Resolve-PackageVersion $feed $p.Pattern $p.Name
+                Write-Host "Resolved $($p.Name) version: $version"
+            }
             Write-Host "##vso[task.setvariable variable=$($p.Variable)]$version"
         }

--- a/eng/pipelines/common/steps/download-driver-packages-step.yml
+++ b/eng/pipelines/common/steps/download-driver-packages-step.yml
@@ -66,60 +66,9 @@ steps:
     displayName: Stage Packages and Resolve Versions
     inputs:
       pwsh: true
-      targetType: inline
-      script: |
-        $ErrorActionPreference = 'Stop'
-        $feed = "${{ parameters.feedPath }}"
-        $artifactDir = "$(Pipeline.Workspace)/${{ parameters.pipelineResource }}/${{ parameters.artifactName }}"
-        New-Item -ItemType Directory -Force -Path $feed | Out-Null
-
-        Copy-Item "$artifactDir/*.nupkg" $feed -Force
-        Copy-Item "$artifactDir/*.snupkg" $feed -Force -ErrorAction SilentlyContinue
-
-        # Resolve the version of a single package from its .nupkg filename in the feed.
-        function Resolve-PackageVersion($feed, $pattern, $name) {
-            $pkg = Get-ChildItem "$feed/*.nupkg" | Where-Object { $_.Name -match $pattern } | Select-Object -First 1
-            if (-not $pkg) { throw "$name package not found in $feed" }
-            return [regex]::Match($pkg.Name, $pattern).Groups[1].Value
-        }
-
-        # Each package's .nupkg filename pattern is anchored so, e.g., the Microsoft.Data.SqlClient
-        # pattern does not also match Microsoft.Data.SqlClient.Extensions.Azure.
-        $packages = @(
-            @{
-                Variable = 'sqlClientPackageVersion';
-                Name = 'Microsoft.Data.SqlClient';
-                Pattern = '^Microsoft\.Data\.SqlClient\.(\d[^\\/]*)\.nupkg$'
-            },
-            @{
-                Variable = 'sqlServerPackageVersion';
-                Name = 'Microsoft.SqlServer.Server';
-                Pattern = '^Microsoft\.SqlServer\.Server\.(\d[^\\/]*)\.nupkg$'
-            },
-            @{
-                Variable = 'abstractionsPackageVersion';
-                Name = 'Microsoft.Data.SqlClient.Extensions.Abstractions';
-                Pattern = '^Microsoft\.Data\.SqlClient\.Extensions\.Abstractions\.(\d[^\\/]*)\.nupkg$'
-            },
-            @{
-                Variable = 'loggingPackageVersion';
-                Name = 'Microsoft.Data.SqlClient.Internal.Logging';
-                Pattern = '^Microsoft\.Data\.SqlClient\.Internal\.Logging\.(\d[^\\/]*)\.nupkg$'
-            },
-            @{
-                Variable = 'azurePackageVersion';
-                Name = 'Microsoft.Data.SqlClient.Extensions.Azure';
-                Pattern = '^Microsoft\.Data\.SqlClient\.Extensions\.Azure\.(\d[^\\/]*)\.nupkg$'
-            }
-        )
-
-        foreach ($p in $packages) {
-            if ($p.Variable -eq 'sqlServerPackageVersion' -and -not [string]::IsNullOrWhiteSpace('${{ parameters.sqlServerVersionOverride }}')) {
-                $version = '${{ parameters.sqlServerVersionOverride }}'
-                Write-Host "Overriding $($p.Name) version: $version"
-            } else {
-                $version = Resolve-PackageVersion $feed $p.Pattern $p.Name
-                Write-Host "Resolved $($p.Name) version: $version"
-            }
-            Write-Host "##vso[task.setvariable variable=$($p.Variable)]$version"
-        }
+      targetType: filePath
+      filePath: $(Build.SourcesDirectory)/eng/pipelines/common/steps/download-driver-packages.ps1
+      arguments: >-
+        -FeedPath "${{ parameters.feedPath }}"
+        -ArtifactDirectory "$(Pipeline.Workspace)/${{ parameters.pipelineResource }}/${{ parameters.artifactName }}"
+        -SqlServerVersionOverride "${{ parameters.sqlServerVersionOverride }}"

--- a/eng/pipelines/common/steps/download-driver-packages.ps1
+++ b/eng/pipelines/common/steps/download-driver-packages.ps1
@@ -85,15 +85,13 @@ function Resolve-PackageVersion {
         [Parameter(Mandatory)][string]$PackageName
     )
 
-    $package = Get-ChildItem "$Path/*.nupkg" |
-        Where-Object { $_.Name -match $Pattern } |
-        Select-Object -First 1
+    $packages = @(Get-ChildItem "$Path/*.nupkg" | Where-Object { $_.Name -match $Pattern })
 
-    if (-not $package) {
-        throw "$PackageName package not found in $Path"
+    if ($packages.Count -ne 1) {
+        throw "Expected exactly one $PackageName package in $Path, found $($packages.Count)"
     }
 
-    return [regex]::Match($package.Name, $Pattern).Groups[1].Value
+    return [regex]::Match($packages[0].Name, $Pattern).Groups[1].Value
 }
 
 # Patterns are anchored so the Microsoft.Data.SqlClient package does not also match extension
@@ -127,12 +125,14 @@ $packages = @(
 )
 
 foreach ($package in $packages) {
+    $artifactVersion = Resolve-PackageVersion $ArtifactDirectory $package.Pattern $package.Name
+
     if ($package.Variable -eq 'sqlServerPackageVersion' -and
         -not [string]::IsNullOrWhiteSpace($SqlServerVersionOverride)) {
         $version = $SqlServerVersionOverride
-        Write-Host "Overriding $($package.Name) version: $version"
+        Write-Host "Overriding $($package.Name) version from $artifactVersion to $version"
     } else {
-        $version = Resolve-PackageVersion $FeedPath $package.Pattern $package.Name
+        $version = $artifactVersion
         Write-Host "Resolved $($package.Name) version: $version"
     }
 

--- a/eng/pipelines/common/steps/download-driver-packages.ps1
+++ b/eng/pipelines/common/steps/download-driver-packages.ps1
@@ -1,0 +1,140 @@
+<#
+.SYNOPSIS
+    Stages SqlClient driver packages and exposes their exact versions to Azure Pipelines.
+
+.DESCRIPTION
+    Copies the .nupkg and .snupkg files downloaded from an upstream SqlClient package artifact into
+    a local NuGet feed. It then resolves package versions from the .nupkg filenames and emits Azure
+    Pipelines logging commands that create these job-scoped variables for downstream tasks:
+
+      sqlClientPackageVersion     Microsoft.Data.SqlClient
+      sqlServerPackageVersion     Microsoft.SqlServer.Server
+      abstractionsPackageVersion  Microsoft.Data.SqlClient.Extensions.Abstractions
+      loggingPackageVersion       Microsoft.Data.SqlClient.Internal.Logging
+      azurePackageVersion         Microsoft.Data.SqlClient.Extensions.Azure
+
+    Every required .nupkg must be present in ArtifactDirectory. Symbol packages are optional. The
+    script stops on missing required packages, copy failures, and ambiguous filesystem errors.
+
+.PARAMETER FeedPath
+    Directory used as the local NuGet feed. The script creates it when it does not exist and
+    overwrites packages with matching filenames.
+
+.PARAMETER ArtifactDirectory
+    Directory containing the .nupkg files downloaded from the upstream pipeline artifact. Optional
+    .snupkg files in this directory are copied when present.
+
+.PARAMETER SqlServerVersionOverride
+    Optional version to expose as sqlServerPackageVersion instead of resolving the version from the
+    Microsoft.SqlServer.Server .nupkg filename. The package itself is still required and staged.
+
+.EXAMPLE
+    ./download-driver-packages.ps1 `
+        -FeedPath 'C:\agent\_work\1\s\packages' `
+        -ArtifactDirectory 'C:\agent\_work\1\sqlclient-ci-package\SqlClient-Driver-Packages'
+
+    Stages all driver packages and resolves every version from its package filename.
+
+.EXAMPLE
+    ./download-driver-packages.ps1 `
+        -FeedPath '/agent/_work/1/s/packages' `
+        -ArtifactDirectory '/agent/_work/1/sqlclient-ci-package/SqlClient-Driver-Packages' `
+        -SqlServerVersionOverride '1.0.0'
+
+    Stages all packages but exposes 1.0.0 as sqlServerPackageVersion.
+
+.OUTPUTS
+    None. Results are emitted as Azure Pipelines task.setvariable logging commands.
+
+.NOTES
+    This script is designed for PowerShell Core in Azure Pipelines. Package filenames must use the
+    conventional <package-id>.<version>.nupkg format, and versions must begin with a digit.
+#>
+
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the MIT license.
+# See the LICENSE file in the project root for more information.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$FeedPath,
+
+    [Parameter(Mandatory)]
+    [string]$ArtifactDirectory,
+
+    [string]$SqlServerVersionOverride = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+New-Item -ItemType Directory -Force -Path $FeedPath | Out-Null
+
+Copy-Item "$ArtifactDirectory/*.nupkg" $FeedPath -Force
+Copy-Item "$ArtifactDirectory/*.snupkg" $FeedPath -Force -ErrorAction SilentlyContinue
+
+function Resolve-PackageVersion {
+    <#
+    .SYNOPSIS
+        Resolves a package version from a matching .nupkg filename.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$Pattern,
+        [Parameter(Mandatory)][string]$PackageName
+    )
+
+    $package = Get-ChildItem "$Path/*.nupkg" |
+        Where-Object { $_.Name -match $Pattern } |
+        Select-Object -First 1
+
+    if (-not $package) {
+        throw "$PackageName package not found in $Path"
+    }
+
+    return [regex]::Match($package.Name, $Pattern).Groups[1].Value
+}
+
+# Patterns are anchored so the Microsoft.Data.SqlClient package does not also match extension
+# packages whose IDs begin with Microsoft.Data.SqlClient.
+$packages = @(
+    @{
+        Variable = 'sqlClientPackageVersion'
+        Name = 'Microsoft.Data.SqlClient'
+        Pattern = '^Microsoft\.Data\.SqlClient\.(\d[^\/]*)\.nupkg$'
+    },
+    @{
+        Variable = 'sqlServerPackageVersion'
+        Name = 'Microsoft.SqlServer.Server'
+        Pattern = '^Microsoft\.SqlServer\.Server\.(\d[^\/]*)\.nupkg$'
+    },
+    @{
+        Variable = 'abstractionsPackageVersion'
+        Name = 'Microsoft.Data.SqlClient.Extensions.Abstractions'
+        Pattern = '^Microsoft\.Data\.SqlClient\.Extensions\.Abstractions\.(\d[^\/]*)\.nupkg$'
+    },
+    @{
+        Variable = 'loggingPackageVersion'
+        Name = 'Microsoft.Data.SqlClient.Internal.Logging'
+        Pattern = '^Microsoft\.Data\.SqlClient\.Internal\.Logging\.(\d[^\/]*)\.nupkg$'
+    },
+    @{
+        Variable = 'azurePackageVersion'
+        Name = 'Microsoft.Data.SqlClient.Extensions.Azure'
+        Pattern = '^Microsoft\.Data\.SqlClient\.Extensions\.Azure\.(\d[^\/]*)\.nupkg$'
+    }
+)
+
+foreach ($package in $packages) {
+    if ($package.Variable -eq 'sqlServerPackageVersion' -and
+        -not [string]::IsNullOrWhiteSpace($SqlServerVersionOverride)) {
+        $version = $SqlServerVersionOverride
+        Write-Host "Overriding $($package.Name) version: $version"
+    } else {
+        $version = Resolve-PackageVersion $FeedPath $package.Pattern $package.Name
+        Write-Host "Resolved $($package.Name) version: $version"
+    }
+
+    Write-Host "##vso[task.setvariable variable=$($package.Variable)]$version"
+}

--- a/eng/pipelines/common/templates/steps/run-all-tests-step.yml
+++ b/eng/pipelines/common/templates/steps/run-all-tests-step.yml
@@ -16,6 +16,17 @@ parameters:
     type: boolean
     default: false
 
+  # The verbosity level for dotnet CLI commands.
+  - name: dotnetVerbosity
+    type: string
+    default: normal
+    values:
+      - quiet
+      - minimal
+      - normal
+      - detailed
+      - diagnostic
+
   - name: targetFramework
     type: string
 
@@ -93,6 +104,7 @@ steps:
       projects: build.proj
       ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
         arguments: >-
+          --verbosity ${{ parameters.dotnetVerbosity }}
           -t:TestSqlClientUnit
           -p:TestFramework=${{ parameters.targetFramework }}
           -p:ReferenceType=${{ parameters.referenceType }}
@@ -102,6 +114,7 @@ steps:
           -p:TestResultsFolderPath=TestResults
       ${{ else }}: # x86
         arguments: >-
+          --verbosity ${{ parameters.dotnetVerbosity }}
           -t:TestSqlClientUnit
           -p:TestFramework=${{ parameters.targetFramework }}
           -p:ReferenceType=${{ parameters.referenceType }}
@@ -120,6 +133,7 @@ steps:
         projects: build.proj
         ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
           arguments: >-
+            --verbosity ${{ parameters.dotnetVerbosity }}
             -t:TestSqlClientUnit
             -p:TestFramework=${{ parameters.targetFramework }}
             -p:ReferenceType=${{ parameters.referenceType }}
@@ -131,6 +145,7 @@ steps:
             -p:TestCodeCoverage=false
         ${{ else }}: # x86
           arguments: >-
+            --verbosity ${{ parameters.dotnetVerbosity }}
             -t:TestSqlClientUnit
             -p:TestFramework=${{ parameters.targetFramework }}
             -p:ReferenceType=${{ parameters.referenceType }}
@@ -151,6 +166,7 @@ steps:
       projects: build.proj
       ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
         arguments: >-
+          --verbosity ${{ parameters.dotnetVerbosity }}
           -t:TestSqlClientFunctional
           -p:TestFramework=${{ parameters.targetFramework }}
           -p:ReferenceType=${{ parameters.referenceType }}
@@ -162,6 +178,7 @@ steps:
           -p:TestResultsFolderPath=TestResults
       ${{ else }}: # x86
         arguments: >-
+          --verbosity ${{ parameters.dotnetVerbosity }}
           -t:TestSqlClientFunctional
           -p:TestFramework=${{ parameters.targetFramework }}
           -p:ReferenceType=${{ parameters.referenceType }}
@@ -182,6 +199,7 @@ steps:
         projects: build.proj
         ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
           arguments: >-
+            --verbosity ${{ parameters.dotnetVerbosity }}
             -t:TestSqlClientFunctional
             -p:TestFramework=${{ parameters.targetFramework }}
             -p:ReferenceType=${{ parameters.referenceType }}
@@ -195,6 +213,7 @@ steps:
             -p:TestCodeCoverage=false
         ${{ else }}: # x86
           arguments: >-
+            --verbosity ${{ parameters.dotnetVerbosity }}
             -t:TestSqlClientFunctional
             -p:TestFramework=${{ parameters.targetFramework }}
             -p:ReferenceType=${{ parameters.referenceType }}
@@ -217,6 +236,7 @@ steps:
       projects: build.proj
       ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
         arguments: >-
+          --verbosity ${{ parameters.dotnetVerbosity }}
           -t:TestSqlClientManual
           -p:TestFramework=${{ parameters.targetFramework }}
           -p:TestSet=${{ parameters.testSet }}
@@ -229,6 +249,7 @@ steps:
           -p:TestResultsFolderPath=TestResults
       ${{ else }}: # x86
         arguments: >-
+          --verbosity ${{ parameters.dotnetVerbosity }}
           -t:TestSqlClientManual
           -p:TestFramework=${{ parameters.targetFramework }}
           -p:TestSet=${{ parameters.testSet }}
@@ -251,6 +272,7 @@ steps:
         projects: build.proj
         ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
           arguments: >-
+            --verbosity ${{ parameters.dotnetVerbosity }}
             -t:TestSqlClientManual
             -p:TestFramework=${{ parameters.targetFramework }}
             -p:TestSet=${{ parameters.testSet }}
@@ -265,6 +287,7 @@ steps:
             -p:TestCodeCoverage=false
         ${{ else }}: # x86
           arguments: >-
+            --verbosity ${{ parameters.dotnetVerbosity }}
             -t:TestSqlClientManual
             -p:TestFramework=${{ parameters.targetFramework }}
             -p:TestSet=${{ parameters.testSet }}
@@ -288,6 +311,7 @@ steps:
       command: build
       projects: build.proj
       arguments: >-
+        --verbosity ${{ parameters.dotnetVerbosity }}
         -t:TestSqlClientUnit
         -p:TestFramework=${{ parameters.targetFramework }}
         -p:ReferenceType=${{ parameters.referenceType }}
@@ -304,6 +328,7 @@ steps:
         command: build
         projects: build.proj
         arguments: >-
+          --verbosity ${{ parameters.dotnetVerbosity }}
           -t:TestSqlClientUnit
           -p:TestFramework=${{ parameters.targetFramework }}
           -p:ReferenceType=${{ parameters.referenceType }}
@@ -322,6 +347,7 @@ steps:
       command: build
       projects: build.proj
       arguments: >-
+        --verbosity ${{ parameters.dotnetVerbosity }}
         -t:TestSqlClientFunctional
         -p:TestFramework=${{ parameters.targetFramework }}
         -p:ReferenceType=${{ parameters.referenceType }}
@@ -340,6 +366,7 @@ steps:
         command: build
         projects: build.proj
         arguments: >-
+          --verbosity ${{ parameters.dotnetVerbosity }}
           -t:TestSqlClientFunctional
           -p:TestFramework=${{ parameters.targetFramework }}
           -p:ReferenceType=${{ parameters.referenceType }}
@@ -359,6 +386,7 @@ steps:
       command: build
       projects: build.proj
       arguments: >-
+        --verbosity ${{ parameters.dotnetVerbosity }}
         -t:TestSqlClientManual
         -p:TestFramework=${{ parameters.targetFramework }}
         -p:TestSet=${{ parameters.testSet }}
@@ -379,6 +407,7 @@ steps:
         command: build
         projects: build.proj
         arguments: >-
+          --verbosity ${{ parameters.dotnetVerbosity }}
           -t:TestSqlClientManual
           -p:TestFramework=${{ parameters.targetFramework }}
           -p:TestSet=${{ parameters.testSet }}

--- a/eng/pipelines/common/templates/steps/run-all-tests-step.yml
+++ b/eng/pipelines/common/templates/steps/run-all-tests-step.yml
@@ -16,17 +16,6 @@ parameters:
     type: boolean
     default: false
 
-  # The verbosity level for dotnet CLI commands.
-  - name: dotnetVerbosity
-    type: string
-    default: normal
-    values:
-      - quiet
-      - minimal
-      - normal
-      - detailed
-      - diagnostic
-
   - name: targetFramework
     type: string
 
@@ -83,12 +72,6 @@ parameters:
     type: number
     default: 2
 
-  # True to run the quarantined flaky tests (in separate, non-blocking steps).  Set to false to skip
-  # them entirely.
-  - name: runFlakyTests
-    type: boolean
-    default: true
-
 steps:
 - ${{ if parameters.debug }}:
   - powershell: 'dotnet sdk check'
@@ -104,7 +87,6 @@ steps:
       projects: build.proj
       ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
         arguments: >-
-          --verbosity ${{ parameters.dotnetVerbosity }}
           -t:TestSqlClientUnit
           -p:TestFramework=${{ parameters.targetFramework }}
           -p:ReferenceType=${{ parameters.referenceType }}
@@ -114,7 +96,6 @@ steps:
           -p:TestResultsFolderPath=TestResults
       ${{ else }}: # x86
         arguments: >-
-          --verbosity ${{ parameters.dotnetVerbosity }}
           -t:TestSqlClientUnit
           -p:TestFramework=${{ parameters.targetFramework }}
           -p:ReferenceType=${{ parameters.referenceType }}
@@ -124,39 +105,36 @@ steps:
           -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
           -p:TestResultsFolderPath=TestResults
 
-  - ${{ if parameters.runFlakyTests }}:
-    - task: DotNetCoreCLI@2
-      displayName: 'Run Flaky Unit Tests ${{parameters.msbuildArchitecture }}'
-      condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
-      inputs:
-        command: build
-        projects: build.proj
-        ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
-          arguments: >-
-            --verbosity ${{ parameters.dotnetVerbosity }}
-            -t:TestSqlClientUnit
-            -p:TestFramework=${{ parameters.targetFramework }}
-            -p:ReferenceType=${{ parameters.referenceType }}
-            -p:Configuration=${{ parameters.buildConfiguration }}
-            -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
-            -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
-            -p:TestFilters="category=flaky"
-            -p:TestResultsFolderPath=TestResults
-            -p:TestCodeCoverage=false
-        ${{ else }}: # x86
-          arguments: >-
-            --verbosity ${{ parameters.dotnetVerbosity }}
-            -t:TestSqlClientUnit
-            -p:TestFramework=${{ parameters.targetFramework }}
-            -p:ReferenceType=${{ parameters.referenceType }}
-            -p:Configuration=${{ parameters.buildConfiguration }}
-            -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
-            -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
-            -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
-            -p:TestFilters="category=flaky"
-            -p:TestResultsFolderPath=TestResults
-            -p:TestCodeCoverage=false
-      continueOnError: true
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Flaky Unit Tests ${{parameters.msbuildArchitecture }}'
+    condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
+    inputs:
+      command: build
+      projects: build.proj
+      ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
+        arguments: >-
+          -t:TestSqlClientUnit
+          -p:TestFramework=${{ parameters.targetFramework }}
+          -p:ReferenceType=${{ parameters.referenceType }}
+          -p:Configuration=${{ parameters.buildConfiguration }}
+          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+          -p:TestFilters="category=flaky"
+          -p:TestResultsFolderPath=TestResults
+          -p:TestCodeCoverage=false
+      ${{ else }}: # x86
+        arguments: >-
+          -t:TestSqlClientUnit
+          -p:TestFramework=${{ parameters.targetFramework }}
+          -p:ReferenceType=${{ parameters.referenceType }}
+          -p:Configuration=${{ parameters.buildConfiguration }}
+          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+          -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
+          -p:TestFilters="category=flaky"
+          -p:TestResultsFolderPath=TestResults
+          -p:TestCodeCoverage=false
+    continueOnError: true
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Functional Tests ${{parameters.msbuildArchitecture }}'
@@ -166,7 +144,6 @@ steps:
       projects: build.proj
       ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
         arguments: >-
-          --verbosity ${{ parameters.dotnetVerbosity }}
           -t:TestSqlClientFunctional
           -p:TestFramework=${{ parameters.targetFramework }}
           -p:ReferenceType=${{ parameters.referenceType }}
@@ -178,7 +155,6 @@ steps:
           -p:TestResultsFolderPath=TestResults
       ${{ else }}: # x86
         arguments: >-
-          --verbosity ${{ parameters.dotnetVerbosity }}
           -t:TestSqlClientFunctional
           -p:TestFramework=${{ parameters.targetFramework }}
           -p:ReferenceType=${{ parameters.referenceType }}
@@ -190,43 +166,40 @@ steps:
           -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
           -p:TestResultsFolderPath=TestResults
 
-  - ${{ if parameters.runFlakyTests }}:
-    - task: DotNetCoreCLI@2
-      displayName: 'Run Flaky Functional Tests ${{parameters.msbuildArchitecture }}'
-      condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
-      inputs:
-        command: build
-        projects: build.proj
-        ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
-          arguments: >-
-            --verbosity ${{ parameters.dotnetVerbosity }}
-            -t:TestSqlClientFunctional
-            -p:TestFramework=${{ parameters.targetFramework }}
-            -p:ReferenceType=${{ parameters.referenceType }}
-            -p:Configuration=${{ parameters.buildConfiguration }}
-            -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
-            -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
-            -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
-            -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
-            -p:TestFilters="category=flaky"
-            -p:TestResultsFolderPath=TestResults
-            -p:TestCodeCoverage=false
-        ${{ else }}: # x86
-          arguments: >-
-            --verbosity ${{ parameters.dotnetVerbosity }}
-            -t:TestSqlClientFunctional
-            -p:TestFramework=${{ parameters.targetFramework }}
-            -p:ReferenceType=${{ parameters.referenceType }}
-            -p:Configuration=${{ parameters.buildConfiguration }}
-            -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
-            -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
-            -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
-            -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
-            -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
-            -p:TestFilters="category=flaky"
-            -p:TestResultsFolderPath=TestResults
-            -p:TestCodeCoverage=false
-      continueOnError: true
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Flaky Functional Tests ${{parameters.msbuildArchitecture }}'
+    condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
+    inputs:
+      command: build
+      projects: build.proj
+      ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
+        arguments: >-
+          -t:TestSqlClientFunctional
+          -p:TestFramework=${{ parameters.targetFramework }}
+          -p:ReferenceType=${{ parameters.referenceType }}
+          -p:Configuration=${{ parameters.buildConfiguration }}
+          -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
+          -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
+          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+          -p:TestFilters="category=flaky"
+          -p:TestResultsFolderPath=TestResults
+          -p:TestCodeCoverage=false
+      ${{ else }}: # x86
+        arguments: >-
+          -t:TestSqlClientFunctional
+          -p:TestFramework=${{ parameters.targetFramework }}
+          -p:ReferenceType=${{ parameters.referenceType }}
+          -p:Configuration=${{ parameters.buildConfiguration }}
+          -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
+          -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
+          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+          -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
+          -p:TestFilters="category=flaky"
+          -p:TestResultsFolderPath=TestResults
+          -p:TestCodeCoverage=false
+    continueOnError: true
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Manual Tests ${{parameters.msbuildArchitecture }}'
@@ -236,7 +209,6 @@ steps:
       projects: build.proj
       ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
         arguments: >-
-          --verbosity ${{ parameters.dotnetVerbosity }}
           -t:TestSqlClientManual
           -p:TestFramework=${{ parameters.targetFramework }}
           -p:TestSet=${{ parameters.testSet }}
@@ -249,7 +221,6 @@ steps:
           -p:TestResultsFolderPath=TestResults
       ${{ else }}: # x86
         arguments: >-
-          --verbosity ${{ parameters.dotnetVerbosity }}
           -t:TestSqlClientManual
           -p:TestFramework=${{ parameters.targetFramework }}
           -p:TestSet=${{ parameters.testSet }}
@@ -263,45 +234,42 @@ steps:
           -p:TestResultsFolderPath=TestResults
     retryCountOnTaskFailure: ${{parameters.retryCountOnManualTests }}
 
-  - ${{ if parameters.runFlakyTests }}:
-    - task: DotNetCoreCLI@2
-      displayName: 'Run Flaky Manual Tests ${{parameters.msbuildArchitecture }}'
-      condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
-      inputs:
-        command: build
-        projects: build.proj
-        ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
-          arguments: >-
-            --verbosity ${{ parameters.dotnetVerbosity }}
-            -t:TestSqlClientManual
-            -p:TestFramework=${{ parameters.targetFramework }}
-            -p:TestSet=${{ parameters.testSet }}
-            -p:ReferenceType=${{ parameters.referenceType }}
-            -p:Configuration=${{ parameters.buildConfiguration }}
-            -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
-            -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
-            -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
-            -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
-            -p:TestFilters="category=flaky"
-            -p:TestResultsFolderPath=TestResults
-            -p:TestCodeCoverage=false
-        ${{ else }}: # x86
-          arguments: >-
-            --verbosity ${{ parameters.dotnetVerbosity }}
-            -t:TestSqlClientManual
-            -p:TestFramework=${{ parameters.targetFramework }}
-            -p:TestSet=${{ parameters.testSet }}
-            -p:ReferenceType=${{ parameters.referenceType }}
-            -p:Configuration=${{ parameters.buildConfiguration }}
-            -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
-            -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
-            -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
-            -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
-            -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
-            -p:TestFilters="category=flaky"
-            -p:TestResultsFolderPath=TestResults
-            -p:TestCodeCoverage=false
-      continueOnError: true
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Flaky Manual Tests ${{parameters.msbuildArchitecture }}'
+    condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
+    inputs:
+      command: build
+      projects: build.proj
+      ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
+        arguments: >-
+          -t:TestSqlClientManual
+          -p:TestFramework=${{ parameters.targetFramework }}
+          -p:TestSet=${{ parameters.testSet }}
+          -p:ReferenceType=${{ parameters.referenceType }}
+          -p:Configuration=${{ parameters.buildConfiguration }}
+          -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
+          -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
+          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+          -p:TestFilters="category=flaky"
+          -p:TestResultsFolderPath=TestResults
+          -p:TestCodeCoverage=false
+      ${{ else }}: # x86
+        arguments: >-
+          -t:TestSqlClientManual
+          -p:TestFramework=${{ parameters.targetFramework }}
+          -p:TestSet=${{ parameters.testSet }}
+          -p:ReferenceType=${{ parameters.referenceType }}
+          -p:Configuration=${{ parameters.buildConfiguration }}
+          -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
+          -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
+          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+          -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
+          -p:TestFilters="category=flaky"
+          -p:TestResultsFolderPath=TestResults
+          -p:TestCodeCoverage=false
+    continueOnError: true
 
 - ${{ else }}: # Linux or macOS
   - task: DotNetCoreCLI@2
@@ -311,7 +279,6 @@ steps:
       command: build
       projects: build.proj
       arguments: >-
-        --verbosity ${{ parameters.dotnetVerbosity }}
         -t:TestSqlClientUnit
         -p:TestFramework=${{ parameters.targetFramework }}
         -p:ReferenceType=${{ parameters.referenceType }}
@@ -320,25 +287,23 @@ steps:
         -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
         -p:TestResultsFolderPath=TestResults
 
-  - ${{ if parameters.runFlakyTests }}:
-    - task: DotNetCoreCLI@2
-      displayName: 'Run Flaky Unit Tests'
-      condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
-      inputs:
-        command: build
-        projects: build.proj
-        arguments: >-
-          --verbosity ${{ parameters.dotnetVerbosity }}
-          -t:TestSqlClientUnit
-          -p:TestFramework=${{ parameters.targetFramework }}
-          -p:ReferenceType=${{ parameters.referenceType }}
-          -p:Configuration=${{ parameters.buildConfiguration }}
-          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
-          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
-          -p:TestFilters="category=flaky"
-          -p:TestResultsFolderPath=TestResults
-          -p:TestCodeCoverage=false
-      continueOnError: true
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Flaky Unit Tests'
+    condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
+    inputs:
+      command: build
+      projects: build.proj
+      arguments: >-
+        -t:TestSqlClientUnit
+        -p:TestFramework=${{ parameters.targetFramework }}
+        -p:ReferenceType=${{ parameters.referenceType }}
+        -p:Configuration=${{ parameters.buildConfiguration }}
+        -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+        -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+        -p:TestFilters="category=flaky"
+        -p:TestResultsFolderPath=TestResults
+        -p:TestCodeCoverage=false
+    continueOnError: true
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Functional Tests'
@@ -347,7 +312,6 @@ steps:
       command: build
       projects: build.proj
       arguments: >-
-        --verbosity ${{ parameters.dotnetVerbosity }}
         -t:TestSqlClientFunctional
         -p:TestFramework=${{ parameters.targetFramework }}
         -p:ReferenceType=${{ parameters.referenceType }}
@@ -358,27 +322,25 @@ steps:
         -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
         -p:TestResultsFolderPath=TestResults
 
-  - ${{ if parameters.runFlakyTests }}:
-    - task: DotNetCoreCLI@2
-      displayName: 'Run Flaky Functional Tests'
-      condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
-      inputs:
-        command: build
-        projects: build.proj
-        arguments: >-
-          --verbosity ${{ parameters.dotnetVerbosity }}
-          -t:TestSqlClientFunctional
-          -p:TestFramework=${{ parameters.targetFramework }}
-          -p:ReferenceType=${{ parameters.referenceType }}
-          -p:Configuration=${{ parameters.buildConfiguration }}
-          -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
-          -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
-          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
-          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
-          -p:TestFilters="category=flaky"
-          -p:TestResultsFolderPath=TestResults
-          -p:TestCodeCoverage=false
-      continueOnError: true
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Flaky Functional Tests'
+    condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
+    inputs:
+      command: build
+      projects: build.proj
+      arguments: >-
+        -t:TestSqlClientFunctional
+        -p:TestFramework=${{ parameters.targetFramework }}
+        -p:ReferenceType=${{ parameters.referenceType }}
+        -p:Configuration=${{ parameters.buildConfiguration }}
+        -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
+        -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
+        -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+        -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+        -p:TestFilters="category=flaky"
+        -p:TestResultsFolderPath=TestResults
+        -p:TestCodeCoverage=false
+    continueOnError: true
   - task: DotNetCoreCLI@2
     displayName: 'Run Manual Tests'
     condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
@@ -386,7 +348,6 @@ steps:
       command: build
       projects: build.proj
       arguments: >-
-        --verbosity ${{ parameters.dotnetVerbosity }}
         -t:TestSqlClientManual
         -p:TestFramework=${{ parameters.targetFramework }}
         -p:TestSet=${{ parameters.testSet }}
@@ -399,25 +360,23 @@ steps:
         -p:TestResultsFolderPath=TestResults
     retryCountOnTaskFailure: ${{parameters.retryCountOnManualTests }}
 
-  - ${{ if parameters.runFlakyTests }}:
-    - task: DotNetCoreCLI@2
-      displayName: 'Run Flaky Manual Tests'
-      condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
-      inputs:
-        command: build
-        projects: build.proj
-        arguments: >-
-          --verbosity ${{ parameters.dotnetVerbosity }}
-          -t:TestSqlClientManual
-          -p:TestFramework=${{ parameters.targetFramework }}
-          -p:TestSet=${{ parameters.testSet }}
-          -p:ReferenceType=${{ parameters.referenceType }}
-          -p:Configuration=${{ parameters.buildConfiguration }}
-          -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
-          -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
-          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
-          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
-          -p:TestFilters="category=flaky"
-          -p:TestResultsFolderPath=TestResults
-          -p:TestCodeCoverage=false
-      continueOnError: true
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Flaky Manual Tests'
+    condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
+    inputs:
+      command: build
+      projects: build.proj
+      arguments: >-
+        -t:TestSqlClientManual
+        -p:TestFramework=${{ parameters.targetFramework }}
+        -p:TestSet=${{ parameters.testSet }}
+        -p:ReferenceType=${{ parameters.referenceType }}
+        -p:Configuration=${{ parameters.buildConfiguration }}
+        -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
+        -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
+        -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+        -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+        -p:TestFilters="category=flaky"
+        -p:TestResultsFolderPath=TestResults
+        -p:TestCodeCoverage=false
+    continueOnError: true

--- a/eng/pipelines/common/templates/steps/run-all-tests-step.yml
+++ b/eng/pipelines/common/templates/steps/run-all-tests-step.yml
@@ -72,6 +72,12 @@ parameters:
     type: number
     default: 2
 
+  # True to run the quarantined flaky tests (in separate, non-blocking steps).  Set to false to skip
+  # them entirely.
+  - name: runFlakyTests
+    type: boolean
+    default: true
+
 steps:
 - ${{ if parameters.debug }}:
   - powershell: 'dotnet sdk check'
@@ -105,36 +111,37 @@ steps:
           -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
           -p:TestResultsFolderPath=TestResults
 
-  - task: DotNetCoreCLI@2
-    displayName: 'Run Flaky Unit Tests ${{parameters.msbuildArchitecture }}'
-    condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
-    inputs:
-      command: build
-      projects: build.proj
-      ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
-        arguments: >-
-          -t:TestSqlClientUnit
-          -p:TestFramework=${{ parameters.targetFramework }}
-          -p:ReferenceType=${{ parameters.referenceType }}
-          -p:Configuration=${{ parameters.buildConfiguration }}
-          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
-          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
-          -p:TestFilters="category=flaky"
-          -p:TestResultsFolderPath=TestResults
-          -p:TestCodeCoverage=false
-      ${{ else }}: # x86
-        arguments: >-
-          -t:TestSqlClientUnit
-          -p:TestFramework=${{ parameters.targetFramework }}
-          -p:ReferenceType=${{ parameters.referenceType }}
-          -p:Configuration=${{ parameters.buildConfiguration }}
-          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
-          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
-          -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
-          -p:TestFilters="category=flaky"
-          -p:TestResultsFolderPath=TestResults
-          -p:TestCodeCoverage=false
-    continueOnError: true
+  - ${{ if parameters.runFlakyTests }}:
+    - task: DotNetCoreCLI@2
+      displayName: 'Run Flaky Unit Tests ${{parameters.msbuildArchitecture }}'
+      condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
+      inputs:
+        command: build
+        projects: build.proj
+        ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
+          arguments: >-
+            -t:TestSqlClientUnit
+            -p:TestFramework=${{ parameters.targetFramework }}
+            -p:ReferenceType=${{ parameters.referenceType }}
+            -p:Configuration=${{ parameters.buildConfiguration }}
+            -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+            -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+            -p:TestFilters="category=flaky"
+            -p:TestResultsFolderPath=TestResults
+            -p:TestCodeCoverage=false
+        ${{ else }}: # x86
+          arguments: >-
+            -t:TestSqlClientUnit
+            -p:TestFramework=${{ parameters.targetFramework }}
+            -p:ReferenceType=${{ parameters.referenceType }}
+            -p:Configuration=${{ parameters.buildConfiguration }}
+            -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+            -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+            -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
+            -p:TestFilters="category=flaky"
+            -p:TestResultsFolderPath=TestResults
+            -p:TestCodeCoverage=false
+      continueOnError: true
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Functional Tests ${{parameters.msbuildArchitecture }}'
@@ -166,40 +173,41 @@ steps:
           -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
           -p:TestResultsFolderPath=TestResults
 
-  - task: DotNetCoreCLI@2
-    displayName: 'Run Flaky Functional Tests ${{parameters.msbuildArchitecture }}'
-    condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
-    inputs:
-      command: build
-      projects: build.proj
-      ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
-        arguments: >-
-          -t:TestSqlClientFunctional
-          -p:TestFramework=${{ parameters.targetFramework }}
-          -p:ReferenceType=${{ parameters.referenceType }}
-          -p:Configuration=${{ parameters.buildConfiguration }}
-          -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
-          -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
-          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
-          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
-          -p:TestFilters="category=flaky"
-          -p:TestResultsFolderPath=TestResults
-          -p:TestCodeCoverage=false
-      ${{ else }}: # x86
-        arguments: >-
-          -t:TestSqlClientFunctional
-          -p:TestFramework=${{ parameters.targetFramework }}
-          -p:ReferenceType=${{ parameters.referenceType }}
-          -p:Configuration=${{ parameters.buildConfiguration }}
-          -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
-          -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
-          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
-          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
-          -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
-          -p:TestFilters="category=flaky"
-          -p:TestResultsFolderPath=TestResults
-          -p:TestCodeCoverage=false
-    continueOnError: true
+  - ${{ if parameters.runFlakyTests }}:
+    - task: DotNetCoreCLI@2
+      displayName: 'Run Flaky Functional Tests ${{parameters.msbuildArchitecture }}'
+      condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
+      inputs:
+        command: build
+        projects: build.proj
+        ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
+          arguments: >-
+            -t:TestSqlClientFunctional
+            -p:TestFramework=${{ parameters.targetFramework }}
+            -p:ReferenceType=${{ parameters.referenceType }}
+            -p:Configuration=${{ parameters.buildConfiguration }}
+            -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
+            -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
+            -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+            -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+            -p:TestFilters="category=flaky"
+            -p:TestResultsFolderPath=TestResults
+            -p:TestCodeCoverage=false
+        ${{ else }}: # x86
+          arguments: >-
+            -t:TestSqlClientFunctional
+            -p:TestFramework=${{ parameters.targetFramework }}
+            -p:ReferenceType=${{ parameters.referenceType }}
+            -p:Configuration=${{ parameters.buildConfiguration }}
+            -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
+            -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
+            -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+            -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+            -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
+            -p:TestFilters="category=flaky"
+            -p:TestResultsFolderPath=TestResults
+            -p:TestCodeCoverage=false
+      continueOnError: true
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Manual Tests ${{parameters.msbuildArchitecture }}'
@@ -234,42 +242,43 @@ steps:
           -p:TestResultsFolderPath=TestResults
     retryCountOnTaskFailure: ${{parameters.retryCountOnManualTests }}
 
-  - task: DotNetCoreCLI@2
-    displayName: 'Run Flaky Manual Tests ${{parameters.msbuildArchitecture }}'
-    condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
-    inputs:
-      command: build
-      projects: build.proj
-      ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
-        arguments: >-
-          -t:TestSqlClientManual
-          -p:TestFramework=${{ parameters.targetFramework }}
-          -p:TestSet=${{ parameters.testSet }}
-          -p:ReferenceType=${{ parameters.referenceType }}
-          -p:Configuration=${{ parameters.buildConfiguration }}
-          -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
-          -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
-          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
-          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
-          -p:TestFilters="category=flaky"
-          -p:TestResultsFolderPath=TestResults
-          -p:TestCodeCoverage=false
-      ${{ else }}: # x86
-        arguments: >-
-          -t:TestSqlClientManual
-          -p:TestFramework=${{ parameters.targetFramework }}
-          -p:TestSet=${{ parameters.testSet }}
-          -p:ReferenceType=${{ parameters.referenceType }}
-          -p:Configuration=${{ parameters.buildConfiguration }}
-          -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
-          -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
-          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
-          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
-          -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
-          -p:TestFilters="category=flaky"
-          -p:TestResultsFolderPath=TestResults
-          -p:TestCodeCoverage=false
-    continueOnError: true
+  - ${{ if parameters.runFlakyTests }}:
+    - task: DotNetCoreCLI@2
+      displayName: 'Run Flaky Manual Tests ${{parameters.msbuildArchitecture }}'
+      condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
+      inputs:
+        command: build
+        projects: build.proj
+        ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
+          arguments: >-
+            -t:TestSqlClientManual
+            -p:TestFramework=${{ parameters.targetFramework }}
+            -p:TestSet=${{ parameters.testSet }}
+            -p:ReferenceType=${{ parameters.referenceType }}
+            -p:Configuration=${{ parameters.buildConfiguration }}
+            -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
+            -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
+            -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+            -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+            -p:TestFilters="category=flaky"
+            -p:TestResultsFolderPath=TestResults
+            -p:TestCodeCoverage=false
+        ${{ else }}: # x86
+          arguments: >-
+            -t:TestSqlClientManual
+            -p:TestFramework=${{ parameters.targetFramework }}
+            -p:TestSet=${{ parameters.testSet }}
+            -p:ReferenceType=${{ parameters.referenceType }}
+            -p:Configuration=${{ parameters.buildConfiguration }}
+            -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
+            -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
+            -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+            -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+            -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
+            -p:TestFilters="category=flaky"
+            -p:TestResultsFolderPath=TestResults
+            -p:TestCodeCoverage=false
+      continueOnError: true
 
 - ${{ else }}: # Linux or macOS
   - task: DotNetCoreCLI@2
@@ -287,23 +296,24 @@ steps:
         -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
         -p:TestResultsFolderPath=TestResults
 
-  - task: DotNetCoreCLI@2
-    displayName: 'Run Flaky Unit Tests'
-    condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
-    inputs:
-      command: build
-      projects: build.proj
-      arguments: >-
-        -t:TestSqlClientUnit
-        -p:TestFramework=${{ parameters.targetFramework }}
-        -p:ReferenceType=${{ parameters.referenceType }}
-        -p:Configuration=${{ parameters.buildConfiguration }}
-        -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
-        -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
-        -p:TestFilters="category=flaky"
-        -p:TestResultsFolderPath=TestResults
-        -p:TestCodeCoverage=false
-    continueOnError: true
+  - ${{ if parameters.runFlakyTests }}:
+    - task: DotNetCoreCLI@2
+      displayName: 'Run Flaky Unit Tests'
+      condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
+      inputs:
+        command: build
+        projects: build.proj
+        arguments: >-
+          -t:TestSqlClientUnit
+          -p:TestFramework=${{ parameters.targetFramework }}
+          -p:ReferenceType=${{ parameters.referenceType }}
+          -p:Configuration=${{ parameters.buildConfiguration }}
+          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+          -p:TestFilters="category=flaky"
+          -p:TestResultsFolderPath=TestResults
+          -p:TestCodeCoverage=false
+      continueOnError: true
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Functional Tests'
@@ -322,25 +332,26 @@ steps:
         -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
         -p:TestResultsFolderPath=TestResults
 
-  - task: DotNetCoreCLI@2
-    displayName: 'Run Flaky Functional Tests'
-    condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
-    inputs:
-      command: build
-      projects: build.proj
-      arguments: >-
-        -t:TestSqlClientFunctional
-        -p:TestFramework=${{ parameters.targetFramework }}
-        -p:ReferenceType=${{ parameters.referenceType }}
-        -p:Configuration=${{ parameters.buildConfiguration }}
-        -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
-        -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
-        -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
-        -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
-        -p:TestFilters="category=flaky"
-        -p:TestResultsFolderPath=TestResults
-        -p:TestCodeCoverage=false
-    continueOnError: true
+  - ${{ if parameters.runFlakyTests }}:
+    - task: DotNetCoreCLI@2
+      displayName: 'Run Flaky Functional Tests'
+      condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
+      inputs:
+        command: build
+        projects: build.proj
+        arguments: >-
+          -t:TestSqlClientFunctional
+          -p:TestFramework=${{ parameters.targetFramework }}
+          -p:ReferenceType=${{ parameters.referenceType }}
+          -p:Configuration=${{ parameters.buildConfiguration }}
+          -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
+          -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
+          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+          -p:TestFilters="category=flaky"
+          -p:TestResultsFolderPath=TestResults
+          -p:TestCodeCoverage=false
+      continueOnError: true
   - task: DotNetCoreCLI@2
     displayName: 'Run Manual Tests'
     condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
@@ -360,23 +371,24 @@ steps:
         -p:TestResultsFolderPath=TestResults
     retryCountOnTaskFailure: ${{parameters.retryCountOnManualTests }}
 
-  - task: DotNetCoreCLI@2
-    displayName: 'Run Flaky Manual Tests'
-    condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
-    inputs:
-      command: build
-      projects: build.proj
-      arguments: >-
-        -t:TestSqlClientManual
-        -p:TestFramework=${{ parameters.targetFramework }}
-        -p:TestSet=${{ parameters.testSet }}
-        -p:ReferenceType=${{ parameters.referenceType }}
-        -p:Configuration=${{ parameters.buildConfiguration }}
-        -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
-        -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
-        -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
-        -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
-        -p:TestFilters="category=flaky"
-        -p:TestResultsFolderPath=TestResults
-        -p:TestCodeCoverage=false
-    continueOnError: true
+  - ${{ if parameters.runFlakyTests }}:
+    - task: DotNetCoreCLI@2
+      displayName: 'Run Flaky Manual Tests'
+      condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
+      inputs:
+        command: build
+        projects: build.proj
+        arguments: >-
+          -t:TestSqlClientManual
+          -p:TestFramework=${{ parameters.targetFramework }}
+          -p:TestSet=${{ parameters.testSet }}
+          -p:ReferenceType=${{ parameters.referenceType }}
+          -p:Configuration=${{ parameters.buildConfiguration }}
+          -p:PackageVersionAbstractions=${{ parameters.abstractionsPackageVersion }}
+          -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
+          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+          -p:TestFilters="category=flaky"
+          -p:TestResultsFolderPath=TestResults
+          -p:TestCodeCoverage=false
+      continueOnError: true

--- a/eng/pipelines/common/templates/steps/update-config-file-step.yml
+++ b/eng/pipelines/common/templates/steps/update-config-file-step.yml
@@ -121,6 +121,10 @@ parameters:
     type: boolean
     default: true
 
+  - name: IsManagedInstance
+    type: boolean
+    default: false
+
   - name: WorkloadIdentityFederationServiceConnectionId
     type: string
     default: ''
@@ -191,6 +195,7 @@ steps:
           $p.UseManagedSNIOnWindows=[System.Convert]::ToBoolean("${{parameters.UseManagedSNIOnWindows }}")
           $p.SupportsIntegratedSecurity=[System.Convert]::ToBoolean("${{parameters.SupportsIntegratedSecurity }}")
           $p.ManagedIdentitySupported=[System.Convert]::ToBoolean("${{parameters.ManagedIdentitySupported }}")
+          $p.IsManagedInstance=[System.Convert]::ToBoolean("${{parameters.IsManagedInstance }}")
           $p.IsDNSCachingSupportedTR=[System.Convert]::ToBoolean("${{parameters.IsDNSCachingSupportedTR }}")
           $p.IsDNSCachingSupportedCR=[System.Convert]::ToBoolean("${{parameters.IsDNSCachingSupportedCR }}")
           $p.TracingEnabled=[System.Convert]::ToBoolean("${{parameters.TracingEnabled }}")

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -616,9 +616,15 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         // Synapse: UDT Test Database not compatible with Azure Synapse.
         public static bool IsUdtTestDatabasePresent() => IsDatabasePresent(UdtTestDbName) && IsNotAzureSynapse();
 
+        /// <summary>
+        /// Returns whether the primary connection strings required by the ManualTests configuration
+        /// are available. Most environments provide both TCP and Named Pipes connection strings.
+        /// Managed Instance requires only TCP because it does not support Named Pipes.
+        /// </summary>
         public static bool AreConnStringsSetup()
         {
-            return !string.IsNullOrEmpty(NPConnectionString) && !string.IsNullOrEmpty(TCPConnectionString);
+            return !string.IsNullOrEmpty(TCPConnectionString) &&
+                (IsManagedInstance || !string.IsNullOrEmpty(NPConnectionString));
         }
 
         public static bool IsSQL2022() => string.Equals("16", SQLServerVersion.Trim());

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/PoolBlockPeriodTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/PoolBlockPeriodTest.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         private const int CompareMargin = 2;
         private static bool AreConnectionStringsSetup() => DataTestUtility.AreConnStringsSetup();
 
+        // This uses deliberately nonexistent Azure hostnames to test client-side pool blocking; it
+        // never connects to the configured Managed Instance.
         [OuterLoop()]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotManagedInstance))]
         [InlineData("Azure with Default Policy must Disable blocking (*.database.windows.net)", new object[] { AzureEndpointSample })]
@@ -50,6 +52,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             PoolBlockingPeriodAzureTest(connString, policy);
         }
 
+        // This uses deliberately nonexistent non-Azure hostnames to test client-side pool blocking;
+        // it never connects to the configured Managed Instance.
         [OuterLoop()]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotManagedInstance))]
         [InlineData("NonAzure with Default Policy must Enable blocking", new object[] { NonExistentServer })]
@@ -73,6 +77,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             PoolBlockingPeriodNonAzureTest(connString, policy);
         }
 
+        // This validates connection-string policy parsing against a nonexistent Azure hostname; it
+        // never connects to the configured Managed Instance.
         [OuterLoop()]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotManagedInstance))]
         [InlineData("Test policy with Auto (lowercase)", "auto")]

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/PoolBlockPeriodTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/PoolBlockPeriodTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         private static bool AreConnectionStringsSetup() => DataTestUtility.AreConnStringsSetup();
 
         [OuterLoop()]
-        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotManagedInstance))]
         [InlineData("Azure with Default Policy must Disable blocking (*.database.windows.net)", new object[] { AzureEndpointSample })]
         [InlineData("Azure with Default Policy must Disable blocking (*.database.chinacloudapi.cn)", new object[] { AzureChinaEnpointSample })]
         [InlineData("Azure with Default Policy must Disable blocking (*.database.usgovcloudapi.net)", new object[] { AzureUSGovernmentEndpointSample })]
@@ -51,7 +51,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [OuterLoop()]
-        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotManagedInstance))]
         [InlineData("NonAzure with Default Policy must Enable blocking", new object[] { NonExistentServer })]
         [InlineData("NonAzure with Auto Policy must Enable Blocking", new object[] { NonExistentServer, PoolBlockingPeriod.Auto })]
         [InlineData("NonAzure with Always Policy must Enable Blocking", new object[] { NonExistentServer, PoolBlockingPeriod.AlwaysBlock })]
@@ -74,7 +74,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [OuterLoop()]
-        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotManagedInstance))]
         [InlineData("Test policy with Auto (lowercase)", "auto")]
         [InlineData("Test policy with Auto (PascalCase)", "Auto")]
         [InlineData("Test policy with Always (lowercase)", "alwaysblock")]

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DNSCachingTest/DNSCachingTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DNSCachingTest/DNSCachingTest.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public static Type SQLFallbackDNSCacheType = systemData.GetType("Microsoft.Data.SqlClient.SQLFallbackDNSCache");
         public static Type SQLDNSInfoType = systemData.GetType("Microsoft.Data.SqlClient.SQLDNSInfo");
         public static MethodInfo SQLFallbackDNSCacheGetDNSInfo = SQLFallbackDNSCacheType.GetMethod("GetDNSInfo", BindingFlags.Instance | BindingFlags.NonPublic);
-
-
+        // This uses the separately configured DNS-caching endpoint rather than the Managed Instance
+        // connection string, so it does not provide Managed Instance coverage.
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsDNSCachingSetup), nameof(DataTestUtility.IsNotManagedInstance))]
         public void DNSCachingIsSupportedFlag()
         {
@@ -39,6 +39,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
+        // This populates the cache from the separately configured DNS-caching endpoint rather than
+        // the Managed Instance connection string.
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsDNSCachingSetup), nameof(DataTestUtility.IsNotManagedInstance))]
         public void DNSCachingGetDNSInfo()
         {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DNSCachingTest/DNSCachingTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DNSCachingTest/DNSCachingTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public static MethodInfo SQLFallbackDNSCacheGetDNSInfo = SQLFallbackDNSCacheType.GetMethod("GetDNSInfo", BindingFlags.Instance | BindingFlags.NonPublic);
 
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsDNSCachingSetup))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsDNSCachingSetup), nameof(DataTestUtility.IsNotManagedInstance))]
         public void DNSCachingIsSupportedFlag()
         {
             string expectedDNSCachingSupportedCR = DataTestUtility.IsDNSCachingSupportedCR ? "true" : "false";
@@ -39,7 +39,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsDNSCachingSetup))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsDNSCachingSetup), nameof(DataTestUtility.IsNotManagedInstance))]
         public void DNSCachingGetDNSInfo()
         {
             using(SqlConnection connection = new SqlConnection(DataTestUtility.DNSCachingConnString))

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlDSEnumeratorTest/SqlDataSourceEnumeratorTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlDSEnumeratorTest/SqlDataSourceEnumeratorTest.cs
@@ -20,7 +20,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             ServiceController[] services = ServiceController.GetServices(Environment.MachineName);
             ServiceController service = services.FirstOrDefault(s => s.ServiceName == "SQLBrowser");
 
-            return DataTestUtility.IsUsingNativeSNI() &&
+            return DataTestUtility.IsNotManagedInstance() &&
+                DataTestUtility.IsUsingNativeSNI() &&
                 service != null &&
                 service.Status == ServiceControllerStatus.Running;
         }
@@ -35,7 +36,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsUsingManagedSNI))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsUsingManagedSNI), nameof(DataTestUtility.IsNotManagedInstance))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void SqlDataSourceEnumerator_ManagedSNI()
         {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlDSEnumeratorTest/SqlDataSourceEnumeratorTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlDSEnumeratorTest/SqlDataSourceEnumeratorTest.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 service.Status == ServiceControllerStatus.Running;
         }
 
+        // Managed Instance endpoints are resolved directly through DNS and cannot be discovered
+        // through the SQL Browser service running on the test agent.
         [ConditionalFact(nameof(IsEnvironmentAvailable))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void SqlDataSourceEnumerator_NativeSNI()
@@ -36,6 +38,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        // This validates client-side managed-SNI enumeration behavior and the agent's SQL Browser
+        // environment; it does not connect to or discover the configured Managed Instance.
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsUsingManagedSNI), nameof(DataTestUtility.IsNotManagedInstance))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void SqlDataSourceEnumerator_ManagedSNI()
@@ -46,6 +50,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         // This test validates behavior of SqlDataSourceConverter used to present instance names in PropertyGrid
         // with the SqlConnectionStringBuilder object presented in the control underneath.
+        // Managed Instance endpoints are not enumerated through the test agent's SQL Browser service.
         [ConditionalFact(nameof(IsEnvironmentAvailable))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void TestDataSourceConverterGetStandardValues()


### PR DESCRIPTION
## Description

Adds an internal, package-triggered CI pipeline that runs the SqlClient **ManualTests** suite against an Azure SQL **Managed Instance** in **Package reference mode**, based on the exported Classic `Test-SqlClient-Managed-Instance` pipeline.

### Managed Instance pipeline

- Adds the pipeline, stage, and job templates under `eng/pipelines/ci/managed-instance/`.
- Triggers after successful `sqlclient-ci-package` runs; it has no PR, commit, or schedule trigger.
- Is registered only in the internal **ADO.Net** project because it depends on the `Managed-Instance-pool` and `SQL_MI_TCP_CONN_STRING` from the `ADO Test Configuration Properties` variable group.
- Runs 10 parallel OS/SNI/runtime jobs:
  - Windows native SNI: `net462`, `net8.0`, `net9.0`, and `net10.0`.
  - Windows managed SNI: `net8.0`, `net9.0`, and `net10.0`.
  - Linux managed SNI: `net8.0`, `net9.0`, and `net10.0`.
- Runs ManualTests sets `1`, `2`, and `3`. UnitTests and FunctionalTests are omitted because they do not exercise Managed Instance integration. Set `AE` is omitted because this pipeline does not provision its separate Always Encrypted, enclave, and Azure Key Vault resources.
- Uses the normal ManualTests filter, which excludes failing, flaky, and interactive tests.
- Configures Managed Instance connectivity over TCP only; Azure SQL Managed Instance does not support Named Pipes. `AreConnStringsSetup` accepts this TCP-only configuration when `IsManagedInstance` is enabled.
- Skips tests that require unrelated infrastructure or endpoints: local SQL Browser discovery, the separate DNS-caching environment, and synthetic pool-blocking endpoints. Existing Managed-Instance conditions continue to skip other unsupported scenarios.
- Builds ManualTests with `ReferenceType=Package` against package versions resolved from the triggering artifact. `Microsoft.SqlServer.Server` is temporarily pinned to stable `1.0.0` to avoid the prerelease-versus-stable NU1605 downgrade.

### Source and package alignment

- Adds a shared source-alignment step used by the Managed Instance and stress pipelines. It checks out the upstream package run's source commit so tests compile against the matching API surface.
- Restores `eng/pipelines` from the queued pipeline commit after alignment so file-based tasks and compiled YAML remain in lockstep.
- Cleans self-hosted agent workspaces and repository checkouts before use.
- Adds a shared package-download step and documented PowerShell script to stage `.nupkg`/`.snupkg` files and publish exact package versions as pipeline variables.
- Requires exactly one matching artifact package for each expected product, preventing stale or ambiguous package selection.
- Refactors `sqlclient-ci-stress` to reuse the shared source-alignment and package-staging steps.

### Test configuration

- Adds `IsManagedInstance` to `update-config-file-step.yml` so tests can opt into Managed-Instance-specific behavior.
- Updates ManualTests connection readiness so Managed Instance requires its TCP connection string without requiring an unsupported Named Pipes connection string.
- Keeps the shared `run-all-tests-step.yml` unchanged from `main`; the Managed Instance job invokes its single ManualTests command directly.

No product code or public API changes are included.

> Note: This pipeline targets `main`. Ports to `release/7.0` and `release/6.1` will be handled separately because those branches predate the `sqlclient-ci-package` single-artifact model and require scheduled, build-from-source variants.

## Testing

- [x] sqlclient-ci-package: [21602](https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=164484&pathAsName=false&view=results)
  - [x] sqlclient-ci-managed-instance: [21603](https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=164487&view=results)