### PR TITLE
Test: remove flaky markers from stabilised tests

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/LocalizationTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/LocalizationTest.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Data.SqlClient.Tests
         [InlineData("ru-RU")]
         [InlineData("zh-Hans")]
         [InlineData("zh-Hant")]
+        [Trait("Category", "flaky")]
         public void Localization_Tests(string culture)
         {
             string localized = GetLocalizedErrorMessage(culture);

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/LocalizationTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/LocalizationTest.cs
@@ -40,7 +40,6 @@ namespace Microsoft.Data.SqlClient.Tests
         [InlineData("ru-RU")]
         [InlineData("zh-Hans")]
         [InlineData("zh-Hant")]
-        [Trait("Category", "flaky")]
         public void Localization_Tests(string culture)
         {
             string localized = GetLocalizedErrorMessage(culture);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
@@ -201,7 +201,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
-        [Trait("Category", "flaky")]
         public static void ReadStream_ReadsStreamDataCorrectly(string connectionString)
         {
             ReadStream(connectionString);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/DateTimeVariantTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/DateTimeVariantTests.cs
@@ -52,7 +52,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
     /// Tests for DateTime variant parameters with different date/time types.
     /// </summary>
     [Trait("Set", "3")]
-    [Trait("Category", "flaky")]
     public class DateTimeVariantTests
     {
         private static void RunTest(
@@ -329,6 +328,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 expectedBaseTypeOverrides);
         }
 
+        [Trait("Category", "flaky")]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         [MemberData(nameof(GetParameterCombinations), DisableDiscoveryEnumeration = true)]
         public void TestSqlDataReaderParameterToTVP_Variant(

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/DateTimeVariantTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/DateTimeVariantTests.cs
@@ -124,6 +124,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             cmd.ExecuteNonQuery();
         }
 
+        [Trait("Category", "flaky")]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         [MemberData(nameof(GetParameterCombinations), DisableDiscoveryEnumeration = true)]
         public void TestSimpleParameter_Type(
@@ -160,6 +161,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 expectedBaseTypeOverrides);
         }
 
+        [Trait("Category", "flaky")]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         [MemberData(nameof(GetParameterCombinations), DisableDiscoveryEnumeration = true)]
         public void TestSimpleParameter_Variant(
@@ -196,6 +198,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 expectedBaseTypeOverrides);
         }
 
+        [Trait("Category", "flaky")]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         [MemberData(nameof(GetParameterCombinations), DisableDiscoveryEnumeration = true)]
         public void TestSqlDataRecordParameterToTVP_Type(
@@ -239,6 +242,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 expectedBaseTypeOverrides);
         }
 
+        [Trait("Category", "flaky")]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         [MemberData(nameof(GetParameterCombinations), DisableDiscoveryEnumeration = true)]
         public void TestSqlDataRecordParameterToTVP_Variant(
@@ -282,6 +286,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 expectedBaseTypeOverrides);
         }
 
+        [Trait("Category", "flaky")]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         [MemberData(nameof(GetParameterCombinations), DisableDiscoveryEnumeration = true)]
         public void TestSqlDataReaderParameterToTVP_Type(
@@ -377,6 +382,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 expectedBaseTypeOverrides);
         }
 
+        [Trait("Category", "flaky")]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         [MemberData(nameof(GetParameterCombinations), DisableDiscoveryEnumeration = true)]
         public void TestSqlDataReader_TVP_Type(
@@ -452,6 +458,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 expectedBaseTypeOverrides);
         }
 
+        [Trait("Category", "flaky")]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         [MemberData(nameof(GetParameterCombinations), DisableDiscoveryEnumeration = true)]
         public void TestSqlDataReader_TVP_Variant(
@@ -527,6 +534,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 expectedBaseTypeOverrides);
         }
 
+        [Trait("Category", "flaky")]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         [MemberData(nameof(GetParameterCombinations), DisableDiscoveryEnumeration = true)]
         public void TestSimpleDataReader_Type(
@@ -584,6 +592,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 expectedBaseTypeOverrides);
         }
 
+        [Trait("Category", "flaky")]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         [MemberData(nameof(GetParameterCombinations), DisableDiscoveryEnumeration = true)]
         public void TestSimpleDataReader_Variant(

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
@@ -244,7 +244,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         // Synapse: Parse error at line: 1, column: 8: Incorrect syntax near 'TYPE'.
-        [Trait("Category", "flaky")]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         public static void TestParametersWithDatatablesTVPInsert()
         {
@@ -287,7 +286,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
 #if !NETFRAMEWORK
         // Synapse: Parse error at line: 1, column: 8: Incorrect syntax near 'TYPE'.
-        [Trait("Category", "flaky")]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         public static void TestParametersWithSqlRecordsTVPInsert()
         {
@@ -379,7 +377,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             cmd.ExecuteNonQuery();
         }
 
-        [Trait("Category", "flaky")]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         public static void TestDateOnlyTVPSqlDataRecord_CommandSP()
         {


### PR DESCRIPTION
## Summary

- remove flaky quarantine markers from 10 stabilized executable tests with zero CI failures over the last 90 days
- narrow the `DateTimeVariantTests` class-level quarantine to the 10 unlisted theories so only the six requested bulk-copy theories are re-enabled
- retain quarantine for environment-sensitive candidates: `CanReadAwkwardDataLengths`, `Localization_Tests`, `CopyAllFromReaderConnectionClosedOnEventAsync.Test`, and `Test_SingleDependency_AllDefaults_SqlAuth`

## Validation

- [x] Tests added or updated
- [x] Public API changes documented (not applicable)
- [x] Verified against customer repro (not applicable)
- [x] Ensure no breaking changes introduced
- [x] Manual test project builds for `net8.0` Release

The targeted localization run was intentionally left quarantined after hanging while opening its local simulated TDS connection.