### PR TITLE
ChannelDbConnectionPool transaction support

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Data.Common;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
@@ -251,6 +252,14 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         private int MinPoolSize => PoolGroupOptions.MinPoolSize;
 
         /// <summary>
+        /// Indicates whether connections may be vended from (and parked in) the
+        /// <see cref="TransactedConnectionPool"/>. This mirrors automatic transaction enlistment:
+        /// when enlistment is disabled a connection is never bound to an ambient transaction, so
+        /// the transacted store must not be consulted.
+        /// </summary>
+        private bool HasTransactionAffinity => PoolGroupOptions.HasTransactionAffinity;
+
+        /// <summary>
         /// The most recently launched warmup/replenishment loop task, exposed so tests can await a
         /// warmup pass to a deterministic completion instead of polling pool counters. May be null
         /// (warmup never requested) or reference an already-completed pass (requests are coalesced);
@@ -313,7 +322,31 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         /// <inheritdoc />
         public void PutObjectFromTransactedPool(DbConnectionInternal connection)
         {
-            throw new NotImplementedException();
+            Debug.Assert(connection is not null, "null connection?");
+            Debug.Assert(connection.EnlistedTransaction is null, "connection is still enlisted?");
+
+            // Called by the transacted connection pool once it has removed the connection from its
+            // list. We put the connection back into general circulation.
+            //
+            // NOTE: no locking is required here because if we're in this method we can safely
+            // presume that the caller is the only one using the connection, that all pre-push logic
+            // has been done, and that all transactions have ended.
+            SqlClientEventSource.Log.TryPoolerTraceEvent(
+                "<prov.DbConnectionPool.PutObjectFromTransactedPool|RES|CPOOL> {0}, Connection {1}, Transaction has ended.",
+                Id,
+                connection.ObjectID);
+
+            if (State is Running && connection.CanBePooled)
+            {
+                connection.ResetConnection();
+                PutConnectionInIdleChannel(connection);
+            }
+            else
+            {
+                // RemoveConnection triggers replenishment, which is the channel pool's equivalent
+                // of the wait handle pool's QueuePoolCreateRequest.
+                RemoveConnection(connection);
+            }
         }
 
         /// <inheritdoc />
@@ -331,7 +364,8 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
 
             if (newConnection is not null)
             {
-                // TODO: Full transaction enlistment support (Story 2).
+                // Carry the old connection's enlistment over to the replacement so that a connection
+                // replaced mid-transaction stays bound to the same transaction.
                 PrepareConnection(owningObject, newConnection, oldConnection.EnlistedTransaction);
                 oldConnection.DeactivateConnection();
                 RemoveConnection(oldConnection);
@@ -373,7 +407,8 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                         newConnection.PostPop(owningObject);
                     }
 
-                    // TODO: Full transaction enlistment support (Story 2).
+                    // Carry the old connection's enlistment over to the replacement so that a
+                    // connection replaced mid-transaction stays bound to the same transaction.
                     newConnection.ActivateConnection(oldConnection.EnlistedTransaction);
 
                     // Place new into old's slot
@@ -422,6 +457,116 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         {
             ValidateOwnershipAndSetPoolingState(connection, owningObject);
 
+            SqlClientEventSource.Log.TryPoolerTraceEvent(
+                "<prov.DbConnectionPool.DeactivateObject|RES|CPOOL> {0}, Connection {1}, Deactivating.",
+                Id,
+                connection.ObjectID);
+
+            // Deactivate before inspecting the connection's transaction state. Deactivation is what
+            // detaches a completed transaction, so reading EnlistedTransaction beforehand could park
+            // a connection in the transacted pool under a transaction that has already ended.
+            connection.DeactivateConnection();
+
+            if (connection.IsConnectionDoomed)
+            {
+                // The connection is not fit for reuse -- just dispose of it.
+                RemoveConnection(connection);
+                return;
+            }
+
+            bool returnToGeneralPool = false;
+            bool destroyConnection = false;
+            bool rootTxn = false;
+
+            // A connection with a delegated transaction cannot be handed to a different customer
+            // until the transaction actually completes, so we send it into stasis -- the
+            // System.Transactions transaction object keeps it owned (not lost) and is certain to
+            // put it back into the pool. The decision is made under the connection lock so that a
+            // transaction completing asynchronously on another thread cannot race with us.
+            lock (connection)
+            {
+                if (State is ShuttingDown)
+                {
+                    if (connection.IsTransactionRoot)
+                    {
+                        // Connections affiliated with a root transaction that happen to live in a
+                        // pool being shut down must be put in stasis so the root transaction isn't
+                        // orphaned with no means to promote itself to a full delegated transaction
+                        // or to Commit/Rollback.
+                        connection.SetInStasis();
+                        rootTxn = true;
+                    }
+                    else
+                    {
+                        destroyConnection = true;
+                    }
+                }
+                else if (connection.IsTransactionRoot && connection.Pool is null)
+                {
+                    connection.SetInStasis();
+                    rootTxn = true;
+                }
+                else if (connection.CanBePooled)
+                {
+                    Transaction? transaction = connection.EnlistedTransaction;
+                    if (transaction is not null)
+                    {
+                        // NOTE: we're not locking on State, so its value could change between the
+                        // conditional check above and here. Although perhaps not ideal, this is OK
+                        // because the DelegatedTransactionEnded event will clean up the connection
+                        // appropriately regardless of the pool state.
+                        //
+                        // Transacting connections are held in their own store and are never
+                        // proactively closed (doing so would abort the transaction, which can be
+                        // distributed). Idle-timeout enforcement does not apply here, so we do not
+                        // stamp the returned time when parking the connection in the transacted pool.
+                        TransactedConnectionPool.PutTransactedObject(transaction, connection);
+                        rootTxn = true;
+                    }
+                    else
+                    {
+                        returnToGeneralPool = true;
+                    }
+                }
+                else if (connection.IsTransactionRoot)
+                {
+                    // The connection cannot be pooled but is a transaction root, so we must have
+                    // hit a race condition: either the pool was shut down or the load balancing
+                    // timeout expired and marked the connection as non-poolable while we were
+                    // processing within this lock. Put it in stasis so the root transaction isn't
+                    // orphaned with no means to promote itself to a full delegated transaction or
+                    // to Commit/Rollback.
+                    connection.SetInStasis();
+                    rootTxn = true;
+                }
+                else
+                {
+                    destroyConnection = true;
+                }
+            }
+
+            if (returnToGeneralPool)
+            {
+                Debug.Assert(!destroyConnection, "Connection cannot both be pooled and destroyed.");
+                PutConnectionInIdleChannel(connection);
+            }
+            else if (destroyConnection)
+            {
+                RemoveConnection(connection);
+            }
+
+            // Ensure the connection was processed by exactly one of the paths above.
+            Debug.Assert(rootTxn || returnToGeneralPool || destroyConnection,
+                "Returned connection was neither pooled, destroyed, nor placed in stasis.");
+        }
+
+        /// <summary>
+        /// Places a connection that is fit for general reuse into the idle channel, stamping its
+        /// idle-return time and dropping it if it is no longer live.
+        /// </summary>
+        /// <param name="connection">The connection to make available to other callers.</param>
+        private void PutConnectionInIdleChannel(DbConnectionInternal connection)
+        {
             // Stamp the return time before IsLiveConnection runs so the idle-expiry gate inside it
             // measures time-in-pool, not time-since-last-return. Without this, a connection whose
             // checkout exceeded IdleTimeout (e.g. a long-running query) would be wrongly evicted on
@@ -440,26 +585,11 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 return;
             }
 
-            SqlClientEventSource.Log.TryPoolerTraceEvent(
-                "<prov.DbConnectionPool.DeactivateObject|RES|CPOOL> {0}, Connection {1}, Deactivating.",
-                Id,
-                connection.ObjectID);
-            connection.DeactivateConnection();
-
-            if (connection.IsConnectionDoomed ||
-                !connection.CanBePooled ||
-                State == ShuttingDown)
+            if (!_idleChannel.TryWrite(connection))
             {
+                // The channel has been completed (pool is shutting down). Race window
+                // between the State check by the caller and TryWrite: destroy instead of pooling.
                 RemoveConnection(connection);
-            }
-            else
-            {
-                if (!_idleChannel.TryWrite(connection))
-                {
-                    // The channel has been completed (pool is shutting down). Race window
-                    // between the State check above and TryWrite: destroy instead of pooling.
-                    RemoveConnection(connection);
-                }
             }
         }
 
@@ -614,7 +744,21 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         /// <inheritdoc />
         public void TransactionEnded(Transaction transaction, DbConnectionInternal transactedObject)
         {
-            throw new NotImplementedException();
+            Debug.Assert(transaction is not null, "null transaction?");
+            Debug.Assert(transactedObject is not null, "null transactedObject?");
+
+            // Note: the connection may still be associated with the transaction due to the explicit
+            // unbinding requirement.
+            SqlClientEventSource.Log.TryPoolerTraceEvent(
+                "<prov.DbConnectionPool.TransactionEnded|RES|CPOOL> {0}, Transaction {1}, Connection {2}, Transaction Completed",
+                Id,
+                transaction.GetHashCode(),
+                transactedObject.ObjectID);
+
+            // If the connection is in the transacted pool, remove it there and return it to general
+            // circulation. TransactedConnectionPool.TransactionEnded calls back into
+            // PutObjectFromTransactedPool for us once it has removed the connection from its list.
+            TransactedConnectionPool.TransactionEnded(transaction, transactedObject);
         }
 
         /// <inheritdoc />
@@ -682,7 +826,8 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 // We're potentially on a new thread, so we need to properly set the ambient transaction.
                 // We rely on the caller to capture the ambient transaction in the TaskCompletionSource's AsyncState
                 // so that we can access it here. Read: area for improvement.
-                // TODO: ADP.SetCurrentTransaction(taskCompletionSource.Task.AsyncState as Transaction);
+                ADP.SetCurrentTransaction(taskCompletionSource.Task.AsyncState as Transaction);
+
                 DbConnectionInternal? connection = null;
 
                 try
@@ -949,6 +1094,19 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         /// <param name="connection">The connection to be closed.</param>
         private void RemoveConnection(DbConnectionInternal connection)
         {
+            // A connection with a delegated transaction cannot be disposed of until the delegated
+            // transaction has actually completed; disposing it would abort the (possibly
+            // distributed) transaction. Leave it alone: when the transaction completes it comes
+            // back through PutObjectFromTransactedPool, which calls us again.
+            if (connection.IsTxRootWaitingForTxEnd)
+            {
+                SqlClientEventSource.Log.TryPoolerTraceEvent(
+                    "<prov.DbConnectionPool.DestroyObject|RES|CPOOL> {0}, Connection {1}, Has Delegated Transaction, waiting to Dispose.",
+                    Id,
+                    connection.ObjectID);
+                return;
+            }
+
             _connectionSlots.TryRemove(connection);
 
             // Removing a connection from the pool opens a free slot.
@@ -1018,14 +1176,26 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             TimeoutTimer timeout)
         {
             DbConnectionInternal? connection = null;
+            Transaction? transaction = null;
+
+            // If automatic transaction enlistment is enabled, we first try to get a connection that
+            // is already enlisted in the ambient transaction. If enlistment is not enabled we cannot
+            // vend connections from the transacted pool.
+            if (HasTransactionAffinity)
+            {
+                connection = GetFromTransactedPool(out transaction);
+            }
 
             // Derive a CancellationTokenSource from the TimeoutTimer so pool-internal wait operations
             // (channel reads, semaphore waits) are cancelled when the overall budget expires.
             using CancellationTokenSource cancellationTokenSource = timeout.CreateCancellationTokenSource();
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            // Continue looping until we create or retrieve a connection
-            do
+            // Continue looping until we create or retrieve a connection. A connection vended from
+            // the transacted pool skips this loop entirely: it has already been liveness-checked and
+            // is exempt from the idle/generation gates, because closing it would abort its
+            // (possibly distributed) transaction.
+            while (connection is null)
             {
                 try
                 {
@@ -1070,9 +1240,8 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                     connection = null;
                 }
             }
-            while (connection is null);
 
-            PrepareConnection(owningConnection, connection);
+            PrepareConnection(owningConnection, connection, transaction);
             return connection;
         }
 
@@ -1139,6 +1308,68 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 ReturnInternalConnection(connection, owningObject);
                 throw;
             }
+        }
+
+        /// <summary>
+        /// Attempts to retrieve a connection that is already enlisted in the ambient transaction.
+        /// </summary>
+        /// <param name="transaction">Receives the ambient transaction, or null when there is none.
+        /// The caller must enlist whatever connection it ends up using in this transaction, even
+        /// when no transacted connection was available.</param>
+        /// <returns>A live connection already enlisted in the ambient transaction, or null.</returns>
+        private DbConnectionInternal? GetFromTransactedPool(out Transaction? transaction)
+        {
+            transaction = ADP.GetCurrentTransaction();
+            if (transaction is null)
+            {
+                return null;
+            }
+
+            DbConnectionInternal? connection = TransactedConnectionPool.GetTransactedObject(transaction);
+            if (connection is null)
+            {
+                return null;
+            }
+
+            SqlClientEventSource.Log.TryPoolerTraceEvent(
+                "<prov.DbConnectionPool.GetFromTransactedPool|RES|CPOOL> {0}, Connection {1}, Popped from transacted pool.",
+                Id,
+                connection.ObjectID);
+
+            SqlClientDiagnostics.Metrics.ExitFreeConnection();
+
+            // Transacting connections are exempt from idle-timeout and clear-generation eviction
+            // (closing them would abort the transaction, which may be distributed), so only
+            // liveness is checked here rather than the full IsLiveConnection gate.
+            if (connection.IsTransactionRoot)
+            {
+                try
+                {
+                    // A dead transaction root must surface the underlying failure to the caller:
+                    // there is no way to recover the delegated transaction on another connection.
+                    connection.IsConnectionAlive(throwOnException: true);
+                }
+                catch
+                {
+                    SqlClientEventSource.Log.TryPoolerTraceEvent(
+                        "<prov.DbConnectionPool.GetFromTransactedPool|RES|CPOOL> {0}, Connection {1}, found dead and removed.",
+                        Id,
+                        connection.ObjectID);
+                    RemoveConnection(connection);
+                    throw;
+                }
+            }
+            else if (!connection.IsConnectionAlive())
+            {
+                SqlClientEventSource.Log.TryPoolerTraceEvent(
+                    "<prov.DbConnectionPool.GetFromTransactedPool|RES|CPOOL> {0}, Connection {1}, found dead and removed.",
+                    Id,
+                    connection.ObjectID);
+                RemoveConnection(connection);
+                connection = null;
+            }
+
+            return connection;
         }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
@@ -322,8 +322,6 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         /// <inheritdoc />
         public void PutObjectFromTransactedPool(DbConnectionInternal connection)
         {
-            Debug.Assert(connection is not null,
-                "PutObjectFromTransactedPool was called with a null connection.");
             Debug.Assert(connection.EnlistedTransaction is null,
                 "PutObjectFromTransactedPool was called with a connection that is still enlisted. " +
                 "The transaction must have ended and been detached before the connection returns to " +
@@ -752,9 +750,6 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         /// <inheritdoc />
         public void TransactionEnded(Transaction transaction, DbConnectionInternal transactedObject)
         {
-            Debug.Assert(transaction is not null, "null transaction?");
-            Debug.Assert(transactedObject is not null, "null transactedObject?");
-
             // Note: the connection may still be associated with the transaction due to the explicit
             // unbinding requirement.
             SqlClientEventSource.Log.TryPoolerTraceEvent(

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
@@ -322,8 +322,12 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         /// <inheritdoc />
         public void PutObjectFromTransactedPool(DbConnectionInternal connection)
         {
-            Debug.Assert(connection is not null, "null connection?");
-            Debug.Assert(connection.EnlistedTransaction is null, "connection is still enlisted?");
+            Debug.Assert(connection is not null,
+                "PutObjectFromTransactedPool was called with a null connection.");
+            Debug.Assert(connection.EnlistedTransaction is null,
+                "PutObjectFromTransactedPool was called with a connection that is still enlisted. " +
+                "The transaction must have ended and been detached before the connection returns to " +
+                "general circulation, otherwise it could be vended to a caller in a different transaction.");
 
             // Called by the transacted connection pool once it has removed the connection from its
             // list. We put the connection back into general circulation.
@@ -474,90 +478,110 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 return;
             }
 
-            bool returnToGeneralPool = false;
-            bool destroyConnection = false;
-            bool rootTxn = false;
-
-            // A connection with a delegated transaction cannot be handed to a different customer
-            // until the transaction actually completes, so we send it into stasis -- the
-            // System.Transactions transaction object keeps it owned (not lost) and is certain to
-            // put it back into the pool. The decision is made under the connection lock so that a
-            // transaction completing asynchronously on another thread cannot race with us.
+            // The disposition is decided while holding the connection's lock so that a transaction
+            // completing asynchronously on another thread cannot race with us, but the resulting
+            // I/O is performed outside of it.
+            ReturnDisposition disposition;
             lock (connection)
             {
-                if (State is ShuttingDown)
-                {
-                    if (connection.IsTransactionRoot)
-                    {
-                        // Connections affiliated with a root transaction that happen to live in a
-                        // pool being shut down must be put in stasis so the root transaction isn't
-                        // orphaned with no means to promote itself to a full delegated transaction
-                        // or to Commit/Rollback.
-                        connection.SetInStasis();
-                        rootTxn = true;
-                    }
-                    else
-                    {
-                        destroyConnection = true;
-                    }
-                }
-                else if (connection.IsTransactionRoot && connection.Pool is null)
-                {
-                    connection.SetInStasis();
-                    rootTxn = true;
-                }
-                else if (connection.CanBePooled)
-                {
-                    Transaction? transaction = connection.EnlistedTransaction;
-                    if (transaction is not null)
-                    {
-                        // NOTE: we're not locking on State, so its value could change between the
-                        // conditional check above and here. Although perhaps not ideal, this is OK
-                        // because the DelegatedTransactionEnded event will clean up the connection
-                        // appropriately regardless of the pool state.
-                        //
-                        // Transacting connections are held in their own store and are never
-                        // proactively closed (doing so would abort the transaction, which can be
-                        // distributed). Idle-timeout enforcement does not apply here, so we do not
-                        // stamp the returned time when parking the connection in the transacted pool.
-                        TransactedConnectionPool.PutTransactedObject(transaction, connection);
-                        rootTxn = true;
-                    }
-                    else
-                    {
-                        returnToGeneralPool = true;
-                    }
-                }
-                else if (connection.IsTransactionRoot)
-                {
-                    // The connection cannot be pooled but is a transaction root, so we must have
-                    // hit a race condition: either the pool was shut down or the load balancing
-                    // timeout expired and marked the connection as non-poolable while we were
-                    // processing within this lock. Put it in stasis so the root transaction isn't
-                    // orphaned with no means to promote itself to a full delegated transaction or
-                    // to Commit/Rollback.
-                    connection.SetInStasis();
-                    rootTxn = true;
-                }
-                else
-                {
-                    destroyConnection = true;
-                }
+                disposition = DecideReturnDisposition(connection);
             }
 
-            if (returnToGeneralPool)
+            switch (disposition)
             {
-                Debug.Assert(!destroyConnection, "Connection cannot both be pooled and destroyed.");
-                PutConnectionInIdleChannel(connection);
+                case ReturnDisposition.Reuse:
+                    PutConnectionInIdleChannel(connection);
+                    break;
+
+                case ReturnDisposition.Destroy:
+                    RemoveConnection(connection);
+                    break;
+
+                case ReturnDisposition.HeldByTransaction:
+                    // Nothing further to do. The connection is parked in the transacted store or
+                    // in stasis, and comes back through PutObjectFromTransactedPool once its
+                    // transaction ends.
+                    break;
             }
-            else if (destroyConnection)
+        }
+
+        /// <summary>
+        /// Decides what should happen to a returning connection that has already been deactivated
+        /// and is not doomed. Must be called while holding the connection's lock: parking a
+        /// connection in the transacted store has to be atomic with respect to a transaction
+        /// completing on another thread.
+        /// </summary>
+        /// <param name="connection">The connection being returned.</param>
+        /// <returns>The action the caller must take for this connection.</returns>
+        private ReturnDisposition DecideReturnDisposition(DbConnectionInternal connection)
+        {
+            // A connection is only fit to go back into circulation if the pool is still running,
+            // the connection itself is still poolable, and it isn't a transaction root that has
+            // already been detached from its pool.
+            bool isReusable =
+                State is Running &&
+                connection.CanBePooled &&
+                !(connection.IsTransactionRoot && connection.Pool is null);
+
+            if (!isReusable)
             {
-                RemoveConnection(connection);
+                // A transaction root that cannot be pooled must be put in stasis rather than
+                // closed. Closing it would orphan the root transaction with no means to promote
+                // itself to a full delegated transaction, or to commit or roll back.
+                // System.Transactions keeps the connection owned (not lost) and is certain to
+                // hand it back to us when the transaction ends.
+                if (connection.IsTransactionRoot)
+                {
+                    connection.SetInStasis();
+                    return ReturnDisposition.HeldByTransaction;
+                }
+
+                return ReturnDisposition.Destroy;
             }
 
-            // Ensure the connection was processed by exactly one of the paths above.
-            Debug.Assert(rootTxn || returnToGeneralPool || destroyConnection,
-                "Returned connection was neither pooled, destroyed, nor placed in stasis.");
+            // A connection that is still enlisted cannot be handed to a different customer until
+            // its transaction actually completes, so it is parked in the transacted store keyed by
+            // that transaction and comes back via PutObjectFromTransactedPool when it ends.
+            //
+            // NOTE: we do not hold a lock on State, so its value could have changed since the
+            // check above. That is acceptable because the DelegatedTransactionEnded event cleans
+            // the connection up appropriately regardless of the pool state.
+            //
+            // Transacted connections are deliberately not stamped with a returned time: they are
+            // never proactively closed (doing so would abort a possibly distributed transaction),
+            // so idle-timeout enforcement does not apply while they are parked. They are stamped
+            // when they rejoin the idle channel in PutObjectFromTransactedPool.
+            Transaction? transaction = connection.EnlistedTransaction;
+            if (transaction is not null)
+            {
+                TransactedConnectionPool.PutTransactedObject(transaction, connection);
+                return ReturnDisposition.HeldByTransaction;
+            }
+
+            return ReturnDisposition.Reuse;
+        }
+
+        /// <summary>
+        /// The outcome of evaluating a connection that is being returned to the pool.
+        /// </summary>
+        private enum ReturnDisposition
+        {
+            /// <summary>
+            /// The connection is fit for general reuse and belongs in the idle channel.
+            /// </summary>
+            Reuse,
+
+            /// <summary>
+            /// The connection cannot be reused and must be closed.
+            /// </summary>
+            Destroy,
+
+            /// <summary>
+            /// The connection is owned by a live transaction, either parked in the transacted
+            /// store or held in stasis, and must not be touched by the pool until that
+            /// transaction ends.
+            /// </summary>
+            HeldByTransaction,
         }
 
         /// <summary>
@@ -573,6 +597,13 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             // return even though it was actively in use on the wire. The same gating conditions are
             // applied here as in IsLiveConnection so we avoid the per-return timestamp read when
             // idle expiry is disabled or the legacy idle-timeout behavior is in effect.
+            //
+            // A connection parked in the transacted store does not pass through here, so it is not
+            // subject to idle timeout for as long as its transaction is live. That is intentional
+            // and matches WaitHandleDbConnectionPool: closing it would abort a possibly distributed
+            // transaction. It is stamped here when the transaction ends and
+            // PutObjectFromTransactedPool returns it to general circulation, so the idle clock
+            // starts from the moment it actually becomes available to other callers.
             if (!LocalAppContextSwitches.UseLegacyIdleTimeoutBehavior &&
                 PoolGroupOptions.IdleTimeout != TimeSpan.Zero)
             {
@@ -1202,24 +1233,35 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             // string's Enlist keyword.
             Transaction? transaction = HasTransactionAffinity ? ambientTransaction : null;
 
-            if (transaction is not null)
-            {
-                connection = GetFromTransactedPool(transaction);
-            }
-
             // Derive a CancellationTokenSource from the TimeoutTimer so pool-internal wait operations
             // (channel reads, semaphore waits) are cancelled when the overall budget expires.
             using CancellationTokenSource cancellationTokenSource = timeout.CreateCancellationTokenSource();
             CancellationToken cancellationToken = cancellationTokenSource.Token;
 
-            // Continue looping until we create or retrieve a connection. A connection vended from
-            // the transacted pool skips this loop entirely: it has already been liveness-checked and
-            // is exempt from the idle/generation gates, because closing it would abort its
-            // (possibly distributed) transaction.
+            // Continue looping until we create or retrieve a connection.
             while (connection is null)
             {
                 try
                 {
+                    // A connection already enlisted in our transaction is always preferred, since
+                    // reusing it avoids promoting the transaction to a distributed one. This is
+                    // re-checked on every iteration so that a connection returned to the transacted
+                    // store while we were looping is picked up rather than being passed over in
+                    // favor of a fresh connection.
+                    if (transaction is not null)
+                    {
+                        connection = GetFromTransactedPool(transaction);
+                        if (connection is not null)
+                        {
+                            // Skip the liveness/idle/generation gate at the bottom of the loop:
+                            // GetFromTransactedPool has already probed liveness, and a transacted
+                            // connection is exempt from idle-timeout, load-balance and
+                            // clear-generation eviction because closing it would abort its
+                            // (possibly distributed) transaction.
+                            break;
+                        }
+                    }
+
                     // Optimistically try to get an idle connection from the channel
                     // Doesn't wait if the channel is empty, just returns null.
                     connection ??= GetIdleConnection();

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
@@ -478,13 +478,46 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 return;
             }
 
-            // The disposition is decided while holding the connection's lock so that a transaction
-            // completing asynchronously on another thread cannot race with us, but the resulting
-            // I/O is performed outside of it.
+            // Note: this logic mirrors WaitHandleDbConnectionPool.ReturnObject
             ReturnDisposition disposition;
             lock (connection)
             {
-                disposition = DecideReturnDisposition(connection);
+                if (State is not Running || !connection.CanBePooled)
+                {
+                    // A transaction root that cannot be pooled must be put in stasis rather than
+                    // closed. Closing it would orphan the root transaction with no means to promote
+                    // itself to a full delegated transaction, or to commit or roll back.
+                    // System.Transactions keeps the connection owned (not lost) and is certain to
+                    // call the appropriate callback when the transaction ends.
+                    if (connection.IsTransactionRoot)
+                    {
+                        connection.SetInStasis();
+                        disposition = ReturnDisposition.HeldByTransaction;
+                    }
+                    else
+                    {
+                        disposition = ReturnDisposition.Destroy;
+                    }
+                }
+                else if (connection.EnlistedTransaction is { } transaction)
+                {
+                    // A connection that is still enlisted cannot be handed to a different customer
+                    // until its transaction actually completes, so it is parked in the transacted
+                    // store keyed by that transaction and comes back via
+                    // PutObjectFromTransactedPool when it ends.
+                    //
+                    // Transacted connections are deliberately not stamped with a returned time:
+                    // they are never proactively closed (doing so would abort a possibly
+                    // distributed transaction), so idle-timeout enforcement does not apply while
+                    // they are parked. They are stamped when they rejoin the idle channel in
+                    // PutObjectFromTransactedPool.
+                    TransactedConnectionPool.PutTransactedObject(transaction, connection);
+                    disposition = ReturnDisposition.HeldByTransaction;
+                }
+                else
+                {
+                    disposition = ReturnDisposition.Reuse;
+                }
             }
 
             switch (disposition)
@@ -503,62 +536,6 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                     // transaction ends.
                     break;
             }
-        }
-
-        /// <summary>
-        /// Decides what should happen to a returning connection that has already been deactivated
-        /// and is not doomed. Must be called while holding the connection's lock: parking a
-        /// connection in the transacted store has to be atomic with respect to a transaction
-        /// completing on another thread.
-        /// </summary>
-        /// <param name="connection">The connection being returned.</param>
-        /// <returns>The action the caller must take for this connection.</returns>
-        private ReturnDisposition DecideReturnDisposition(DbConnectionInternal connection)
-        {
-            // A connection is only fit to go back into circulation if the pool is still running,
-            // the connection itself is still poolable, and it isn't a transaction root that has
-            // already been detached from its pool.
-            bool isReusable =
-                State is Running &&
-                connection.CanBePooled &&
-                !(connection.IsTransactionRoot && connection.Pool is null);
-
-            if (!isReusable)
-            {
-                // A transaction root that cannot be pooled must be put in stasis rather than
-                // closed. Closing it would orphan the root transaction with no means to promote
-                // itself to a full delegated transaction, or to commit or roll back.
-                // System.Transactions keeps the connection owned (not lost) and is certain to
-                // hand it back to us when the transaction ends.
-                if (connection.IsTransactionRoot)
-                {
-                    connection.SetInStasis();
-                    return ReturnDisposition.HeldByTransaction;
-                }
-
-                return ReturnDisposition.Destroy;
-            }
-
-            // A connection that is still enlisted cannot be handed to a different customer until
-            // its transaction actually completes, so it is parked in the transacted store keyed by
-            // that transaction and comes back via PutObjectFromTransactedPool when it ends.
-            //
-            // NOTE: we do not hold a lock on State, so its value could have changed since the
-            // check above. That is acceptable because the DelegatedTransactionEnded event cleans
-            // the connection up appropriately regardless of the pool state.
-            //
-            // Transacted connections are deliberately not stamped with a returned time: they are
-            // never proactively closed (doing so would abort a possibly distributed transaction),
-            // so idle-timeout enforcement does not apply while they are parked. They are stamped
-            // when they rejoin the idle channel in PutObjectFromTransactedPool.
-            Transaction? transaction = connection.EnlistedTransaction;
-            if (transaction is not null)
-            {
-                TransactedConnectionPool.PutTransactedObject(transaction, connection);
-                return ReturnDisposition.HeldByTransaction;
-            }
-
-            return ReturnDisposition.Reuse;
         }
 
         /// <summary>
@@ -1396,32 +1373,26 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             // Transacting connections are exempt from idle-timeout and clear-generation eviction
             // (closing them would abort the transaction, which may be distributed), so only
             // liveness is checked here rather than the full IsLiveConnection gate.
-            if (connection.IsTransactionRoot)
+            bool isAlive = false;
+            try
             {
-                try
-                {
-                    // A dead transaction root must surface the underlying failure to the caller:
-                    // there is no way to recover the delegated transaction on another connection.
-                    connection.IsConnectionAlive(throwOnException: true);
-                }
-                catch
+                // A dead transaction root must surface the underlying failure to the caller, since
+                // there is no way to recover the delegated transaction on another connection. Any
+                // other dead connection is simply reported so the caller can pick up or open a
+                // different one. Either way the connection is dropped in the finally below.
+                isAlive = connection.IsConnectionAlive(throwOnException: connection.IsTransactionRoot);
+            }
+            finally
+            {
+                if (!isAlive)
                 {
                     SqlClientEventSource.Log.TryPoolerTraceEvent(
                         "<prov.DbConnectionPool.GetFromTransactedPool|RES|CPOOL> {0}, Connection {1}, found dead and removed.",
                         Id,
                         connection.ObjectID);
                     RemoveConnection(connection);
-                    throw;
+                    connection = null;
                 }
-            }
-            else if (!connection.IsConnectionAlive())
-            {
-                SqlClientEventSource.Log.TryPoolerTraceEvent(
-                    "<prov.DbConnectionPool.GetFromTransactedPool|RES|CPOOL> {0}, Connection {1}, found dead and removed.",
-                    Id,
-                    connection.ObjectID);
-                RemoveConnection(connection);
-                connection = null;
             }
 
             return connection;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
@@ -252,10 +252,13 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         private int MinPoolSize => PoolGroupOptions.MinPoolSize;
 
         /// <summary>
-        /// Indicates whether connections may be vended from (and parked in) the
-        /// <see cref="TransactedConnectionPool"/>. This mirrors automatic transaction enlistment:
-        /// when enlistment is disabled a connection is never bound to an ambient transaction, so
-        /// the transacted store must not be consulted.
+        /// Indicates whether the pool automatically enlists connections in the ambient transaction.
+        /// When disabled, the ambient transaction is neither used to consult the
+        /// <see cref="TransactedConnectionPool"/> nor handed to activation.
+        ///
+        /// This governs the ambient transaction only. A caller may still enlist explicitly via
+        /// SqlConnection.EnlistTransaction, and such a connection is parked in the transacted store
+        /// on return regardless of this flag, since it is bound to a transaction either way.
         /// </summary>
         private bool HasTransactionAffinity => PoolGroupOptions.HasTransactionAffinity;
 
@@ -333,18 +336,23 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             // NOTE: no locking is required here because if we're in this method we can safely
             // presume that the caller is the only one using the connection, that all pre-push logic
             // has been done, and that all transactions have ended.
-            SqlClientEventSource.Log.TryPoolerTraceEvent(
-                "<prov.DbConnectionPool.PutObjectFromTransactedPool|RES|CPOOL> {0}, Connection {1}, Transaction has ended.",
-                Id,
-                connection.ObjectID);
-
             if (State is Running && connection.CanBePooled)
             {
+                SqlClientEventSource.Log.TryPoolerTraceEvent(
+                    "<prov.DbConnectionPool.PutObjectFromTransactedPool|RES|CPOOL> {0}, Connection {1}, Transaction has ended; returning connection to pool.",
+                    Id,
+                    connection.ObjectID);
+
                 connection.ResetConnection();
                 PutConnectionInIdleChannel(connection);
             }
             else
             {
+                SqlClientEventSource.Log.TryPoolerTraceEvent(
+                    "<prov.DbConnectionPool.PutObjectFromTransactedPool|RES|CPOOL> {0}, Connection {1}, Transaction has ended; destroying unpoolable connection.",
+                    Id,
+                    connection.ObjectID);
+
                 // RemoveConnection triggers replenishment, which is the channel pool's equivalent
                 // of the wait handle pool's QueuePoolCreateRequest.
                 RemoveConnection(connection);
@@ -758,9 +766,17 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 transaction.GetHashCode(),
                 transactedObject.ObjectID);
 
-            // If the connection is in the transacted pool, remove it there and return it to general
-            // circulation. TransactedConnectionPool.TransactionEnded calls back into
-            // PutObjectFromTransactedPool for us once it has removed the connection from its list.
+            // Removal from the transacted list happens synchronously inside this call, and
+            // TransactedConnectionPool.TransactionEnded calls back into PutObjectFromTransactedPool
+            // itself to return the connection to general circulation.
+            //
+            // We deliberately do not call PutObjectFromTransactedPool ourselves afterwards: that
+            // callback is conditional on the connection actually having been found in the list.
+            // A transaction can complete while the application still holds the connection, in which
+            // case the connection was never parked, and returning it here would hand a connection
+            // that is still in use to another caller. In that case the connection instead reaches
+            // the pool through the normal ReturnInternalConnection path when it is closed.
+            // This mirrors WaitHandleDbConnectionPool.TransactionEnded.
             TransactedConnectionPool.TransactionEnded(transaction, transactedObject);
         }
 
@@ -1368,8 +1384,9 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             }
 
             SqlClientEventSource.Log.TryPoolerTraceEvent(
-                "<prov.DbConnectionPool.GetFromTransactedPool|RES|CPOOL> {0}, Connection {1}, Popped from transacted pool.",
+                "<prov.DbConnectionPool.GetFromTransactedPool|RES|CPOOL> {0}, Transaction {1}, Connection {2}, Popped from transacted pool.",
                 Id,
+                transaction.GetHashCode(),
                 connection.ObjectID);
 
             SqlClientDiagnostics.Metrics.ExitFreeConnection();

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
@@ -377,6 +377,12 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 // Carry the old connection's enlistment over to the replacement so that a connection
                 // replaced mid-transaction stays bound to the same transaction.
                 PrepareConnection(owningObject, newConnection, oldConnection.EnlistedTransaction);
+
+                // newConnection came from the idle channel, so it already holds a slot of its own.
+                // Releasing oldConnection's slot here keeps the pool's count accurate. This is
+                // deliberately different from the create-new branch below, which hands oldConnection's
+                // slot to the replacement via _connectionSlots.TryReplace and therefore only disposes
+                // it -- calling RemoveConnection there would signal a free slot that does not exist.
                 oldConnection.DeactivateConnection();
                 RemoveConnection(oldConnection);
             }
@@ -472,9 +478,13 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 Id,
                 connection.ObjectID);
 
-            // Deactivate before inspecting the connection's transaction state. Deactivation is what
-            // detaches a completed transaction, so reading EnlistedTransaction beforehand could park
-            // a connection in the transacted pool under a transaction that has already ended.
+            // Deactivate before inspecting the connection, because DeactivateConnection mutates both
+            // of the gates we branch on below:
+            //  - Deactivate() dooms the connection when async commands are still outstanding, which
+            //    the IsConnectionDoomed check must observe.
+            //  - DeactivateConnection dooms it via DoNotPoolThisConnection when the load-balance
+            //    timeout has elapsed, which the CanBePooled check must observe.
+            // WaitHandleDbConnectionPool.DeactivateObject orders it the same way.
             connection.DeactivateConnection();
 
             if (connection.IsConnectionDoomed)
@@ -484,7 +494,12 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 return;
             }
 
-            // Note: this logic mirrors WaitHandleDbConnectionPool.ReturnObject
+            // Note: this logic mirrors WaitHandleDbConnectionPool.ReturnObject, minus one dead
+            // branch. Its Running path also checks IsTransactionRoot && Pool == null -> SetInStasis,
+            // under its own "how did we get here if the pool is null?" TODO. A connection cannot
+            // arrive here without a pool, because this method is called through the connection's own
+            // Pool reference. The branch is redundant in any case: putting a transaction root in
+            // stasis is exactly what the first case below does when the connection cannot be pooled.
             ReturnDisposition disposition;
             lock (connection)
             {
@@ -837,10 +852,11 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             // OpenAsync call. This means that we cannot cancel the connection open operation if the caller's token
             // is cancelled. We can only cancel based on our own timeout, which is set to the owningObject's
             // ConnectionTimeout.
+            //
             // The ambient transaction is captured by the caller, on the caller's thread, and handed
             // to us in the TaskCompletionSource's AsyncState (see SqlConnection.InternalOpenAsync).
             //
-            // We must not read Transaction.Current inside the Task.Run below instead. A
+            // We must not read Transaction.Current inside the Task.Run below. A
             // TransactionScope created with TransactionScopeAsyncFlowOption.Enabled stores the
             // transaction in an AsyncLocal, which does flow onto the pool's worker thread, so that
             // would appear to work. But Enabled is not the default: a plain TransactionScope keeps

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
@@ -784,10 +784,12 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             // If taskCompletionSource is null, we are in a sync context.
             if (taskCompletionSource is null)
             {
+                // We're on the caller's thread, so the ambient transaction is directly observable.
                 var task = GetInternalConnection(
                         owningObject,
                         async: false,
-                        timeout);
+                        timeout,
+                        ADP.GetCurrentTransaction());
 
                 // When running synchronously, we are guaranteed that the task is already completed.
                 // We don't need to guard the managed threadpool at this spot because we pass the async flag as false
@@ -816,17 +818,28 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             // OpenAsync call. This means that we cannot cancel the connection open operation if the caller's token
             // is cancelled. We can only cancel based on our own timeout, which is set to the owningObject's
             // ConnectionTimeout.
+            // The ambient transaction is captured here, on the caller's thread, because
+            // Transaction.Current does not flow into the Task.Run below: a TransactionScope keeps
+            // the ambient transaction in thread-static storage unless it was created with
+            // TransactionScopeAsyncFlowOption.Enabled. We rely on the caller to capture the ambient
+            // transaction in the TaskCompletionSource's AsyncState, and then hand it to
+            // GetInternalConnection explicitly.
+            //
+            // Note that we deliberately do not assign Transaction.Current on the thread pool
+            // thread. That assignment writes to thread-static storage which is *not* unwound when
+            // the ExecutionContext is restored, so it would outlive this open and be observed by
+            // unrelated work later scheduled onto the same thread pool thread -- including the
+            // login-time auto-enlistment that non-pooled connections perform against
+            // Transaction.Current. The WaitHandle pool can get away with assigning it because it
+            // processes pending opens on a dedicated non-thread-pool thread.
+            Transaction? ambientTransaction = taskCompletionSource.Task.AsyncState as Transaction;
+
             Task.Run(async () =>
             {
                 if (taskCompletionSource.Task.IsCompleted)
                 {
                     return;
                 }
-
-                // We're potentially on a new thread, so we need to properly set the ambient transaction.
-                // We rely on the caller to capture the ambient transaction in the TaskCompletionSource's AsyncState
-                // so that we can access it here. Read: area for improvement.
-                ADP.SetCurrentTransaction(taskCompletionSource.Task.AsyncState as Transaction);
 
                 DbConnectionInternal? connection = null;
 
@@ -835,7 +848,8 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                     connection = await GetInternalConnection(
                         owningObject,
                         async: true,
-                        timeout
+                        timeout,
+                        ambientTransaction
                     ).ConfigureAwait(false);
 
                     if (!taskCompletionSource.TrySetResult(connection))
@@ -1161,6 +1175,10 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         /// <param name="async">A boolean indicating whether the operation should be asynchronous.</param>
         /// <param name="timeout">The overall timeout budget for this connection request. Time spent waiting
         /// in the pool is deducted from the budget available for physical connection creation.</param>
+        /// <param name="ambientTransaction">The ambient transaction captured on the caller's thread, or
+        /// null when the caller is not inside a transaction. It is passed explicitly rather than read
+        /// from <see cref="Transaction.Current"/> because this method may run on a thread pool thread
+        /// that the ambient transaction does not flow to.</param>
         /// <returns>Returns a DbConnectionInternal that is retrieved from the pool.</returns>
         /// <exception cref="InvalidOperationException">
         /// Thrown when an OperationCanceledException is caught, indicating that the timeout period
@@ -1173,17 +1191,20 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         private async Task<DbConnectionInternal> GetInternalConnection(
             DbConnection owningConnection,
             bool async,
-            TimeoutTimer timeout)
+            TimeoutTimer timeout,
+            Transaction? ambientTransaction)
         {
             DbConnectionInternal? connection = null;
-            Transaction? transaction = null;
 
-            // If automatic transaction enlistment is enabled, we first try to get a connection that
-            // is already enlisted in the ambient transaction. If enlistment is not enabled we cannot
-            // vend connections from the transacted pool.
-            if (HasTransactionAffinity)
+            // When automatic enlistment is disabled, the connection must never be bound to the
+            // ambient transaction, so we neither consult the transacted store nor hand the
+            // transaction to activation. HasTransactionAffinity is derived from the connection
+            // string's Enlist keyword.
+            Transaction? transaction = HasTransactionAffinity ? ambientTransaction : null;
+
+            if (transaction is not null)
             {
-                connection = GetFromTransactedPool(out transaction);
+                connection = GetFromTransactedPool(transaction);
             }
 
             // Derive a CancellationTokenSource from the TimeoutTimer so pool-internal wait operations
@@ -1311,20 +1332,12 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         }
 
         /// <summary>
-        /// Attempts to retrieve a connection that is already enlisted in the ambient transaction.
+        /// Attempts to retrieve a connection that is already enlisted in the given transaction.
         /// </summary>
-        /// <param name="transaction">Receives the ambient transaction, or null when there is none.
-        /// The caller must enlist whatever connection it ends up using in this transaction, even
-        /// when no transacted connection was available.</param>
-        /// <returns>A live connection already enlisted in the ambient transaction, or null.</returns>
-        private DbConnectionInternal? GetFromTransactedPool(out Transaction? transaction)
+        /// <param name="transaction">The transaction the connection must already be enlisted in.</param>
+        /// <returns>A live connection already enlisted in the transaction, or null.</returns>
+        private DbConnectionInternal? GetFromTransactedPool(Transaction transaction)
         {
-            transaction = ADP.GetCurrentTransaction();
-            if (transaction is null)
-            {
-                return null;
-            }
-
             DbConnectionInternal? connection = TransactedConnectionPool.GetTransactedObject(transaction);
             if (connection is null)
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
@@ -829,9 +829,13 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             // The ambient transaction is captured here, on the caller's thread, because
             // Transaction.Current does not flow into the Task.Run below: a TransactionScope keeps
             // the ambient transaction in thread-static storage unless it was created with
-            // TransactionScopeAsyncFlowOption.Enabled. We rely on the caller to capture the ambient
-            // transaction in the TaskCompletionSource's AsyncState, and then hand it to
-            // GetInternalConnection explicitly.
+            // TransactionScopeAsyncFlowOption.Enabled.
+            //
+            // The TaskCompletionSource's AsyncState takes priority: SqlConnection.OpenAsync
+            // captures the ambient transaction there at the point of the call, which stays correct
+            // even when a retry re-enters us from a continuation running on some other thread.
+            // We fall back to the caller's own ambient transaction so that this path behaves the
+            // same as the synchronous one for callers that don't supply the state.
             //
             // Note that we deliberately do not assign Transaction.Current on the thread pool
             // thread. That assignment writes to thread-static storage which is *not* unwound when
@@ -840,7 +844,8 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             // login-time auto-enlistment that non-pooled connections perform against
             // Transaction.Current. The WaitHandle pool can get away with assigning it because it
             // processes pending opens on a dedicated non-thread-pool thread.
-            Transaction? ambientTransaction = taskCompletionSource.Task.AsyncState as Transaction;
+            Transaction? ambientTransaction =
+                taskCompletionSource.Task.AsyncState as Transaction ?? ADP.GetCurrentTransaction();
 
             Task.Run(async () =>
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
@@ -823,11 +823,19 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             // ConnectionTimeout.
             // The ambient transaction is captured by the caller, on the caller's thread, and handed
             // to us in the TaskCompletionSource's AsyncState (see SqlConnection.InternalOpenAsync).
-            // We must not read Transaction.Current ourselves here: a TransactionScope keeps the
-            // ambient transaction in thread-static storage unless it was created with
-            // TransactionScopeAsyncFlowOption.Enabled, and on a retry we are re-entered from a
-            // continuation running on an arbitrary thread, so Transaction.Current at this point
-            // says nothing reliable about the caller's transaction.
+            //
+            // We must not read Transaction.Current inside the Task.Run below instead. A
+            // TransactionScope created with TransactionScopeAsyncFlowOption.Enabled stores the
+            // transaction in an AsyncLocal, which does flow onto the pool's worker thread, so that
+            // would appear to work. But Enabled is not the default: a plain TransactionScope keeps
+            // the transaction in thread-static storage, which does not flow, and reading
+            // Transaction.Current on the worker would silently fail to enlist. The WaitHandle pool
+            // enlists correctly in that case, so this is also a compatibility requirement.
+            // AsyncState is correct under both options.
+            //
+            // This does not make the suppressed-flow pattern work -- the caller's own scope is
+            // still broken past the first await -- but it keeps the connection in the transaction
+            // the caller intended rather than silently running outside it.
             //
             // Note that we deliberately do not assign Transaction.Current on the thread pool
             // thread either. That assignment writes to thread-static storage which is *not* unwound

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
@@ -826,26 +826,22 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             // OpenAsync call. This means that we cannot cancel the connection open operation if the caller's token
             // is cancelled. We can only cancel based on our own timeout, which is set to the owningObject's
             // ConnectionTimeout.
-            // The ambient transaction is captured here, on the caller's thread, because
-            // Transaction.Current does not flow into the Task.Run below: a TransactionScope keeps
-            // the ambient transaction in thread-static storage unless it was created with
-            // TransactionScopeAsyncFlowOption.Enabled.
-            //
-            // The TaskCompletionSource's AsyncState takes priority: SqlConnection.OpenAsync
-            // captures the ambient transaction there at the point of the call, which stays correct
-            // even when a retry re-enters us from a continuation running on some other thread.
-            // We fall back to the caller's own ambient transaction so that this path behaves the
-            // same as the synchronous one for callers that don't supply the state.
+            // The ambient transaction is captured by the caller, on the caller's thread, and handed
+            // to us in the TaskCompletionSource's AsyncState (see SqlConnection.InternalOpenAsync).
+            // We must not read Transaction.Current ourselves here: a TransactionScope keeps the
+            // ambient transaction in thread-static storage unless it was created with
+            // TransactionScopeAsyncFlowOption.Enabled, and on a retry we are re-entered from a
+            // continuation running on an arbitrary thread, so Transaction.Current at this point
+            // says nothing reliable about the caller's transaction.
             //
             // Note that we deliberately do not assign Transaction.Current on the thread pool
-            // thread. That assignment writes to thread-static storage which is *not* unwound when
-            // the ExecutionContext is restored, so it would outlive this open and be observed by
-            // unrelated work later scheduled onto the same thread pool thread -- including the
+            // thread either. That assignment writes to thread-static storage which is *not* unwound
+            // when the ExecutionContext is restored, so it would outlive this open and be observed
+            // by unrelated work later scheduled onto the same thread pool thread -- including the
             // login-time auto-enlistment that non-pooled connections perform against
             // Transaction.Current. The WaitHandle pool can get away with assigning it because it
             // processes pending opens on a dedicated non-thread-pool thread.
-            Transaction? ambientTransaction =
-                taskCompletionSource.Task.AsyncState as Transaction ?? ADP.GetCurrentTransaction();
+            Transaction? ambientTransaction = taskCompletionSource.Task.AsyncState as Transaction;
 
             Task.Run(async () =>
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
@@ -344,7 +344,18 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                     connection.ObjectID);
 
                 connection.ResetConnection();
-                PutConnectionInIdleChannel(connection);
+
+                // probeLiveness: false because we are running on the System.Transactions
+                // transaction-completion callback thread (see DbConnectionInternal
+                // .DelegatedTransactionEnded, whose contract requires the caller to hold a lock on
+                // the connection). DbConnectionInternal.IsConnectionAlive polls the socket, and we
+                // do not want to do socket work while holding that lock on a thread we do not own.
+                // WaitHandleDbConnectionPool does not probe here either; it simply calls
+                // ResetConnection followed by PutNewObject. The connection is still validated on
+                // its way back out of the idle channel, so a connection that died during the
+                // transaction is detected before it is vended. The idle-expiry, load-balance and
+                // clear-generation checks all still run below; only the socket poll is skipped.
+                PutConnectionInIdleChannel(connection, probeLiveness: false);
             }
             else
             {
@@ -384,6 +395,20 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 // slot to the replacement via _connectionSlots.TryReplace and therefore only disposes
                 // it -- calling RemoveConnection there would signal a free slot that does not exist.
                 oldConnection.DeactivateConnection();
+
+                // RemoveConnection early-returns without freeing the slot when the connection is a
+                // transaction root awaiting its transaction's end, which would leave the pool
+                // holding two reservations for one logical connection. That cannot happen here:
+                // IsTxRootWaitingForTxEnd is set only by SetInStasis, and the only path that puts a
+                // pooled connection in stasis is ReturnInternalConnection. oldConnection is checked
+                // out by owningObject at this point, so it has not been returned and cannot be in
+                // stasis. Being a transaction root is not sufficient; the connection must also have
+                // been returned. The slot is therefore always released here.
+                //
+                // If that ever changes, the outcome is a transient over-reservation rather than a
+                // leak: the connection comes back through PutObjectFromTransactedPool when its
+                // transaction ends, which calls RemoveConnection again once stasis has been
+                // terminated, and the slot is reclaimed then.
                 RemoveConnection(oldConnection);
             }
             else
@@ -587,7 +612,13 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         /// idle-return time and dropping it if it is no longer live.
         /// </summary>
         /// <param name="connection">The connection to make available to other callers.</param>
-        private void PutConnectionInIdleChannel(DbConnectionInternal connection)
+        /// <param name="probeLiveness">
+        /// Whether to poll the physical connection to confirm it is still alive. Pass false when
+        /// running on a thread that must not block, such as a System.Transactions completion
+        /// callback. The idle-expiry, load-balance timeout and clear-generation checks run
+        /// regardless; only the socket poll is suppressed.
+        /// </param>
+        private void PutConnectionInIdleChannel(DbConnectionInternal connection, bool probeLiveness = true)
         {
             // Stamp the return time before IsLiveConnection runs so the idle-expiry gate inside it
             // measures time-in-pool, not time-since-last-return. Without this, a connection whose
@@ -608,7 +639,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 connection.SetReturnedTime(_timeProvider.GetUtcNow().UtcDateTime);
             }
 
-            if (!IsLiveConnection(connection))
+            if (!IsLiveConnection(connection, probeLiveness))
             {
                 RemoveConnection(connection);
                 return;
@@ -1104,8 +1135,12 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         /// Checks that the provided connection is live and unexpired and closes it if needed.
         /// </summary>
         /// <param name="connection"></param>
+        /// <param name="probeLiveness">
+        /// Whether to poll the physical connection to confirm it is still alive. Pass false when
+        /// running on a thread that must not block; the remaining checks are all cheap and local.
+        /// </param>
         /// <returns>Returns true if the connection is live and unexpired, otherwise returns false.</returns>
-        private bool IsLiveConnection(DbConnectionInternal connection)
+        private bool IsLiveConnection(DbConnectionInternal connection, bool probeLiveness = true)
         {
             // Connection has been sitting idle longer than the configured idle timeout.
             // Checked before the (potentially expensive) liveness probe so an idle-expired
@@ -1125,8 +1160,9 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 return false;
             }
 
-            // Broken physical connection
-            if (!connection.IsConnectionAlive())
+            // Broken physical connection. Skipped when the caller cannot afford to block: this
+            // polls the socket, so it must not run on a thread we do not own.
+            if (probeLiveness && !connection.IsConnectionAlive())
             {
                 return false;
             }
@@ -1147,8 +1183,24 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         }
 
         /// <summary>
-        /// Closes the provided connection and removes it from the pool.
+        /// Closes the provided connection and removes it from the pool, freeing its slot.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Not guaranteed: a connection that is a transaction root awaiting its transaction's end
+        /// is left alone and its slot stays reserved, because disposing it would abort a possibly
+        /// distributed transaction. Callers that treat this method as "the slot is now free" must
+        /// tolerate that, including <see cref="Clear"/> and the <see cref="Shutdown"/> drain, which
+        /// can therefore complete while the pool still owns a connection.
+        /// </para>
+        /// <para>
+        /// In practice no current caller reaches that early return, because a connection in stasis
+        /// is filed in neither the idle channel nor the transacted store, and every caller sources
+        /// its connection from one of those or from a connection that is still checked out. The
+        /// guard is retained to match WaitHandleDbConnectionPool.DestroyObject and to keep the
+        /// invariant enforced if a future caller does reach it.
+        /// </para>
+        /// </remarks>
         /// <param name="connection">The connection to be closed.</param>
         private void RemoveConnection(DbConnectionInternal connection)
         {

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTest.cs
@@ -888,37 +888,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
 
         #endregion
 
-        #region Not Implemented Method Tests
-
-        /// <summary>
-        /// Verifies that <see cref="ChannelDbConnectionPool.PutObjectFromTransactedPool"/> remains
-        /// unimplemented and throws <see cref="NotImplementedException"/>.
-        /// </summary>
-        [Fact]
-        public void TestPutObjectFromTransactedPool()
-        {
-            // Arrange
-            var pool = ConstructPool(SuccessfulConnectionFactory);
-
-            // Act & Assert
-            Assert.Throws<NotImplementedException>(() => pool.PutObjectFromTransactedPool(null!));
-        }
-
-        /// <summary>
-        /// Verifies that <see cref="ChannelDbConnectionPool.TransactionEnded(System.Transactions.Transaction, Microsoft.Data.ProviderBase.DbConnectionInternal)"/>
-        /// remains unimplemented and throws <see cref="NotImplementedException"/>.
-        /// </summary>
-        [Fact]
-        public void TestTransactionEnded()
-        {
-            // Arrange
-            var pool = ConstructPool(SuccessfulConnectionFactory);
-
-            // Act & Assert
-            Assert.Throws<NotImplementedException>(() => pool.TransactionEnded(null!, null!));
-        }
-        #endregion
-
         #region Pool Clear Tests
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
@@ -113,16 +113,20 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
     }
 
     /// <summary>
-    /// Opens a connection asynchronously, carrying <paramref name="transaction"/> in the
-    /// <see cref="TaskCompletionSource{TResult}"/>'s AsyncState exactly as
-    /// SqlConnection.InternalOpenAsync does. The pool must take the transaction from there,
-    /// because the open runs on a thread pool thread the ambient transaction may not flow to.
+    /// Opens a connection asynchronously the way SqlConnection.InternalOpenAsync does: the ambient
+    /// transaction is captured here, on the caller's thread, and handed to the pool in the
+    /// <see cref="TaskCompletionSource{TResult}"/>'s AsyncState. The pool must take it from there,
+    /// because the open itself runs on a thread pool thread the ambient transaction may not flow
+    /// to, and on a retry the pool is re-entered from a continuation on an arbitrary thread.
     /// </summary>
+    /// <param name="owner">The owning connection.</param>
+    /// <param name="transaction">The transaction to hand to the pool. Defaults to the caller's
+    /// ambient transaction, matching what InternalOpenAsync captures.</param>
     private async Task<DbConnectionInternal> GetConnectionAsync(
         SqlConnection owner,
         Transaction? transaction = null)
     {
-        var tcs = new TaskCompletionSource<DbConnectionInternal>(transaction);
+        var tcs = new TaskCompletionSource<DbConnectionInternal>(transaction ?? Transaction.Current);
         _pool.TryGetConnection(
             owner,
             taskCompletionSource: tcs,
@@ -661,24 +665,24 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
     }
 
     /// <summary>
-    /// The asynchronous equivalent of the case above: when the ambient transaction does flow to
-    /// the caller (a TransactionScope created with
-    /// <see cref="TransactionScopeAsyncFlowOption.Enabled"/>) but the caller supplies no
-    /// transaction in the TaskCompletionSource's AsyncState, the pool must still pick it up. The
-    /// capture happens on the caller's thread before the open is scheduled, so the two paths agree
-    /// on what "the caller's transaction" means.
+    /// The asynchronous equivalent of the case above. The pool cannot read the caller's ambient
+    /// transaction itself, because the open runs on a thread pool thread it does not flow to, so
+    /// the caller captures it and passes it in AsyncState. Even with a scope created with
+    /// <see cref="TransactionScopeAsyncFlowOption.Enabled"/>, where the transaction is genuinely
+    /// ambient on the calling thread, that capture is what has to carry it through.
     /// </summary>
     [Fact]
-    public async Task GetConnectionAsync_WithoutAsyncState_UsesAmbientTransactionFromCallersThread()
+    public async Task GetConnectionAsync_UsesAmbientTransactionCapturedOnCallersThread()
     {
         // Arrange
         using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
         Transaction? transaction = Transaction.Current;
         Assert.NotNull(transaction);
 
-        // Act - note that no transaction is passed, so AsyncState is null.
+        // Act - no transaction is passed explicitly, so the helper captures the ambient one on
+        // this thread exactly as SqlConnection.InternalOpenAsync does.
         var owner = new SqlConnection();
-        var connection = await GetConnectionAsync(owner, transaction: null);
+        var connection = await GetConnectionAsync(owner);
 
         // Assert
         Assert.NotNull(connection);

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
@@ -575,13 +575,17 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
     /// <summary>
     /// A <see cref="TransactionScope"/> created without
     /// <see cref="TransactionScopeAsyncFlowOption.Enabled"/> -- the default -- keeps its ambient
-    /// transaction in thread-static storage, so it does not flow across an await onto the thread
-    /// pool thread the pool opens on. The connection must still enlist, because the transaction is
-    /// captured on the caller's thread before the open is scheduled (see
-    /// SqlConnection.InternalOpenAsync). This covers that end to end; it does not distinguish
-    /// AsyncState from the caller's ambient transaction, which agree here. See
+    /// transaction in thread-static storage, so it does not flow onto the thread pool thread the
+    /// pool opens on. The connection must still enlist, because the transaction is captured on the
+    /// caller's thread before the open is scheduled (see SqlConnection.InternalOpenAsync).
+    ///
+    /// This is one of three guards on that capture. With Enabled the transaction rides an
+    /// AsyncLocal and is live on the pool's worker thread, so reading Transaction.Current there
+    /// would pass every other test in this class -- and silently stop enlisting for the default
+    /// option, which the WaitHandle pool handles correctly. This case is the realistic shape of
+    /// that regression; see also
     /// <see cref="GetConnectionAsync_EnteredFromThreadWithoutAmbientTransaction_EnlistsFromAsyncState"/>
-    /// for the case that separates them.
+    /// and <see cref="GetConnectionAsync_DoesNotSetAmbientTransactionOnPoolWorkerThread"/>.
     ///
     /// The open is started inside the scope but awaited outside it. That is not incidental:
     /// awaiting inside resumes the continuation on a thread pool thread, and disposing the scope

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
@@ -1021,6 +1021,96 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
 
     #endregion
 
+    #region Async Ambient Transaction Flow Tests
+
+    /// <summary>
+    /// A <see cref="TransactionScope"/> created without <see cref="TransactionScopeAsyncFlowOption.Enabled"/>
+    /// keeps the ambient transaction in thread-static storage, so it is not observable from the thread
+    /// pool thread the pool opens on. The pool must therefore take the transaction from the
+    /// <see cref="TaskCompletionSource{TResult}"/>'s AsyncState, which is where SqlConnection.OpenAsync
+    /// captures it.
+    /// </summary>
+    [Fact]
+    public async Task GetConnectionAsync_AmbientTransactionNotFlowed_StillEnlistsFromAsyncState()
+    {
+        // Arrange - a transaction that is never ambient on any thread, so AsyncState is the only
+        // way the pool can learn about it.
+        using var transaction = new CommittableTransaction();
+        Assert.Null(Transaction.Current);
+        Assert.Null(await Task.Run(() => Transaction.Current));
+
+        // Act
+        var owner = new SqlConnection();
+        var connection = await GetConnectionAsync(owner, transaction);
+
+        // Assert
+        Assert.NotNull(connection);
+        Assert.Equal(transaction, connection.EnlistedTransaction);
+
+        ReturnConnection(connection, owner);
+
+        // Being enlisted, the connection parks in the transacted pool rather than the idle channel.
+        Assert.Single(_pool.TransactedConnectionPool.TransactedConnections[transaction]);
+        Assert.Equal(0, _pool.IdleCount);
+
+        transaction.Rollback();
+    }
+
+    /// <summary>
+    /// Assigning <see cref="Transaction.Current"/> writes to thread-static storage that the
+    /// ExecutionContext does not unwind, so doing it on a thread pool thread would leave a stale
+    /// transaction behind for unrelated work later scheduled onto that same thread -- including the
+    /// login-time auto-enlistment that non-pooled connections perform against the ambient
+    /// transaction. The pool must pass the transaction explicitly instead of assigning it.
+    /// </summary>
+    [Fact]
+    public async Task GetConnectionAsync_DoesNotLeakAmbientTransactionOntoThreadPool()
+    {
+        // Arrange & Act - several async opens under a transaction, each on a thread pool thread.
+        for (int i = 0; i < 8; i++)
+        {
+            using var transaction = new CommittableTransaction();
+            var owner = new SqlConnection();
+            var connection = await GetConnectionAsync(owner, transaction);
+            ReturnConnection(connection, owner);
+            transaction.Rollback();
+        }
+
+        // Assert - no thread pool thread was left with an ambient transaction.
+        for (int i = 0; i < 16; i++)
+        {
+            Assert.Null(await Task.Run(() => Transaction.Current));
+        }
+    }
+
+    /// <summary>
+    /// The synchronous path runs on the caller's thread, where the ambient transaction set by a
+    /// TransactionScope is directly observable and must still be honored.
+    /// </summary>
+    [Fact]
+    public void GetConnection_Sync_UsesAmbientTransactionFromCallersThread()
+    {
+        // Arrange
+        using var scope = new TransactionScope();
+        var transaction = Transaction.Current;
+        Assert.NotNull(transaction);
+
+        // Act - no transaction is handed to the pool explicitly; it must read Transaction.Current.
+        var owner = new SqlConnection();
+        var connection = GetConnection(owner);
+
+        // Assert
+        Assert.NotNull(connection);
+        Assert.Equal(transaction, connection.EnlistedTransaction);
+
+        ReturnConnection(connection, owner);
+        Assert.Single(_pool.TransactedConnectionPool.TransactedConnections[transaction!]);
+
+        scope.Complete();
+    }
+
+    #endregion
+
     #region Mock Classes
 
     internal class MockSqlConnectionFactory : SqlConnectionFactory

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
@@ -659,14 +659,19 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
 
         transaction.Rollback();
     }
-    /// ExecutionContext does not unwind, so doing it on a thread pool thread would leave a stale
-    /// transaction behind for unrelated work later scheduled onto that same thread -- including
-    /// the login-time auto-enlistment that non-pooled connections perform against the ambient
-    /// transaction. The pool must pass the transaction explicitly instead of assigning it.
+
+    /// <summary>
+    /// The pool must enlist the connection in the caller's transaction without making that
+    /// transaction ambient on the thread it opens on. Assigning Transaction.Current writes to
+    /// thread-static storage that ExecutionContext does not unwind, so doing it on a thread pool
+    /// thread would leave a stale transaction behind for unrelated work later scheduled onto that
+    /// same thread -- including the login-time auto-enlistment that non-pooled connections perform
+    /// against the ambient transaction. The pool must pass the transaction explicitly instead of
+    /// assigning it.
     ///
-    /// The connection factory runs on exactly the thread the pool does its open work on, so it is
-    /// used here to observe that thread's ambient transaction directly rather than inferring the
-    /// leak from thread pool reuse.
+    /// The connection factory runs inside the pool's own open work, so it observes what the pool
+    /// made ambient there. That is an observation of the code under test rather than of whichever
+    /// thread happened to run it, so it does not depend on thread identity or scheduling.
     /// </summary>
     [Fact]
     public async Task GetConnectionAsync_DoesNotSetAmbientTransactionOnPoolWorkerThread()
@@ -679,10 +684,9 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         var owner = new SqlConnection();
         var connection = await GetConnectionAsync(owner, transaction);
 
-        // Assert - the open really did happen on a thread pool thread, and the pool left that
-        // thread's ambient transaction alone while still enlisting the connection.
+        // Assert - the pool left the worker's ambient transaction alone while still enlisting the
+        // connection.
         Assert.Equal(1, _connectionFactory.CreateCount);
-        Assert.True(_connectionFactory.CreatedOnThreadPoolThread);
         Assert.Null(_connectionFactory.AmbientTransactionAtCreate);
         Assert.Equal(transaction, connection.EnlistedTransaction);
 
@@ -764,12 +768,6 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         /// </summary>
         public Transaction? AmbientTransactionAtCreate { get; private set; }
 
-        /// <summary>
-        /// Whether the pool created the connection on a thread pool thread, which is what makes
-        /// assigning the ambient transaction there unsafe.
-        /// </summary>
-        public bool CreatedOnThreadPoolThread { get; private set; }
-
         public int CreateCount { get; private set; }
 
         protected override DbConnectionInternal CreateConnection(
@@ -781,7 +779,6 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
             TimeoutTimer timeout)
         {
             AmbientTransactionAtCreate = Transaction.Current;
-            CreatedOnThreadPoolThread = Thread.CurrentThread.IsThreadPoolThread;
             CreateCount++;
             return new MockDbConnectionInternal();
         }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
@@ -598,12 +598,15 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         {
             Assert.Equal(transaction, Transaction.Current);
 
-#if NET
             // The transaction really is confined to this thread, so AsyncState is the only way
-            // the pool can learn about it. .NET Framework flows the ambient transaction through
-            // ExecutionContext whatever the async flow option says, so this only holds on .NET.
-            Assert.Null(Task.Run(() => Transaction.Current).GetAwaiter().GetResult());
-#endif
+            // the pool can learn about it. Probed on a dedicated thread rather than with
+            // Task.Run: blocking on a queued task lets the runtime execute it inline on this
+            // thread, which would observe this thread's own ambient transaction and prove nothing.
+            Transaction? observedOnAnotherThread = null;
+            var probe = new Thread(() => observedOnAnotherThread = Transaction.Current);
+            probe.Start();
+            probe.Join();
+            Assert.Null(observedOnAnotherThread);
 
             // Act - starting the open captures the ambient transaction synchronously, here, and
             // hands the rest of the work to a thread pool thread.

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
@@ -1,0 +1,1079 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Transactions;
+using Microsoft.Data.Common.ConnectionString;
+using Microsoft.Data.ProviderBase;
+using Microsoft.Data.SqlClient.ConnectionPool;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool;
+
+/// <summary>
+/// Deterministic tests for ChannelDbConnectionPool transaction functionality.
+/// These tests exercise transacted connection pathways with controlled synchronization
+/// to verify correct behavior without relying on probabilistic concurrency.
+/// </summary>
+public class ChannelDbConnectionPoolTransactionTest : IDisposable
+{
+    private const int DefaultMaxPoolSize = 50;
+    private const int DefaultMinPoolSize = 0;
+    private const int DefaultCreationTimeoutInMilliseconds = 15000;
+
+    private IDbConnectionPool _pool = null!;
+
+    public ChannelDbConnectionPoolTransactionTest()
+    {
+        _pool = CreatePool();
+    }
+
+    public void Dispose()
+    {
+        // Verify no leaked transactions before cleanup
+        Assert.Empty(_pool.TransactedConnectionPool.TransactedConnections);
+
+        _pool?.Shutdown();
+        _pool?.Clear();
+    }
+
+    #region Helper Methods
+
+    private ChannelDbConnectionPool CreatePool(
+        int maxPoolSize = DefaultMaxPoolSize,
+        int minPoolSize = DefaultMinPoolSize,
+        bool hasTransactionAffinity = true)
+    {
+        var poolGroupOptions = new DbConnectionPoolGroupOptions(
+            poolByIdentity: false,
+            minPoolSize: minPoolSize,
+            maxPoolSize: maxPoolSize,
+            creationTimeout: DefaultCreationTimeoutInMilliseconds,
+            loadBalanceTimeout: 0,
+            hasTransactionAffinity: hasTransactionAffinity,
+            idleTimeout: 0
+        );
+
+        var dbConnectionPoolGroup = new DbConnectionPoolGroup(
+            new SqlConnectionOptions("Data Source=localhost;"),
+            new ConnectionPoolKey("TestDataSource", credential: null, accessToken: null, accessTokenCallback: null, sspiContextProvider: null),
+            poolGroupOptions
+        );
+
+        var connectionFactory = new MockSqlConnectionFactory();
+
+        var pool = new ChannelDbConnectionPool(
+            connectionFactory,
+            dbConnectionPoolGroup,
+            DbConnectionPoolIdentity.NoIdentity,
+            new DbConnectionPoolProviderInfo()
+        );
+
+        pool.Startup();
+        return pool;
+    }
+
+    private DbConnectionInternal GetConnection(SqlConnection owner)
+    {
+        _pool.TryGetConnection(
+            owner,
+            taskCompletionSource: null,
+            TimeoutTimer.StartNew(TimeSpan.FromSeconds(15)),
+            out DbConnectionInternal? connection);
+        return connection!;
+    }
+
+    private async Task<DbConnectionInternal> GetConnectionAsync(
+        SqlConnection owner,
+        Transaction? transaction = null)
+    {
+        var tcs = new TaskCompletionSource<DbConnectionInternal>(transaction);
+        _pool.TryGetConnection(
+            owner,
+            taskCompletionSource: tcs,
+            TimeoutTimer.StartNew(TimeSpan.FromSeconds(15)),
+            out DbConnectionInternal? connection);
+        return connection ?? await tcs.Task;
+    }
+
+    private void ReturnConnection(DbConnectionInternal connection, SqlConnection owner)
+    {
+        _pool.ReturnInternalConnection(connection, owner);
+    }
+
+    private void AssertPoolMetrics()
+    {
+        Assert.True(_pool.Count <= _pool.PoolGroupOptions.MaxPoolSize,
+            $"Pool count ({_pool.Count}) exceeded max pool size ({_pool.PoolGroupOptions.MaxPoolSize})");
+        Assert.True(_pool.Count >= 0,
+            $"Pool count ({_pool.Count}) is negative");
+        Assert.Empty(_pool.TransactedConnectionPool.TransactedConnections);
+    }
+
+    #endregion
+
+    #region Transaction Routing Tests
+
+    [Fact]
+    public void GetConnection_UnderTransaction_RoutesToTransactedPool()
+    {
+        // Arrange & Act
+        using var scope = new TransactionScope();
+        var transaction = Transaction.Current;
+        Assert.NotNull(transaction);
+
+        var owner = new SqlConnection();
+        var conn = GetConnection(owner);
+        Assert.NotNull(conn);
+
+        ReturnConnection(conn, owner);
+
+        // Assert - connection should be in the transacted pool
+        Assert.True(_pool.TransactedConnectionPool.TransactedConnections.ContainsKey(transaction));
+        Assert.Single(_pool.TransactedConnectionPool.TransactedConnections[transaction]);
+
+        scope.Complete();
+    }
+
+    [Fact]
+    public void GetConnection_WithoutTransaction_RoutesToGeneralPool()
+    {
+        // Arrange & Act (no TransactionScope)
+        var owner = new SqlConnection();
+        var conn = GetConnection(owner);
+        Assert.NotNull(conn);
+
+        ReturnConnection(conn, owner);
+
+        // Assert - transacted pool should be empty
+        Assert.Empty(_pool.TransactedConnectionPool.TransactedConnections);
+    }
+
+    [Fact]
+    public void GetConnection_UnderTransaction_ReturnsSameConnectionFromTransactedPool()
+    {
+        // Arrange
+        using var scope = new TransactionScope();
+
+        // Act - first call creates a new connection
+        var owner1 = new SqlConnection();
+        var conn1 = GetConnection(owner1);
+        Assert.NotNull(conn1);
+        ReturnConnection(conn1, owner1);
+
+        // Second call should retrieve the SAME connection from the transacted pool (LIFO)
+        var owner2 = new SqlConnection();
+        var conn2 = GetConnection(owner2);
+        Assert.NotNull(conn2);
+        Assert.Same(conn1, conn2);
+
+        ReturnConnection(conn2, owner2);
+        scope.Complete();
+    }
+
+    [Fact]
+    public async Task GetConnectionAsync_UnderTransaction_ReturnsSameConnectionFromTransactedPool()
+    {
+        // Arrange
+        using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+        var transaction = Transaction.Current;
+
+        // Act - first call creates a new connection
+        var owner1 = new SqlConnection();
+        var conn1 = await GetConnectionAsync(owner1, transaction: transaction);
+        Assert.NotNull(conn1);
+        ReturnConnection(conn1, owner1);
+
+        // Second call should retrieve the SAME connection from the transacted pool
+        var owner2 = new SqlConnection();
+        var conn2 = await GetConnectionAsync(owner2, transaction: transaction);
+        Assert.NotNull(conn2);
+        Assert.Same(conn1, conn2);
+
+        ReturnConnection(conn2, owner2);
+        scope.Complete();
+    }
+
+    [Fact]
+    public void GetConnection_WithTransactionAffinityDisabled_SkipsTransactedPool()
+    {
+        // Arrange
+        _pool.Shutdown();
+        _pool.Clear();
+        _pool = CreatePool(hasTransactionAffinity: false);
+
+        using var scope = new TransactionScope();
+
+        // Act
+        var owner = new SqlConnection();
+        var conn = GetConnection(owner);
+        Assert.NotNull(conn);
+        ReturnConnection(conn, owner);
+
+        // Assert - even though a transaction is active, transacted pool is not used
+        Assert.Empty(_pool.TransactedConnectionPool.TransactedConnections);
+
+        scope.Complete();
+    }
+
+    #endregion
+
+    #region Transaction Lifecycle Tests
+
+    [Fact]
+    public void TransactionCommit_ClearsTransactedPool()
+    {
+        // Arrange & Act
+        using (var scope = new TransactionScope())
+        {
+            var owner = new SqlConnection();
+            var conn = GetConnection(owner);
+            Assert.NotNull(conn);
+            ReturnConnection(conn, owner);
+
+            // While transaction is active, connection should be in transacted pool
+            Assert.Single(_pool.TransactedConnectionPool.TransactedConnections);
+
+            scope.Complete();
+        }
+
+        // Assert - after transaction completes, transacted pool should be empty
+        AssertPoolMetrics();
+    }
+
+    [Fact]
+    public void TransactionRollback_ClearsTransactedPool()
+    {
+        // Arrange & Act
+        using (var scope = new TransactionScope())
+        {
+            var owner = new SqlConnection();
+            var conn = GetConnection(owner);
+            Assert.NotNull(conn);
+            ReturnConnection(conn, owner);
+
+            Assert.Single(_pool.TransactedConnectionPool.TransactedConnections);
+
+            // Don't call scope.Complete() — triggers rollback
+        }
+
+        // Assert - transacted pool should be empty after rollback too
+        AssertPoolMetrics();
+    }
+
+    [Fact]
+    public void MultipleGetReturn_SameTransaction_ReusesConnection()
+    {
+        // Arrange
+        using var scope = new TransactionScope();
+        var transaction = Transaction.Current;
+        Assert.NotNull(transaction);
+
+        // Act - get and return multiple times within same transaction
+        for (int i = 0; i < 10; i++)
+        {
+            var owner = new SqlConnection();
+            var conn = GetConnection(owner);
+            Assert.NotNull(conn);
+            ReturnConnection(conn, owner);
+        }
+
+        // Assert - only one connection should be in the transacted pool
+        Assert.Single(_pool.TransactedConnectionPool.TransactedConnections[transaction]);
+
+        scope.Complete();
+    }
+
+    [Fact]
+    public async Task MultipleGetReturn_SameTransaction_Async_ReusesConnection()
+    {
+        // Arrange
+        using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+        var transaction = Transaction.Current;
+        Assert.NotNull(transaction);
+
+        // Act - get and return multiple times within same transaction
+        for (int i = 0; i < 10; i++)
+        {
+            var owner = new SqlConnection();
+            var conn = await GetConnectionAsync(owner, transaction: transaction);
+            Assert.NotNull(conn);
+            ReturnConnection(conn, owner);
+        }
+
+        // Assert - only one connection should be in the transacted pool
+        Assert.Single(_pool.TransactedConnectionPool.TransactedConnections[transaction]);
+
+        scope.Complete();
+    }
+
+    [Fact]
+    public void AlternatingCommitAndRollback_MaintainsConsistentState()
+    {
+        // Act - alternate between commit and rollback
+        for (int i = 0; i < 20; i++)
+        {
+            using var scope = new TransactionScope();
+            var owner = new SqlConnection();
+            var conn = GetConnection(owner);
+            Assert.NotNull(conn);
+            ReturnConnection(conn, owner);
+
+            if (i % 2 == 0)
+            {
+                scope.Complete();
+            }
+            // else: rollback (no Complete)
+        }
+
+        // Assert
+        AssertPoolMetrics();
+    }
+
+    #endregion
+
+    #region Nested Transaction Tests
+
+    [Fact]
+    public void NestedTransaction_Required_SharesSameTransactedEntry()
+    {
+        // Arrange
+        using var outerScope = new TransactionScope();
+        var outerTxn = Transaction.Current;
+        Assert.NotNull(outerTxn);
+
+        var owner1 = new SqlConnection();
+        var conn1 = GetConnection(owner1);
+        Assert.NotNull(conn1);
+        ReturnConnection(conn1, owner1);
+
+        // Act - nested scope with Required shares the same transaction
+        using (var innerScope = new TransactionScope(TransactionScopeOption.Required))
+        {
+            Assert.Same(outerTxn, Transaction.Current);
+
+            var owner2 = new SqlConnection();
+            var conn2 = GetConnection(owner2);
+            Assert.NotNull(conn2);
+            Assert.Same(conn1, conn2); // Same transaction -> same connection from transacted pool
+            ReturnConnection(conn2, owner2);
+
+            // Only one transaction tracked
+            Assert.Single(_pool.TransactedConnectionPool.TransactedConnections);
+
+            innerScope.Complete();
+        }
+
+        outerScope.Complete();
+    }
+
+    [Fact]
+    public void NestedTransaction_RequiresNew_CreatesSeparateTransactedEntry()
+    {
+        // Arrange
+        using var outerScope = new TransactionScope();
+        var outerTxn = Transaction.Current;
+        Assert.NotNull(outerTxn);
+
+        var owner1 = new SqlConnection();
+        var conn1 = GetConnection(owner1);
+        Assert.NotNull(conn1);
+        ReturnConnection(conn1, owner1);
+
+        // Act - nested scope with RequiresNew creates a new transaction
+        using (var innerScope = new TransactionScope(TransactionScopeOption.RequiresNew))
+        {
+            var innerTxn = Transaction.Current;
+            Assert.NotNull(innerTxn);
+            Assert.NotEqual(outerTxn, innerTxn);
+
+            var owner2 = new SqlConnection();
+            var conn2 = GetConnection(owner2);
+            Assert.NotNull(conn2);
+            Assert.NotSame(conn1, conn2); // Different transaction -> different connection
+            ReturnConnection(conn2, owner2);
+
+            // Two separate transactions tracked
+            Assert.Equal(2, _pool.TransactedConnectionPool.TransactedConnections.Count);
+
+            innerScope.Complete();
+        }
+
+        outerScope.Complete();
+    }
+
+    [Fact]
+    public void NestedTransaction_RequiresNew_CompletesIndependently()
+    {
+        // Arrange & Act
+        using (var outerScope = new TransactionScope())
+        {
+            var owner1 = new SqlConnection();
+            var conn1 = GetConnection(owner1);
+            Assert.NotNull(conn1);
+            ReturnConnection(conn1, owner1);
+
+            using (var innerScope = new TransactionScope(TransactionScopeOption.RequiresNew))
+            {
+                var owner2 = new SqlConnection();
+                var conn2 = GetConnection(owner2);
+                Assert.NotNull(conn2);
+                ReturnConnection(conn2, owner2);
+                innerScope.Complete();
+            }
+
+            // Inner transaction completed - its entry should be cleared
+            // Outer transaction entry should still exist
+            Assert.Single(_pool.TransactedConnectionPool.TransactedConnections);
+
+            outerScope.Complete();
+        }
+
+        // Both completed
+        AssertPoolMetrics();
+    }
+
+    [Fact]
+    public void DeeplyNestedTransactions_RequiresNew_AllTrackedSeparately()
+    {
+        // Arrange & Act
+        using var scope1 = new TransactionScope();
+        var owner1 = new SqlConnection();
+        var conn1 = GetConnection(owner1);
+        ReturnConnection(conn1, owner1);
+
+        using var scope2 = new TransactionScope(TransactionScopeOption.RequiresNew);
+        var owner2 = new SqlConnection();
+        var conn2 = GetConnection(owner2);
+        ReturnConnection(conn2, owner2);
+
+        using var scope3 = new TransactionScope(TransactionScopeOption.RequiresNew);
+        var owner3 = new SqlConnection();
+        var conn3 = GetConnection(owner3);
+        ReturnConnection(conn3, owner3);
+
+        // Assert - three separate transactions tracked
+        Assert.Equal(3, _pool.TransactedConnectionPool.TransactedConnections.Count);
+
+        scope3.Complete();
+        scope2.Complete();
+        scope1.Complete();
+    }
+
+    [Fact]
+    public void DeeplyNestedTransactions_Required_AllShareOneEntry()
+    {
+        // Arrange & Act
+        using var scope1 = new TransactionScope();
+        var txn = Transaction.Current;
+        var owner1 = new SqlConnection();
+        var conn1 = GetConnection(owner1);
+        ReturnConnection(conn1, owner1);
+
+        using var scope2 = new TransactionScope(TransactionScopeOption.Required);
+        Assert.Same(txn, Transaction.Current);
+        var owner2 = new SqlConnection();
+        var conn2 = GetConnection(owner2);
+        Assert.Same(conn1, conn2);
+        ReturnConnection(conn2, owner2);
+
+        using var scope3 = new TransactionScope(TransactionScopeOption.Required);
+        Assert.Same(txn, Transaction.Current);
+        var owner3 = new SqlConnection();
+        var conn3 = GetConnection(owner3);
+        Assert.Same(conn1, conn3);
+        ReturnConnection(conn3, owner3);
+
+        // Assert - single transaction entry
+        Assert.Single(_pool.TransactedConnectionPool.TransactedConnections);
+
+        scope3.Complete();
+        scope2.Complete();
+        scope1.Complete();
+    }
+
+    #endregion
+
+    #region Mixed Transacted and Non-Transacted Tests
+
+    [Fact]
+    public void MixedWorkload_AlternatingTransactedAndNonTransacted()
+    {
+        // Act - alternate between transacted and non-transacted
+        for (int i = 0; i < 10; i++)
+        {
+            if (i % 2 == 0)
+            {
+                using var scope = new TransactionScope();
+                var owner = new SqlConnection();
+                var conn = GetConnection(owner);
+                Assert.NotNull(conn);
+                ReturnConnection(conn, owner);
+                scope.Complete();
+            }
+            else
+            {
+                var owner = new SqlConnection();
+                var conn = GetConnection(owner);
+                Assert.NotNull(conn);
+                ReturnConnection(conn, owner);
+            }
+        }
+
+        // Assert
+        AssertPoolMetrics();
+    }
+
+    #endregion
+
+    #region Shared Transaction Tests
+
+    [Fact]
+    public void SharedTransaction_DependentScopes_UseTransactedPool()
+    {
+        // Arrange
+        using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+        var transaction = Transaction.Current;
+        Assert.NotNull(transaction);
+
+        // Act - first connection
+        var owner1 = new SqlConnection();
+        var conn1 = GetConnection(owner1);
+        Assert.NotNull(conn1);
+        ReturnConnection(conn1, owner1);
+
+        // Use dependent scope on same transaction
+        using (var innerScope = new TransactionScope(transaction))
+        {
+            Assert.Same(transaction, Transaction.Current);
+            var owner2 = new SqlConnection();
+            var conn2 = GetConnection(owner2);
+            Assert.NotNull(conn2);
+            Assert.Same(conn1, conn2); // Same transaction -> same connection
+            ReturnConnection(conn2, owner2);
+            innerScope.Complete();
+        }
+
+        // Assert - still one transaction entry
+        Assert.Single(_pool.TransactedConnectionPool.TransactedConnections);
+        Assert.Single(_pool.TransactedConnectionPool.TransactedConnections[transaction]);
+
+        scope.Complete();
+    }
+
+    #endregion
+
+    #region Pool Saturation with Transactions Tests
+
+    [Fact]
+    public void PoolSaturation_BlocksUntilConnectionAvailable()
+    {
+        // Arrange - small pool
+        _pool.Shutdown();
+        _pool.Clear();
+        _pool = CreatePool(maxPoolSize: 1);
+
+        using var allAcquired = new ManualResetEventSlim(false);
+        using var releaseFirst = new ManualResetEventSlim(false);
+
+        var saturatingTask = Task.Run(() =>
+            {
+                using var scope = new TransactionScope();
+                var owner = new SqlConnection();
+                var conn = GetConnection(owner);
+                Assert.NotNull(conn);
+
+                allAcquired.Set(); // Signal that this connection is held
+
+                Assert.True(releaseFirst.Wait(TimeSpan.FromSeconds(15)),
+                    "Timed out waiting for releaseFirst signal.");
+
+                ReturnConnection(conn, owner);
+                scope.Complete();
+            });
+
+        Assert.True(allAcquired.Wait(TimeSpan.FromSeconds(10)),
+            "Timed out waiting for connection to be acquired.");
+        Assert.Equal(1, _pool.Count);
+
+        using var acquired = new ManualResetEventSlim(false);
+        var waitingTask = Task.Run(() =>
+        {
+            using var scope = new TransactionScope();
+            var owner = new SqlConnection();
+            var conn = GetConnection(owner);
+            Assert.NotNull(conn);
+            acquired.Set();
+            ReturnConnection(conn, owner);
+            scope.Complete();
+        });
+
+        // Give the waiting task time to block — it should NOT complete yet
+        Assert.False(acquired.Wait(TimeSpan.FromMilliseconds(500)),
+            "Waiting task should not have acquired a connection while pool is saturated");
+
+        // Release one connection to unblock the waiting task
+        releaseFirst.Set();
+
+        // Now the waiting task should complete
+        Assert.True(waitingTask.Wait(TimeSpan.FromSeconds(15)),
+            "Waiting task should have completed after a connection was released");
+        Assert.True(acquired.IsSet);
+
+        // Cleanup remaining held connections
+        Task.WaitAll(saturatingTask);
+    }
+
+    #endregion
+
+    #region Controlled Concurrency Tests
+
+    // Flaky under CI load only (never reproduces locally): the two worker tasks are
+    // scheduled via Task.Run on the thread pool. On a loaded agent the pool can be slow to
+    // spin up a worker, so task1 starts late and fails to signal task1Returned within
+    // task2's 10s wait, producing a WaitAll timeout. That is thread-pool starvation, not a
+    // pool/transaction defect.
+    [Trait("Category", "flaky")]
+    [Fact]
+    public void TwoThreads_SharedTransaction_AccessSameTransactedEntry()
+    {
+        // Arrange
+        // Use 3-phase synchronization so task1 gets AND returns before task2 requests.
+        // This ensures the connection is back in the transacted pool for task2 to reuse.
+        using var task1Returned = new ManualResetEventSlim(false);
+        using var task2Done = new ManualResetEventSlim(false);
+        DbConnectionInternal? connFromTask1 = null;
+        DbConnectionInternal? connFromTask2 = null;
+
+        using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+        var transaction = Transaction.Current;
+        Assert.NotNull(transaction);
+
+        // Act - two threads sharing the same transaction, sequenced so the
+        // transacted pool can vend the same connection to both.
+        var task1 = Task.Run(() =>
+        {
+            using var innerScope = new TransactionScope(transaction);
+            var owner = new SqlConnection();
+            connFromTask1 = GetConnection(owner);
+            Assert.NotNull(connFromTask1);
+
+            // Return the connection so it's available in the transacted pool
+            ReturnConnection(connFromTask1, owner);
+            innerScope.Complete();
+
+            task1Returned.Set(); // Signal: connection is back in the transacted pool
+        });
+
+        var task2 = Task.Run(() =>
+        {
+            // Wait until task1 has returned the connection to the transacted pool
+            Assert.True(task1Returned.Wait(TimeSpan.FromSeconds(10)),
+                "Timed out waiting for task1 to return its connection.");
+
+            using var innerScope = new TransactionScope(transaction);
+            var owner = new SqlConnection();
+            connFromTask2 = GetConnection(owner);
+            Assert.NotNull(connFromTask2);
+            ReturnConnection(connFromTask2, owner);
+            innerScope.Complete();
+        });
+
+        Task.WaitAll(task1, task2);
+
+        // Both tasks should have received the same connection via the transacted pool
+        Assert.Same(connFromTask1, connFromTask2);
+        scope.Complete();
+    }
+
+    [Fact]
+    public async Task TwoThreads_SeparateTransactions_Async_IsolatedTransactedEntries()
+    {
+        // Arrange
+        using var barrier = new SemaphoreSlim(0, 2);
+
+        // Act
+        var task1 = Task.Run(async () =>
+        {
+            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+            var transaction = Transaction.Current;
+            var owner = new SqlConnection();
+            var conn = await GetConnectionAsync(owner, transaction: transaction);
+            Assert.NotNull(conn);
+            ReturnConnection(conn, owner);
+
+            barrier.Release(); // Signal ready
+            await barrier.WaitAsync(); // Wait for other task
+
+            scope.Complete();
+        });
+
+        var task2 = Task.Run(async () =>
+        {
+            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+            var transaction = Transaction.Current;
+            var owner = new SqlConnection();
+            var conn = await GetConnectionAsync(owner, transaction: transaction);
+            Assert.NotNull(conn);
+            ReturnConnection(conn, owner);
+
+            barrier.Release(); // Signal ready
+            await barrier.WaitAsync(); // Wait for other task
+
+            scope.Complete();
+        });
+
+        await Task.WhenAll(task1, task2);
+
+        // Assert
+        AssertPoolMetrics();
+    }
+
+    #endregion
+
+    #region Pool Shutdown with Transactions Tests
+
+    [Fact]
+    public void PoolShutdown_AfterTransactionComplete_NoLeaks()
+    {
+        // Arrange
+        using (var scope = new TransactionScope())
+        {
+            var owner = new SqlConnection();
+            var conn = GetConnection(owner);
+            Assert.NotNull(conn);
+            ReturnConnection(conn, owner);
+            scope.Complete();
+        }
+
+        // Act
+        _pool.Shutdown();
+
+        // Assert
+        AssertPoolMetrics();
+    }
+
+    [Fact]
+    public void PoolShutdown_WhileConnectionHeld_NoException()
+    {
+        // Arrange
+        using var scope = new TransactionScope();
+        var owner = new SqlConnection();
+        var conn = GetConnection(owner);
+        Assert.NotNull(conn);
+
+        // Act - shutdown while connection is held (not yet returned)
+        _pool.Shutdown();
+
+        // Return after shutdown — the pool deactivates and disposes the connection
+        // rather than returning it to the pool. Verify this doesn't throw.
+        ReturnConnection(conn, owner);
+
+        // Assert
+        // The connection should have been deactivated and disposed (not returned to the pool).
+        // After Dispose(), IsConnectionDoomed is set to true and Pool is set to null.
+        Assert.True(conn.IsConnectionDoomed,
+            "Connection should be doomed after returning to a shut-down pool.");
+        Assert.Null(conn.Pool);
+    }
+
+    #endregion
+
+    #region Transaction Complete Before Return Tests
+
+    [Fact]
+    public void TransactionComplete_ThenReturn_ConnectionStillReturned()
+    {
+        // Arrange
+        var owner = new SqlConnection();
+        DbConnectionInternal conn;
+
+        using (var scope = new TransactionScope())
+        {
+            conn = GetConnection(owner);
+            Assert.NotNull(conn);
+            scope.Complete();
+        }
+        // Transaction is fully disposed here
+
+        // Act - return connection after transaction ended
+        ReturnConnection(conn, owner);
+
+        // Assert - no leak, pool metrics consistent
+        AssertPoolMetrics();
+        Assert.True(_pool.Count > 0, "Pool should still have the connection");
+    }
+
+    #endregion
+
+    #region Sequential Transaction Isolation Tests
+
+    [Fact]
+    public void SequentialTransactions_EachGetsOwnTransactedEntry()
+    {
+        // Act - create multiple sequential transactions
+        for (int i = 0; i < 5; i++)
+        {
+            using var scope = new TransactionScope();
+            var transaction = Transaction.Current;
+            Assert.NotNull(transaction);
+
+            var owner = new SqlConnection();
+            var conn = GetConnection(owner);
+            Assert.NotNull(conn);
+            ReturnConnection(conn, owner);
+
+            // Only the current transaction should be tracked
+            Assert.Single(_pool.TransactedConnectionPool.TransactedConnections);
+            Assert.True(_pool.TransactedConnectionPool.TransactedConnections.ContainsKey(transaction));
+
+            scope.Complete();
+        }
+
+        // Assert - after all are done, pool should be clean
+        AssertPoolMetrics();
+    }
+
+    [Fact]
+    public async Task SequentialTransactions_Async_EachGetsOwnTransactedEntry()
+    {
+        // Act - create multiple sequential transactions
+        for (int i = 0; i < 5; i++)
+        {
+            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+            var transaction = Transaction.Current;
+            Assert.NotNull(transaction);
+
+            var owner = new SqlConnection();
+            var conn = await GetConnectionAsync(owner, transaction: transaction);
+            Assert.NotNull(conn);
+            ReturnConnection(conn, owner);
+
+            Assert.Single(_pool.TransactedConnectionPool.TransactedConnections);
+            Assert.True(_pool.TransactedConnectionPool.TransactedConnections.ContainsKey(transaction));
+
+            scope.Complete();
+        }
+
+        // Assert
+        AssertPoolMetrics();
+    }
+
+    [Fact]
+    public void SequentialTransactions_CanReuseConnections()
+    {
+        // Act
+        DbConnectionInternal conn1;
+        DbConnectionInternal conn2;
+        Transaction? txn1;
+        Transaction? txn2;
+
+        using (var scope1 = new TransactionScope())
+        {
+            txn1 = Transaction.Current;
+            var owner1 = new SqlConnection();
+            conn1 = GetConnection(owner1);
+            Assert.NotNull(conn1);
+            ReturnConnection(conn1, owner1);
+            scope1.Complete();
+        }
+
+        using (var scope2 = new TransactionScope())
+        {
+            txn2 = Transaction.Current;
+            var owner2 = new SqlConnection();
+            conn2 = GetConnection(owner2);
+            Assert.NotNull(conn2);
+            ReturnConnection(conn2, owner2);
+            scope2.Complete();
+        }
+
+        // Assert
+        // The connection was returned to the general pool and picked up by the second transaction
+        Assert.NotSame(txn1, txn2);
+        Assert.Same(conn1, conn2);
+        AssertPoolMetrics();
+    }
+
+    #endregion
+
+    #region Transacted Pool Plumbing Tests
+
+    [Fact]
+    public void TransactionCompletion_ReturnsConnectionToIdleChannel()
+    {
+        // Arrange - park a connection in the transacted pool.
+        DbConnectionInternal conn;
+        using (var scope = new TransactionScope())
+        {
+            var owner = new SqlConnection();
+            conn = GetConnection(owner);
+            Assert.NotNull(conn);
+            ReturnConnection(conn, owner);
+
+            // While the transaction is live the connection is held by the transacted pool and is
+            // deliberately absent from the idle channel.
+            Assert.Single(_pool.TransactedConnectionPool.TransactedConnections);
+            Assert.Equal(0, _pool.IdleCount);
+
+            scope.Complete();
+        }
+
+        // Assert - completion drives TransactionEnded -> PutObjectFromTransactedPool, which puts
+        // the connection back into general circulation.
+        Assert.Empty(_pool.TransactedConnectionPool.TransactedConnections);
+        Assert.Equal(1, _pool.IdleCount);
+        Assert.Equal(1, _pool.Count);
+
+        // The connection is now reusable by a caller with no ambient transaction.
+        var owner2 = new SqlConnection();
+        var conn2 = GetConnection(owner2);
+        Assert.Same(conn, conn2);
+        ReturnConnection(conn2, owner2);
+    }
+
+    [Fact]
+    public void TransactionCompletion_AfterShutdown_DestroysConnection()
+    {
+        // Arrange - park a connection in the transacted pool, then shut the pool down. The
+        // transacted connection survives the shutdown drain because closing it would abort the
+        // (possibly distributed) transaction.
+        DbConnectionInternal conn;
+        using (var scope = new TransactionScope())
+        {
+            var owner = new SqlConnection();
+            conn = GetConnection(owner);
+            Assert.NotNull(conn);
+            ReturnConnection(conn, owner);
+
+            // Act
+            _pool.Shutdown();
+            scope.Complete();
+        }
+
+        // Assert - a shut-down pool must not re-pool the connection when the transaction ends.
+        Assert.Empty(_pool.TransactedConnectionPool.TransactedConnections);
+        Assert.Equal(0, _pool.IdleCount);
+        Assert.Equal(0, _pool.Count);
+        Assert.True(conn.IsConnectionDoomed);
+    }
+
+    [Fact]
+    public void TransactionEnded_UnknownConnection_DoesNotPoolConnection()
+    {
+        // Arrange - a connection that was never parked in the transacted pool.
+        var owner = new SqlConnection();
+        var conn = GetConnection(owner);
+        Assert.NotNull(conn);
+
+        using var scope = new TransactionScope();
+        var transaction = Transaction.Current;
+        Assert.NotNull(transaction);
+
+        // Act
+        _pool.TransactionEnded(transaction!, conn);
+
+        // Assert - nothing to remove, so the connection stays checked out.
+        Assert.Equal(0, _pool.IdleCount);
+        Assert.Equal(1, _pool.Count);
+
+        ReturnConnection(conn, owner);
+        scope.Complete();
+    }
+
+    [Fact]
+    public void ReplaceConnection_CarriesEnlistedTransactionToNewConnection()
+    {
+        // Arrange
+        using var scope = new TransactionScope();
+        var transaction = Transaction.Current;
+        Assert.NotNull(transaction);
+
+        var owner = new SqlConnection();
+        var oldConnection = GetConnection(owner);
+        Assert.NotNull(oldConnection);
+        Assert.Equal(1, _pool.Count);
+
+        // Act
+        var newConnection = _pool.ReplaceConnection(
+            owner,
+            oldConnection,
+            TimeoutTimer.StartNew(TimeSpan.FromSeconds(15)));
+
+        // Assert - a distinct connection took over the old connection's slot and enlistment.
+        Assert.NotNull(newConnection);
+        Assert.NotSame(oldConnection, newConnection);
+        Assert.Equal(1, _pool.Count);
+        Assert.True(oldConnection.IsConnectionDoomed);
+
+        ReturnConnection(newConnection, owner);
+
+        // The replacement inherited the transaction, so it parks in the transacted pool.
+        Assert.Single(_pool.TransactedConnectionPool.TransactedConnections[transaction!]);
+
+        scope.Complete();
+    }
+
+    #endregion
+
+    #region Mock Classes
+
+    internal class MockSqlConnectionFactory : SqlConnectionFactory
+    {
+        protected override DbConnectionInternal CreateConnection(
+            SqlConnectionOptions options,
+            ConnectionPoolKey poolKey,
+            DbConnectionPoolGroupProviderInfo poolGroupProviderInfo,
+            IDbConnectionPool pool,
+            DbConnection owningConnection,
+            TimeoutTimer timeout)
+        {
+            return new MockDbConnectionInternal();
+        }
+    }
+
+    internal class MockDbConnectionInternal : DbConnectionInternal
+    {
+        private static int s_nextId = 1;
+        public int MockId { get; } = Interlocked.Increment(ref s_nextId);
+
+        public override string ServerVersion => "Mock";
+
+        public override ConnectionCapabilities Capabilities => new();
+
+        public override DbTransaction BeginTransaction(System.Data.IsolationLevel il)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void EnlistTransaction(Transaction? transaction)
+        {
+            if (transaction != null)
+            {
+                EnlistedTransaction = transaction;
+            }
+        }
+
+        protected override void Activate(Transaction? transaction)
+        {
+            EnlistedTransaction = transaction;
+        }
+
+        protected override void Deactivate()
+        {
+        }
+
+        public override string ToString() => $"MockConnection_{MockId}";
+
+        internal override void ResetConnection()
+        {
+        }
+    }
+
+    #endregion
+}

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
@@ -99,6 +99,17 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
     }
 
     /// <summary>
+    /// Replaces the fixture's pool with one capped at <paramref name="maxPoolSize"/>, so a test can
+    /// exhaust it and observe what happens to a caller that has to wait.
+    /// </summary>
+    private void ReplaceFixturePool(int maxPoolSize)
+    {
+        _pool.Shutdown();
+        _pool.Clear();
+        _pool = CreatePool(maxPoolSize: maxPoolSize);
+    }
+
+    /// <summary>
     /// Opens a connection synchronously. The pool reads the ambient transaction off the calling
     /// thread on this path.
     /// </summary>
@@ -322,6 +333,41 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
             "A connection returned to a shut-down pool should be destroyed, not pooled.");
         Assert.Null(connection.Pool);
         AssertPoolState(count: 0, idleCount: 0, transactedCount: 0);
+    }
+
+    /// <summary>
+    /// A doomed connection is destroyed even when it is still enlisted. The doomed check runs
+    /// before the transacted decision precisely so that a connection unfit for reuse is never
+    /// parked in the transacted store, where it would be handed to the next caller in that same
+    /// transaction.
+    /// </summary>
+    [Fact]
+    public void ReturnConnection_WhenDoomedWhileEnlisted_DestroysWithoutParking()
+    {
+        // Arrange
+        using var scope = new TransactionScope();
+        Transaction? transaction = Transaction.Current;
+        Assert.NotNull(transaction);
+
+        var owner = new SqlConnection();
+        var connection = GetConnection(owner);
+        Assert.NotNull(connection);
+        AssertEnlistedIn(transaction, connection);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
+
+        // The connection breaks while it is enlisted and checked out.
+        ((MockDbConnectionInternal)connection).Doom();
+        Assert.True(connection.IsConnectionDoomed);
+
+        // Act
+        ReturnConnection(connection, owner);
+
+        // Assert - destroyed rather than parked under its transaction, and its slot is released.
+        Assert.Equal(0, TransactedConnectionsFor(transaction!));
+        AssertPoolState(count: 0, idleCount: 0, transactedCount: 0);
+        Assert.Null(connection.Pool);
+
+        scope.Complete();
     }
 
     #endregion
@@ -611,6 +657,262 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         // It reaches the pool only when its owner returns it.
         ReturnConnection(connection, owner);
         AssertPoolState(count: 1, idleCount: 1, transactedCount: 0);
+    }
+
+    /// <summary>
+    /// Releasing a parked connection runs on the System.Transactions transaction-completion
+    /// callback thread, under DbConnectionInternal.DelegatedTransactionEnded's requirement that the
+    /// caller holds a lock on the connection. The pool must not poll the socket there, so the
+    /// liveness probe is suppressed on that path and the connection is pooled without it.
+    /// WaitHandleDbConnectionPool likewise does not probe when returning a connection from the
+    /// transacted store. A connection that died during the transaction is still caught, just later:
+    /// it is validated on its way back out of the idle channel, before it can be vended.
+    /// </summary>
+    [Fact]
+    public void TransactionCommit_ReturningParkedConnection_DoesNotProbeLiveness()
+    {
+        // Arrange
+        MockDbConnectionInternal connection;
+        using (var scope = new TransactionScope())
+        {
+            var owner = new SqlConnection();
+            connection = Assert.IsType<MockDbConnectionInternal>(GetConnection(owner));
+            ReturnConnection(connection, owner);
+            AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
+
+            // Report the connection as dead and ignore any probes made while arranging, so the
+            // assertions below describe only what the completion path itself did.
+            connection.IsDead = true;
+            connection.LivenessProbeCount = 0;
+
+            // Act
+            scope.Complete();
+        }
+
+        // Assert - the completion path pooled it without asking whether it was alive.
+        Assert.Equal(0, connection.LivenessProbeCount);
+        AssertPoolState(count: 1, idleCount: 1, transactedCount: 0);
+
+        // The deferred check still catches it: vending probes the connection, finds it dead, and
+        // discards it rather than handing a broken connection to the caller.
+        var owner2 = new SqlConnection();
+        var connection2 = GetConnection(owner2);
+        Assert.NotSame(connection, connection2);
+        Assert.True(connection.LivenessProbeCount > 0);
+        ReturnConnection(connection2, owner2);
+    }
+
+    /// <summary>
+    /// The counterpart to <see cref="TransactionCommit_ReturningParkedConnection_DoesNotProbeLiveness"/>:
+    /// suppressing the probe is specific to the transaction-completion path. An ordinary return
+    /// runs on the caller's own thread, where blocking is acceptable, so it still probes and drops
+    /// a dead connection immediately instead of leaving it to be discovered later.
+    /// </summary>
+    [Fact]
+    public void ReturnConnection_WhenDeadAndNotEnlisted_ProbesLivenessAndDestroysIt()
+    {
+        // Arrange
+        var owner = new SqlConnection();
+        var connection = Assert.IsType<MockDbConnectionInternal>(GetConnection(owner));
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
+
+        connection.IsDead = true;
+        connection.LivenessProbeCount = 0;
+
+        // Act
+        ReturnConnection(connection, owner);
+
+        // Assert
+        Assert.True(connection.LivenessProbeCount > 0);
+        AssertPoolState(count: 0, idleCount: 0, transactedCount: 0);
+    }
+
+    /// <summary>
+    /// A connection parked in the transacted store still holds its pool slot, so with MaxPoolSize
+    /// reached and everything parked, a caller outside the transaction cannot be served and must
+    /// wait. Ending the transaction has to wake it: the release path writes the connection into the
+    /// idle channel, which completes the waiter. If it did not, the caller would block until its
+    /// own timeout even though a connection had become available.
+    /// </summary>
+    [Fact]
+    public async Task TransactionEnd_WithPoolExhaustedByParkedConnection_WakesWaitingCaller()
+    {
+        // Arrange - a pool of exactly one connection, parked under a transaction.
+        ReplaceFixturePool(maxPoolSize: 1);
+
+        DbConnectionInternal parkedConnection;
+        var waiter = new TaskCompletionSource<DbConnectionInternal>(state: null);
+
+        using (var scope = new TransactionScope())
+        {
+            var owner = new SqlConnection();
+            parkedConnection = GetConnection(owner);
+            ReturnConnection(parkedConnection, owner);
+            AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
+
+            // A second caller with no ambient transaction. The pool is at MaxPoolSize and the idle
+            // channel is empty, and the parked connection belongs to a transaction this caller is
+            // not in, so it cannot be served now. Suppress the ambient transaction so the request
+            // is genuinely unrelated rather than being handed the parked connection by affinity.
+            using (new TransactionScope(TransactionScopeOption.Suppress))
+            {
+                bool completedSynchronously = _pool.TryGetConnection(
+                    new SqlConnection(),
+                    waiter,
+                    TimeoutTimer.StartNew(TimeSpan.FromSeconds(15)),
+                    out DbConnectionInternal? immediateConnection);
+
+                Assert.False(completedSynchronously);
+                Assert.Null(immediateConnection);
+            }
+
+            Assert.False(waiter.Task.IsCompleted, "The caller must wait while the only connection is parked.");
+
+            // Act
+            scope.Complete();
+        }
+
+        // Assert - the waiter was handed the released connection rather than timing out.
+        DbConnectionInternal servedConnection = await waiter.Task.WaitAsync(TimeSpan.FromSeconds(15));
+        Assert.Same(parkedConnection, servedConnection);
+        AssertEnlistedIn(null, servedConnection);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
+    }
+
+    /// <summary>
+    /// Clear cannot destroy a connection parked in the transacted store, because doing so would
+    /// abort a possibly distributed transaction, and the parked connection is not in the idle
+    /// channel that Clear drains. It is instead retired lazily: Clear bumps the generation counter,
+    /// and when the transaction ends the release path sees the stale generation and destroys the
+    /// connection rather than returning it to circulation. This is the channel pool's substitute
+    /// for WaitHandleDbConnectionPool's eager DoNotPoolThisConnection sweep, so the lag between
+    /// Clear returning and the connection actually going away is expected.
+    /// </summary>
+    [Fact]
+    public void Clear_WhileConnectionIsParked_RetiresItOnTransactionEndInsteadOfRepooling()
+    {
+        // Arrange
+        DbConnectionInternal connection;
+        using (var scope = new TransactionScope())
+        {
+            var owner = new SqlConnection();
+            connection = GetConnection(owner);
+            ReturnConnection(connection, owner);
+            AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
+
+            // Act - Clear runs while the connection is parked and its transaction is live.
+            _pool.Clear();
+
+            // Assert - it survives Clear, still parked and still holding its slot.
+            AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
+            Assert.False(connection.IsConnectionDoomed);
+
+            scope.Complete();
+        }
+
+        // Assert - on release the stale generation is detected, so the connection is destroyed
+        // instead of being handed to the next caller.
+        Assert.True(connection.IsConnectionDoomed);
+        Assert.Null(connection.Pool);
+        AssertPoolState(count: 0, idleCount: 0, transactedCount: 0);
+
+        // The next caller therefore gets a freshly created connection, not the cleared one.
+        var owner2 = new SqlConnection();
+        var connection2 = GetConnection(owner2);
+        Assert.NotSame(connection, connection2);
+        ReturnConnection(connection2, owner2);
+    }
+
+    #endregion
+
+    #region Stasis
+    /// <summary>
+    /// A transaction root that cannot be pooled is put in stasis rather than destroyed: closing it
+    /// would orphan the root transaction with no way to commit or roll back. Stasis is not the
+    /// transacted store. The connection is filed nowhere, so it is invisible to the idle channel,
+    /// to <see cref="ChannelDbConnectionPool.Clear"/> and to pruning, but it still holds its pool
+    /// slot. The slot comes back when the transaction ends and the connection unwinds through
+    /// PutObjectFromTransactedPool.
+    /// </summary>
+    [Fact]
+    public void ReturnConnection_NonPoolableTransactionRoot_EntersStasisThenReleasesSlotOnTransactionEnd()
+    {
+        // Arrange
+        MockDbConnectionInternal connection;
+        using (var scope = new TransactionScope())
+        {
+            var owner = new SqlConnection();
+            connection = Assert.IsType<MockDbConnectionInternal>(GetConnection(owner));
+
+            // A root that cannot be pooled. Deliberately not doomed: IsConnectionDoomed would
+            // short-circuit the return path before the stasis decision is ever reached.
+            connection.IsRoot = true;
+            connection.MarkDoNotPool();
+            Assert.False(connection.CanBePooled);
+            Assert.False(connection.IsConnectionDoomed);
+
+            // Act
+            ReturnConnection(connection, owner);
+
+            // Assert - in stasis: holding its slot, but filed in neither the idle channel nor the
+            // transacted store, so no other caller can reach it.
+            Assert.True(connection.IsTxRootWaitingForTxEnd);
+            AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
+
+            // It survives a Clear that would have destroyed any pooled connection, because Clear
+            // drains the idle channel and a connection in stasis is not in it.
+            _pool.Clear();
+            Assert.True(connection.IsTxRootWaitingForTxEnd);
+            AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
+
+            scope.Complete();
+        }
+
+        // Assert - the transaction ended, stasis terminated, and because the connection still
+        // cannot be pooled it was destroyed rather than returned to circulation. Its slot is free.
+        Assert.False(connection.IsTxRootWaitingForTxEnd);
+        Assert.Null(connection.Pool);
+        AssertPoolState(count: 0, idleCount: 0, transactedCount: 0);
+    }
+
+    /// <summary>
+    /// The transaction-root counterpart to
+    /// <see cref="ReturnConnection_ToShutDownPool_DestroysConnection"/>. A shut-down pool destroys
+    /// an ordinary connection on return, but a transaction root must still go to stasis instead, or
+    /// shutting down a pool would abort a live transaction. The slot stays outstanding until the
+    /// transaction ends, which is why a completed Shutdown does not imply the pool owns nothing.
+    /// </summary>
+    [Fact]
+    public void ReturnConnection_TransactionRootToShutDownPool_EntersStasisRatherThanBeingDestroyed()
+    {
+        // Arrange
+        MockDbConnectionInternal connection;
+        using (var scope = new TransactionScope())
+        {
+            var owner = new SqlConnection();
+            connection = Assert.IsType<MockDbConnectionInternal>(GetConnection(owner));
+            connection.IsRoot = true;
+
+            _pool.Shutdown();
+
+            // Act
+            ReturnConnection(connection, owner);
+
+            // Assert - not destroyed, unlike the non-root case.
+            Assert.True(connection.IsTxRootWaitingForTxEnd);
+            Assert.False(connection.IsConnectionDoomed);
+            Assert.NotNull(connection.Pool);
+            AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
+
+            scope.Complete();
+        }
+
+        // Assert - the pool is not Running, so the connection is destroyed on the way out of
+        // stasis rather than pooled, and only now does the pool's count reach zero.
+        Assert.False(connection.IsTxRootWaitingForTxEnd);
+        Assert.True(connection.IsConnectionDoomed);
+        Assert.Null(connection.Pool);
+        AssertPoolState(count: 0, idleCount: 0, transactedCount: 0);
     }
 
     #endregion
@@ -903,6 +1205,43 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
 
         protected override void Deactivate()
         {
+        }
+
+        internal void Doom() => DoomThisConnection();
+
+        /// <summary>
+        /// Marks the connection unfit for pooling without dooming it. This is the distinction the
+        /// pool cares about: <see cref="DbConnectionInternal.IsConnectionDoomed"/> short-circuits
+        /// the return path before the transacted decision, whereas a merely non-poolable connection
+        /// still reaches it and can be put in stasis.
+        /// </summary>
+        internal void MarkDoNotPool() => DoNotPoolThisConnection();
+
+        /// <summary>
+        /// When true, the connection reports itself as the root of a delegated transaction, which
+        /// is what makes the pool put it in stasis rather than destroy it.
+        /// </summary>
+        internal bool IsRoot { get; set; }
+
+        internal override bool IsTransactionRoot => IsRoot;
+
+        /// <summary>
+        /// When true, the connection reports itself as dead from
+        /// <see cref="IsConnectionAlive"/>, simulating a physical connection that died while the
+        /// pool was not looking.
+        /// </summary>
+        internal bool IsDead { get; set; }
+
+        /// <summary>
+        /// Counts calls to <see cref="IsConnectionAlive"/>. Settable so a test can zero it after
+        /// arranging and observe only the probes made by the operation under test.
+        /// </summary>
+        internal int LivenessProbeCount { get; set; }
+
+        internal override bool IsConnectionAlive(bool throwOnException = false)
+        {
+            LivenessProbeCount++;
+            return !IsDead;
         }
 
         public override string ToString() => $"MockConnection_{MockId}";

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
@@ -28,6 +28,7 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
     private const int DefaultCreationTimeoutInMilliseconds = 15000;
 
     private IDbConnectionPool _pool;
+    private MockSqlConnectionFactory _connectionFactory = null!;
 
     public ChannelDbConnectionPoolTransactionTest()
     {
@@ -72,8 +73,10 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
             poolGroupOptions
         );
 
+        _connectionFactory = new MockSqlConnectionFactory();
+
         var pool = new ChannelDbConnectionPool(
-            new MockSqlConnectionFactory(),
+            _connectionFactory,
             dbConnectionPoolGroup,
             DbConnectionPoolIdentity.NoIdentity,
             new DbConnectionPoolProviderInfo(),
@@ -601,25 +604,33 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
     /// transaction behind for unrelated work later scheduled onto that same thread -- including
     /// the login-time auto-enlistment that non-pooled connections perform against the ambient
     /// transaction. The pool must pass the transaction explicitly instead of assigning it.
+    ///
+    /// The connection factory runs on exactly the thread the pool does its open work on, so it is
+    /// used here to observe that thread's ambient transaction directly rather than inferring the
+    /// leak from thread pool reuse.
     /// </summary>
     [Fact]
-    public async Task GetConnectionAsync_DoesNotLeakAmbientTransactionOntoThreadPool()
+    public async Task GetConnectionAsync_DoesNotSetAmbientTransactionOnPoolWorkerThread()
     {
-        // Arrange & Act - several async opens under a transaction, each on a thread pool thread.
-        for (int i = 0; i < 8; i++)
-        {
-            using var transaction = new CommittableTransaction();
-            var owner = new SqlConnection();
-            var connection = await GetConnectionAsync(owner, transaction);
-            ReturnConnection(connection, owner);
-            transaction.Rollback();
-        }
+        // Arrange - a transaction the pool must enlist in but must not make ambient.
+        using var transaction = new CommittableTransaction();
+        Assert.Null(Transaction.Current);
 
-        // Assert - no thread pool thread was left with an ambient transaction.
-        for (int i = 0; i < 16; i++)
-        {
-            Assert.Null(await Task.Run(() => Transaction.Current));
-        }
+        // Act
+        var owner = new SqlConnection();
+        var connection = await GetConnectionAsync(owner, transaction);
+
+        // Assert - the open really did happen off the calling thread, and the pool left that
+        // thread's ambient transaction alone while still enlisting the connection.
+        Assert.Equal(1, _connectionFactory.CreateCount);
+        Assert.NotEqual(Environment.CurrentManagedThreadId, _connectionFactory.CreateThreadId);
+        Assert.Null(_connectionFactory.AmbientTransactionAtCreate);
+        Assert.Equal(transaction, connection.EnlistedTransaction);
+
+        ReturnConnection(connection, owner);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
+
+        transaction.Rollback();
     }
 
     /// <summary>
@@ -649,12 +660,58 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         scope.Complete();
     }
 
+    /// <summary>
+    /// The asynchronous equivalent of the case above: when the ambient transaction does flow to
+    /// the caller (a TransactionScope created with
+    /// <see cref="TransactionScopeAsyncFlowOption.Enabled"/>) but the caller supplies no
+    /// transaction in the TaskCompletionSource's AsyncState, the pool must still pick it up. The
+    /// capture happens on the caller's thread before the open is scheduled, so the two paths agree
+    /// on what "the caller's transaction" means.
+    /// </summary>
+    [Fact]
+    public async Task GetConnectionAsync_WithoutAsyncState_UsesAmbientTransactionFromCallersThread()
+    {
+        // Arrange
+        using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+        Transaction? transaction = Transaction.Current;
+        Assert.NotNull(transaction);
+
+        // Act - note that no transaction is passed, so AsyncState is null.
+        var owner = new SqlConnection();
+        var connection = await GetConnectionAsync(owner, transaction: null);
+
+        // Assert
+        Assert.NotNull(connection);
+        Assert.Equal(transaction, connection.EnlistedTransaction);
+
+        ReturnConnection(connection, owner);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
+        Assert.Equal(1, TransactedConnectionsFor(transaction!));
+
+        scope.Complete();
+    }
+
     #endregion
 
     #region Mock Classes
 
     internal class MockSqlConnectionFactory : SqlConnectionFactory
     {
+        /// <summary>
+        /// The value of <see cref="Transaction.Current"/> observed on the thread the pool used to
+        /// create the connection. On the asynchronous path that is the thread pool thread the pool
+        /// runs its open work on, so this is a direct observation of whether the pool assigned the
+        /// ambient transaction there.
+        /// </summary>
+        public Transaction? AmbientTransactionAtCreate { get; private set; }
+
+        /// <summary>
+        /// The managed thread the pool created the connection on.
+        /// </summary>
+        public int CreateThreadId { get; private set; }
+
+        public int CreateCount { get; private set; }
+
         protected override DbConnectionInternal CreateConnection(
             SqlConnectionOptions options,
             ConnectionPoolKey poolKey,
@@ -663,6 +720,9 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
             DbConnection owningConnection,
             TimeoutTimer timeout)
         {
+            AmbientTransactionAtCreate = Transaction.Current;
+            CreateThreadId = Environment.CurrentManagedThreadId;
+            CreateCount++;
             return new MockDbConnectionInternal();
         }
     }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Data;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,14 +10,16 @@ using System.Transactions;
 using Microsoft.Data.Common.ConnectionString;
 using Microsoft.Data.ProviderBase;
 using Microsoft.Data.SqlClient.ConnectionPool;
+using Microsoft.Extensions.Time.Testing;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool;
 
 /// <summary>
-/// Deterministic tests for ChannelDbConnectionPool transaction functionality.
-/// These tests exercise transacted connection pathways with controlled synchronization
-/// to verify correct behavior without relying on probabilistic concurrency.
+/// Tests for <see cref="ChannelDbConnectionPool"/> transaction affinity: routing a returning
+/// connection to the transacted store instead of the idle channel, vending an already-enlisted
+/// connection back to the same transaction, releasing the connection when the transaction ends,
+/// and flowing the ambient transaction on the asynchronous open path.
 /// </summary>
 public class ChannelDbConnectionPoolTransactionTest : IDisposable
 {
@@ -26,7 +27,7 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
     private const int DefaultMinPoolSize = 0;
     private const int DefaultCreationTimeoutInMilliseconds = 15000;
 
-    private IDbConnectionPool _pool = null!;
+    private IDbConnectionPool _pool;
 
     public ChannelDbConnectionPoolTransactionTest()
     {
@@ -35,15 +36,21 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
 
     public void Dispose()
     {
-        // Verify no leaked transactions before cleanup
+        // A transaction entry that outlives its transaction is a leak: the connections it holds
+        // are never returned to general circulation.
         Assert.Empty(_pool.TransactedConnectionPool.TransactedConnections);
 
-        _pool?.Shutdown();
-        _pool?.Clear();
+        _pool.Shutdown();
+        _pool.Clear();
     }
 
     #region Helper Methods
 
+    /// <summary>
+    /// Builds a pool for these tests. A frozen <see cref="FakeTimeProvider"/> is injected so that
+    /// time-driven background maintenance (idle-timeout pruning, warmup and replenishment,
+    /// blocking-period expiry) cannot advance and race the assertions about pool contents.
+    /// </summary>
     private ChannelDbConnectionPool CreatePool(
         int maxPoolSize = DefaultMaxPoolSize,
         int minPoolSize = DefaultMinPoolSize,
@@ -65,19 +72,33 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
             poolGroupOptions
         );
 
-        var connectionFactory = new MockSqlConnectionFactory();
-
         var pool = new ChannelDbConnectionPool(
-            connectionFactory,
+            new MockSqlConnectionFactory(),
             dbConnectionPoolGroup,
             DbConnectionPoolIdentity.NoIdentity,
-            new DbConnectionPoolProviderInfo()
+            new DbConnectionPoolProviderInfo(),
+            timeProvider: new FakeTimeProvider()
         );
 
         pool.Startup();
         return pool;
     }
 
+    /// <summary>
+    /// Tears down the pool built by the constructor and replaces it with one configured
+    /// differently, for the few tests that need non-default pool options.
+    /// </summary>
+    private void ReplaceFixturePool(bool hasTransactionAffinity)
+    {
+        _pool.Shutdown();
+        _pool.Clear();
+        _pool = CreatePool(hasTransactionAffinity: hasTransactionAffinity);
+    }
+
+    /// <summary>
+    /// Opens a connection synchronously. The pool reads the ambient transaction off the calling
+    /// thread on this path.
+    /// </summary>
     private DbConnectionInternal GetConnection(SqlConnection owner)
     {
         _pool.TryGetConnection(
@@ -88,6 +109,12 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         return connection!;
     }
 
+    /// <summary>
+    /// Opens a connection asynchronously, carrying <paramref name="transaction"/> in the
+    /// <see cref="TaskCompletionSource{TResult}"/>'s AsyncState exactly as
+    /// SqlConnection.InternalOpenAsync does. The pool must take the transaction from there,
+    /// because the open runs on a thread pool thread the ambient transaction may not flow to.
+    /// </summary>
     private async Task<DbConnectionInternal> GetConnectionAsync(
         SqlConnection owner,
         Transaction? transaction = null)
@@ -101,903 +128,417 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         return connection ?? await tcs.Task;
     }
 
-    private void ReturnConnection(DbConnectionInternal connection, SqlConnection owner)
-    {
+    private void ReturnConnection(DbConnectionInternal connection, SqlConnection owner) =>
         _pool.ReturnInternalConnection(connection, owner);
+
+    /// <summary>
+    /// Asserts the pool's accounting after a step.
+    /// </summary>
+    /// <param name="count">Total connections owned by the pool, checked out or not. A connection
+    /// parked in the transacted store still holds its pool slot and so is counted here.</param>
+    /// <param name="idleCount">Connections sitting in the idle channel, available to any caller.</param>
+    /// <param name="transactedCount">Connections parked in the transacted store across all
+    /// transactions. These hold a pool slot but are not available to other callers.</param>
+    private void AssertPoolState(int count, int idleCount, int transactedCount)
+    {
+        Assert.Equal(count, _pool.Count);
+        Assert.Equal(idleCount, _pool.IdleCount);
+        Assert.Equal(transactedCount, TotalTransactedConnections());
     }
 
-    private void AssertPoolMetrics()
+    private int TotalTransactedConnections()
     {
-        Assert.True(_pool.Count <= _pool.PoolGroupOptions.MaxPoolSize,
-            $"Pool count ({_pool.Count}) exceeded max pool size ({_pool.PoolGroupOptions.MaxPoolSize})");
-        Assert.True(_pool.Count >= 0,
-            $"Pool count ({_pool.Count}) is negative");
-        Assert.Empty(_pool.TransactedConnectionPool.TransactedConnections);
+        int total = 0;
+        foreach (var entry in _pool.TransactedConnectionPool.TransactedConnections)
+        {
+            total += entry.Value.Count;
+        }
+        return total;
     }
+
+    private int TransactedConnectionsFor(Transaction transaction) =>
+        _pool.TransactedConnectionPool.TransactedConnections.TryGetValue(transaction, out var connections)
+            ? connections.Count
+            : 0;
 
     #endregion
 
-    #region Transaction Routing Tests
+    #region Connection Return Routing
 
+    /// <summary>
+    /// A connection returned while still enlisted must be parked in the transacted store rather
+    /// than the idle channel, so it cannot be vended to a caller in a different transaction. It
+    /// keeps its pool slot while parked.
+    /// </summary>
     [Fact]
-    public void GetConnection_UnderTransaction_RoutesToTransactedPool()
+    public void ReturnConnection_WhileEnlisted_ParksInTransactedStoreNotIdleChannel()
     {
-        // Arrange & Act
+        // Arrange
         using var scope = new TransactionScope();
-        var transaction = Transaction.Current;
+        Transaction? transaction = Transaction.Current;
         Assert.NotNull(transaction);
 
         var owner = new SqlConnection();
-        var conn = GetConnection(owner);
-        Assert.NotNull(conn);
-
-        ReturnConnection(conn, owner);
-
-        // Assert - connection should be in the transacted pool
-        Assert.True(_pool.TransactedConnectionPool.TransactedConnections.ContainsKey(transaction));
-        Assert.Single(_pool.TransactedConnectionPool.TransactedConnections[transaction]);
-
-        scope.Complete();
-    }
-
-    [Fact]
-    public void GetConnection_WithoutTransaction_RoutesToGeneralPool()
-    {
-        // Arrange & Act (no TransactionScope)
-        var owner = new SqlConnection();
-        var conn = GetConnection(owner);
-        Assert.NotNull(conn);
-
-        ReturnConnection(conn, owner);
-
-        // Assert - transacted pool should be empty
-        Assert.Empty(_pool.TransactedConnectionPool.TransactedConnections);
-    }
-
-    [Fact]
-    public void GetConnection_UnderTransaction_ReturnsSameConnectionFromTransactedPool()
-    {
-        // Arrange
-        using var scope = new TransactionScope();
-
-        // Act - first call creates a new connection
-        var owner1 = new SqlConnection();
-        var conn1 = GetConnection(owner1);
-        Assert.NotNull(conn1);
-        ReturnConnection(conn1, owner1);
-
-        // Second call should retrieve the SAME connection from the transacted pool (LIFO)
-        var owner2 = new SqlConnection();
-        var conn2 = GetConnection(owner2);
-        Assert.NotNull(conn2);
-        Assert.Same(conn1, conn2);
-
-        ReturnConnection(conn2, owner2);
-        scope.Complete();
-    }
-
-    [Fact]
-    public async Task GetConnectionAsync_UnderTransaction_ReturnsSameConnectionFromTransactedPool()
-    {
-        // Arrange
-        using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-        var transaction = Transaction.Current;
-
-        // Act - first call creates a new connection
-        var owner1 = new SqlConnection();
-        var conn1 = await GetConnectionAsync(owner1, transaction: transaction);
-        Assert.NotNull(conn1);
-        ReturnConnection(conn1, owner1);
-
-        // Second call should retrieve the SAME connection from the transacted pool
-        var owner2 = new SqlConnection();
-        var conn2 = await GetConnectionAsync(owner2, transaction: transaction);
-        Assert.NotNull(conn2);
-        Assert.Same(conn1, conn2);
-
-        ReturnConnection(conn2, owner2);
-        scope.Complete();
-    }
-
-    [Fact]
-    public void GetConnection_WithTransactionAffinityDisabled_SkipsTransactedPool()
-    {
-        // Arrange
-        _pool.Shutdown();
-        _pool.Clear();
-        _pool = CreatePool(hasTransactionAffinity: false);
-
-        using var scope = new TransactionScope();
+        var connection = GetConnection(owner);
+        Assert.NotNull(connection);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
 
         // Act
-        var owner = new SqlConnection();
-        var conn = GetConnection(owner);
-        Assert.NotNull(conn);
-        ReturnConnection(conn, owner);
+        ReturnConnection(connection, owner);
 
-        // Assert - even though a transaction is active, transacted pool is not used
-        Assert.Empty(_pool.TransactedConnectionPool.TransactedConnections);
+        // Assert
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
+        Assert.Equal(1, TransactedConnectionsFor(transaction!));
 
         scope.Complete();
     }
 
-    #endregion
-
-    #region Transaction Lifecycle Tests
-
+    /// <summary>
+    /// Without an ambient transaction there is nothing to enlist in, so a returning connection
+    /// goes straight back into the idle channel.
+    /// </summary>
     [Fact]
-    public void TransactionCommit_ClearsTransactedPool()
+    public void ReturnConnection_WithoutTransaction_ReturnsToIdleChannel()
     {
-        // Arrange & Act
+        // Arrange
+        var owner = new SqlConnection();
+        var connection = GetConnection(owner);
+        Assert.NotNull(connection);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
+
+        // Act
+        ReturnConnection(connection, owner);
+
+        // Assert
+        AssertPoolState(count: 1, idleCount: 1, transactedCount: 0);
+    }
+
+    /// <summary>
+    /// The pool deactivates a returning connection before reading its enlistment, and deactivation
+    /// is what detaches a completed transaction. A connection returned after its transaction has
+    /// already ended must therefore land in the idle channel, not be parked under a dead
+    /// transaction where nothing would ever release it.
+    /// </summary>
+    [Fact]
+    public void ReturnConnection_AfterTransactionCompleted_ReturnsToIdleChannel()
+    {
+        // Arrange
+        var owner = new SqlConnection();
+        DbConnectionInternal connection;
         using (var scope = new TransactionScope())
         {
-            var owner = new SqlConnection();
-            var conn = GetConnection(owner);
-            Assert.NotNull(conn);
-            ReturnConnection(conn, owner);
-
-            // While transaction is active, connection should be in transacted pool
-            Assert.Single(_pool.TransactedConnectionPool.TransactedConnections);
-
+            connection = GetConnection(owner);
+            Assert.NotNull(connection);
             scope.Complete();
         }
 
-        // Assert - after transaction completes, transacted pool should be empty
-        AssertPoolMetrics();
+        // Act - the transaction is fully disposed by this point.
+        ReturnConnection(connection, owner);
+
+        // Assert
+        AssertPoolState(count: 1, idleCount: 1, transactedCount: 0);
     }
 
+    /// <summary>
+    /// A pool with automatic enlistment disabled must never bind a connection to the ambient
+    /// transaction, so the transacted store stays out of the picture entirely.
+    /// </summary>
     [Fact]
-    public void TransactionRollback_ClearsTransactedPool()
+    public void ReturnConnection_WithTransactionAffinityDisabled_ReturnsToIdleChannel()
     {
-        // Arrange & Act
-        using (var scope = new TransactionScope())
-        {
-            var owner = new SqlConnection();
-            var conn = GetConnection(owner);
-            Assert.NotNull(conn);
-            ReturnConnection(conn, owner);
+        // Arrange
+        ReplaceFixturePool(hasTransactionAffinity: false);
 
-            Assert.Single(_pool.TransactedConnectionPool.TransactedConnections);
+        using var scope = new TransactionScope();
+        var owner = new SqlConnection();
+        var connection = GetConnection(owner);
+        Assert.NotNull(connection);
 
-            // Don't call scope.Complete() — triggers rollback
-        }
+        // Act
+        ReturnConnection(connection, owner);
 
-        // Assert - transacted pool should be empty after rollback too
-        AssertPoolMetrics();
+        // Assert
+        AssertPoolState(count: 1, idleCount: 1, transactedCount: 0);
+
+        scope.Complete();
     }
 
+    /// <summary>
+    /// Returning to a pool that has already shut down destroys the connection instead of pooling
+    /// it, and must not throw.
+    /// </summary>
     [Fact]
-    public void MultipleGetReturn_SameTransaction_ReusesConnection()
+    public void ReturnConnection_ToShutDownPool_DestroysConnection()
     {
         // Arrange
         using var scope = new TransactionScope();
-        var transaction = Transaction.Current;
-        Assert.NotNull(transaction);
+        var owner = new SqlConnection();
+        var connection = GetConnection(owner);
+        Assert.NotNull(connection);
 
-        // Act - get and return multiple times within same transaction
-        for (int i = 0; i < 10; i++)
-        {
-            var owner = new SqlConnection();
-            var conn = GetConnection(owner);
-            Assert.NotNull(conn);
-            ReturnConnection(conn, owner);
-        }
+        _pool.Shutdown();
 
-        // Assert - only one connection should be in the transacted pool
-        Assert.Single(_pool.TransactedConnectionPool.TransactedConnections[transaction]);
+        // Act
+        ReturnConnection(connection, owner);
 
-        scope.Complete();
-    }
-
-    [Fact]
-    public async Task MultipleGetReturn_SameTransaction_Async_ReusesConnection()
-    {
-        // Arrange
-        using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-        var transaction = Transaction.Current;
-        Assert.NotNull(transaction);
-
-        // Act - get and return multiple times within same transaction
-        for (int i = 0; i < 10; i++)
-        {
-            var owner = new SqlConnection();
-            var conn = await GetConnectionAsync(owner, transaction: transaction);
-            Assert.NotNull(conn);
-            ReturnConnection(conn, owner);
-        }
-
-        // Assert - only one connection should be in the transacted pool
-        Assert.Single(_pool.TransactedConnectionPool.TransactedConnections[transaction]);
-
-        scope.Complete();
-    }
-
-    [Fact]
-    public void AlternatingCommitAndRollback_MaintainsConsistentState()
-    {
-        // Act - alternate between commit and rollback
-        for (int i = 0; i < 20; i++)
-        {
-            using var scope = new TransactionScope();
-            var owner = new SqlConnection();
-            var conn = GetConnection(owner);
-            Assert.NotNull(conn);
-            ReturnConnection(conn, owner);
-
-            if (i % 2 == 0)
-            {
-                scope.Complete();
-            }
-            // else: rollback (no Complete)
-        }
-
-        // Assert
-        AssertPoolMetrics();
+        // Assert - Dispose() dooms the connection and clears its pool back-reference.
+        Assert.True(connection.IsConnectionDoomed,
+            "A connection returned to a shut-down pool should be destroyed, not pooled.");
+        Assert.Null(connection.Pool);
+        AssertPoolState(count: 0, idleCount: 0, transactedCount: 0);
     }
 
     #endregion
 
-    #region Nested Transaction Tests
+    #region Vending From The Transacted Store
 
+    /// <summary>
+    /// Round trip: a second request inside the same transaction must be served the connection that
+    /// is already enlisted in it, rather than a fresh connection. Reusing it is what keeps the
+    /// transaction from being promoted to a distributed one.
+    /// </summary>
     [Fact]
-    public void NestedTransaction_Required_SharesSameTransactedEntry()
+    public void GetConnection_UnderSameTransaction_VendsTheAlreadyEnlistedConnection()
     {
         // Arrange
-        using var outerScope = new TransactionScope();
-        var outerTxn = Transaction.Current;
-        Assert.NotNull(outerTxn);
+        using var scope = new TransactionScope();
+        Transaction? transaction = Transaction.Current;
+        Assert.NotNull(transaction);
 
         var owner1 = new SqlConnection();
-        var conn1 = GetConnection(owner1);
-        Assert.NotNull(conn1);
-        ReturnConnection(conn1, owner1);
+        var connection1 = GetConnection(owner1);
+        Assert.NotNull(connection1);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
 
-        // Act - nested scope with Required shares the same transaction
-        using (var innerScope = new TransactionScope(TransactionScopeOption.Required))
-        {
-            Assert.Same(outerTxn, Transaction.Current);
+        ReturnConnection(connection1, owner1);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
 
-            var owner2 = new SqlConnection();
-            var conn2 = GetConnection(owner2);
-            Assert.NotNull(conn2);
-            Assert.Same(conn1, conn2); // Same transaction -> same connection from transacted pool
-            ReturnConnection(conn2, owner2);
+        // Act
+        var owner2 = new SqlConnection();
+        var connection2 = GetConnection(owner2);
 
-            // Only one transaction tracked
-            Assert.Single(_pool.TransactedConnectionPool.TransactedConnections);
+        // Assert
+        Assert.Same(connection1, connection2);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
 
-            innerScope.Complete();
-        }
+        ReturnConnection(connection2, owner2);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
+        Assert.Equal(1, TransactedConnectionsFor(transaction!));
 
-        outerScope.Complete();
+        scope.Complete();
     }
 
+    /// <summary>
+    /// The asynchronous path must reuse the enlisted connection exactly as the synchronous path
+    /// does, even though it runs the open on a thread pool thread.
+    /// </summary>
     [Fact]
-    public void NestedTransaction_RequiresNew_CreatesSeparateTransactedEntry()
+    public async Task GetConnectionAsync_UnderSameTransaction_VendsTheAlreadyEnlistedConnection()
+    {
+        // Arrange
+        using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+        Transaction? transaction = Transaction.Current;
+        Assert.NotNull(transaction);
+
+        var owner1 = new SqlConnection();
+        var connection1 = await GetConnectionAsync(owner1, transaction);
+        Assert.NotNull(connection1);
+        ReturnConnection(connection1, owner1);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
+
+        // Act
+        var owner2 = new SqlConnection();
+        var connection2 = await GetConnectionAsync(owner2, transaction);
+
+        // Assert
+        Assert.Same(connection1, connection2);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
+
+        ReturnConnection(connection2, owner2);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
+
+        scope.Complete();
+    }
+
+    /// <summary>
+    /// A connection enlisted in one transaction must never be handed to a caller in a different
+    /// transaction; each transaction gets its own entry in the transacted store.
+    /// </summary>
+    [Fact]
+    public void GetConnection_UnderDifferentTransaction_DoesNotVendTheEnlistedConnection()
     {
         // Arrange
         using var outerScope = new TransactionScope();
-        var outerTxn = Transaction.Current;
-        Assert.NotNull(outerTxn);
+        Transaction? outerTransaction = Transaction.Current;
+        Assert.NotNull(outerTransaction);
 
         var owner1 = new SqlConnection();
-        var conn1 = GetConnection(owner1);
-        Assert.NotNull(conn1);
-        ReturnConnection(conn1, owner1);
+        var connection1 = GetConnection(owner1);
+        ReturnConnection(connection1, owner1);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
 
-        // Act - nested scope with RequiresNew creates a new transaction
+        // Act - RequiresNew starts an unrelated transaction.
         using (var innerScope = new TransactionScope(TransactionScopeOption.RequiresNew))
         {
-            var innerTxn = Transaction.Current;
-            Assert.NotNull(innerTxn);
-            Assert.NotEqual(outerTxn, innerTxn);
+            Transaction? innerTransaction = Transaction.Current;
+            Assert.NotEqual(outerTransaction, innerTransaction);
 
             var owner2 = new SqlConnection();
-            var conn2 = GetConnection(owner2);
-            Assert.NotNull(conn2);
-            Assert.NotSame(conn1, conn2); // Different transaction -> different connection
-            ReturnConnection(conn2, owner2);
+            var connection2 = GetConnection(owner2);
 
-            // Two separate transactions tracked
-            Assert.Equal(2, _pool.TransactedConnectionPool.TransactedConnections.Count);
+            // Assert - a fresh connection, because connection1 belongs to the outer transaction.
+            Assert.NotSame(connection1, connection2);
+            AssertPoolState(count: 2, idleCount: 0, transactedCount: 1);
+
+            ReturnConnection(connection2, owner2);
+            AssertPoolState(count: 2, idleCount: 0, transactedCount: 2);
+            Assert.Equal(1, TransactedConnectionsFor(outerTransaction!));
+            Assert.Equal(1, TransactedConnectionsFor(innerTransaction!));
 
             innerScope.Complete();
         }
+
+        // Completing the inner transaction releases only its connection; the outer transaction's
+        // connection stays parked.
+        AssertPoolState(count: 2, idleCount: 1, transactedCount: 1);
+        Assert.Equal(1, TransactedConnectionsFor(outerTransaction!));
 
         outerScope.Complete();
     }
 
-    [Fact]
-    public void NestedTransaction_RequiresNew_CompletesIndependently()
-    {
-        // Arrange & Act
-        using (var outerScope = new TransactionScope())
-        {
-            var owner1 = new SqlConnection();
-            var conn1 = GetConnection(owner1);
-            Assert.NotNull(conn1);
-            ReturnConnection(conn1, owner1);
-
-            using (var innerScope = new TransactionScope(TransactionScopeOption.RequiresNew))
-            {
-                var owner2 = new SqlConnection();
-                var conn2 = GetConnection(owner2);
-                Assert.NotNull(conn2);
-                ReturnConnection(conn2, owner2);
-                innerScope.Complete();
-            }
-
-            // Inner transaction completed - its entry should be cleared
-            // Outer transaction entry should still exist
-            Assert.Single(_pool.TransactedConnectionPool.TransactedConnections);
-
-            outerScope.Complete();
-        }
-
-        // Both completed
-        AssertPoolMetrics();
-    }
-
-    [Fact]
-    public void DeeplyNestedTransactions_RequiresNew_AllTrackedSeparately()
-    {
-        // Arrange & Act
-        using var scope1 = new TransactionScope();
-        var owner1 = new SqlConnection();
-        var conn1 = GetConnection(owner1);
-        ReturnConnection(conn1, owner1);
-
-        using var scope2 = new TransactionScope(TransactionScopeOption.RequiresNew);
-        var owner2 = new SqlConnection();
-        var conn2 = GetConnection(owner2);
-        ReturnConnection(conn2, owner2);
-
-        using var scope3 = new TransactionScope(TransactionScopeOption.RequiresNew);
-        var owner3 = new SqlConnection();
-        var conn3 = GetConnection(owner3);
-        ReturnConnection(conn3, owner3);
-
-        // Assert - three separate transactions tracked
-        Assert.Equal(3, _pool.TransactedConnectionPool.TransactedConnections.Count);
-
-        scope3.Complete();
-        scope2.Complete();
-        scope1.Complete();
-    }
-
-    [Fact]
-    public void DeeplyNestedTransactions_Required_AllShareOneEntry()
-    {
-        // Arrange & Act
-        using var scope1 = new TransactionScope();
-        var txn = Transaction.Current;
-        var owner1 = new SqlConnection();
-        var conn1 = GetConnection(owner1);
-        ReturnConnection(conn1, owner1);
-
-        using var scope2 = new TransactionScope(TransactionScopeOption.Required);
-        Assert.Same(txn, Transaction.Current);
-        var owner2 = new SqlConnection();
-        var conn2 = GetConnection(owner2);
-        Assert.Same(conn1, conn2);
-        ReturnConnection(conn2, owner2);
-
-        using var scope3 = new TransactionScope(TransactionScopeOption.Required);
-        Assert.Same(txn, Transaction.Current);
-        var owner3 = new SqlConnection();
-        var conn3 = GetConnection(owner3);
-        Assert.Same(conn1, conn3);
-        ReturnConnection(conn3, owner3);
-
-        // Assert - single transaction entry
-        Assert.Single(_pool.TransactedConnectionPool.TransactedConnections);
-
-        scope3.Complete();
-        scope2.Complete();
-        scope1.Complete();
-    }
-
     #endregion
 
-    #region Mixed Transacted and Non-Transacted Tests
+    #region Transaction Completion
 
+    /// <summary>
+    /// Committing releases the parked connection back into the idle channel, where it becomes
+    /// available to any caller.
+    /// </summary>
     [Fact]
-    public void MixedWorkload_AlternatingTransactedAndNonTransacted()
-    {
-        // Act - alternate between transacted and non-transacted
-        for (int i = 0; i < 10; i++)
-        {
-            if (i % 2 == 0)
-            {
-                using var scope = new TransactionScope();
-                var owner = new SqlConnection();
-                var conn = GetConnection(owner);
-                Assert.NotNull(conn);
-                ReturnConnection(conn, owner);
-                scope.Complete();
-            }
-            else
-            {
-                var owner = new SqlConnection();
-                var conn = GetConnection(owner);
-                Assert.NotNull(conn);
-                ReturnConnection(conn, owner);
-            }
-        }
-
-        // Assert
-        AssertPoolMetrics();
-    }
-
-    #endregion
-
-    #region Shared Transaction Tests
-
-    [Fact]
-    public void SharedTransaction_DependentScopes_UseTransactedPool()
+    public void TransactionCommit_ReturnsParkedConnectionToIdleChannel()
     {
         // Arrange
-        using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-        var transaction = Transaction.Current;
-        Assert.NotNull(transaction);
-
-        // Act - first connection
-        var owner1 = new SqlConnection();
-        var conn1 = GetConnection(owner1);
-        Assert.NotNull(conn1);
-        ReturnConnection(conn1, owner1);
-
-        // Use dependent scope on same transaction
-        using (var innerScope = new TransactionScope(transaction))
-        {
-            Assert.Same(transaction, Transaction.Current);
-            var owner2 = new SqlConnection();
-            var conn2 = GetConnection(owner2);
-            Assert.NotNull(conn2);
-            Assert.Same(conn1, conn2); // Same transaction -> same connection
-            ReturnConnection(conn2, owner2);
-            innerScope.Complete();
-        }
-
-        // Assert - still one transaction entry
-        Assert.Single(_pool.TransactedConnectionPool.TransactedConnections);
-        Assert.Single(_pool.TransactedConnectionPool.TransactedConnections[transaction]);
-
-        scope.Complete();
-    }
-
-    #endregion
-
-    #region Pool Saturation with Transactions Tests
-
-    [Fact]
-    public void PoolSaturation_BlocksUntilConnectionAvailable()
-    {
-        // Arrange - small pool
-        _pool.Shutdown();
-        _pool.Clear();
-        _pool = CreatePool(maxPoolSize: 1);
-
-        using var allAcquired = new ManualResetEventSlim(false);
-        using var releaseFirst = new ManualResetEventSlim(false);
-
-        var saturatingTask = Task.Run(() =>
-            {
-                using var scope = new TransactionScope();
-                var owner = new SqlConnection();
-                var conn = GetConnection(owner);
-                Assert.NotNull(conn);
-
-                allAcquired.Set(); // Signal that this connection is held
-
-                Assert.True(releaseFirst.Wait(TimeSpan.FromSeconds(15)),
-                    "Timed out waiting for releaseFirst signal.");
-
-                ReturnConnection(conn, owner);
-                scope.Complete();
-            });
-
-        Assert.True(allAcquired.Wait(TimeSpan.FromSeconds(10)),
-            "Timed out waiting for connection to be acquired.");
-        Assert.Equal(1, _pool.Count);
-
-        using var acquired = new ManualResetEventSlim(false);
-        var waitingTask = Task.Run(() =>
-        {
-            using var scope = new TransactionScope();
-            var owner = new SqlConnection();
-            var conn = GetConnection(owner);
-            Assert.NotNull(conn);
-            acquired.Set();
-            ReturnConnection(conn, owner);
-            scope.Complete();
-        });
-
-        // Give the waiting task time to block — it should NOT complete yet
-        Assert.False(acquired.Wait(TimeSpan.FromMilliseconds(500)),
-            "Waiting task should not have acquired a connection while pool is saturated");
-
-        // Release one connection to unblock the waiting task
-        releaseFirst.Set();
-
-        // Now the waiting task should complete
-        Assert.True(waitingTask.Wait(TimeSpan.FromSeconds(15)),
-            "Waiting task should have completed after a connection was released");
-        Assert.True(acquired.IsSet);
-
-        // Cleanup remaining held connections
-        Task.WaitAll(saturatingTask);
-    }
-
-    #endregion
-
-    #region Controlled Concurrency Tests
-
-    // Flaky under CI load only (never reproduces locally): the two worker tasks are
-    // scheduled via Task.Run on the thread pool. On a loaded agent the pool can be slow to
-    // spin up a worker, so task1 starts late and fails to signal task1Returned within
-    // task2's 10s wait, producing a WaitAll timeout. That is thread-pool starvation, not a
-    // pool/transaction defect.
-    [Trait("Category", "flaky")]
-    [Fact]
-    public void TwoThreads_SharedTransaction_AccessSameTransactedEntry()
-    {
-        // Arrange
-        // Use 3-phase synchronization so task1 gets AND returns before task2 requests.
-        // This ensures the connection is back in the transacted pool for task2 to reuse.
-        using var task1Returned = new ManualResetEventSlim(false);
-        using var task2Done = new ManualResetEventSlim(false);
-        DbConnectionInternal? connFromTask1 = null;
-        DbConnectionInternal? connFromTask2 = null;
-
-        using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-        var transaction = Transaction.Current;
-        Assert.NotNull(transaction);
-
-        // Act - two threads sharing the same transaction, sequenced so the
-        // transacted pool can vend the same connection to both.
-        var task1 = Task.Run(() =>
-        {
-            using var innerScope = new TransactionScope(transaction);
-            var owner = new SqlConnection();
-            connFromTask1 = GetConnection(owner);
-            Assert.NotNull(connFromTask1);
-
-            // Return the connection so it's available in the transacted pool
-            ReturnConnection(connFromTask1, owner);
-            innerScope.Complete();
-
-            task1Returned.Set(); // Signal: connection is back in the transacted pool
-        });
-
-        var task2 = Task.Run(() =>
-        {
-            // Wait until task1 has returned the connection to the transacted pool
-            Assert.True(task1Returned.Wait(TimeSpan.FromSeconds(10)),
-                "Timed out waiting for task1 to return its connection.");
-
-            using var innerScope = new TransactionScope(transaction);
-            var owner = new SqlConnection();
-            connFromTask2 = GetConnection(owner);
-            Assert.NotNull(connFromTask2);
-            ReturnConnection(connFromTask2, owner);
-            innerScope.Complete();
-        });
-
-        Task.WaitAll(task1, task2);
-
-        // Both tasks should have received the same connection via the transacted pool
-        Assert.Same(connFromTask1, connFromTask2);
-        scope.Complete();
-    }
-
-    [Fact]
-    public async Task TwoThreads_SeparateTransactions_Async_IsolatedTransactedEntries()
-    {
-        // Arrange
-        using var barrier = new SemaphoreSlim(0, 2);
-
-        // Act
-        var task1 = Task.Run(async () =>
-        {
-            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-            var transaction = Transaction.Current;
-            var owner = new SqlConnection();
-            var conn = await GetConnectionAsync(owner, transaction: transaction);
-            Assert.NotNull(conn);
-            ReturnConnection(conn, owner);
-
-            barrier.Release(); // Signal ready
-            await barrier.WaitAsync(); // Wait for other task
-
-            scope.Complete();
-        });
-
-        var task2 = Task.Run(async () =>
-        {
-            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-            var transaction = Transaction.Current;
-            var owner = new SqlConnection();
-            var conn = await GetConnectionAsync(owner, transaction: transaction);
-            Assert.NotNull(conn);
-            ReturnConnection(conn, owner);
-
-            barrier.Release(); // Signal ready
-            await barrier.WaitAsync(); // Wait for other task
-
-            scope.Complete();
-        });
-
-        await Task.WhenAll(task1, task2);
-
-        // Assert
-        AssertPoolMetrics();
-    }
-
-    #endregion
-
-    #region Pool Shutdown with Transactions Tests
-
-    [Fact]
-    public void PoolShutdown_AfterTransactionComplete_NoLeaks()
-    {
-        // Arrange
+        DbConnectionInternal connection;
         using (var scope = new TransactionScope())
         {
             var owner = new SqlConnection();
-            var conn = GetConnection(owner);
-            Assert.NotNull(conn);
-            ReturnConnection(conn, owner);
-            scope.Complete();
-        }
+            connection = GetConnection(owner);
+            ReturnConnection(connection, owner);
+            AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
 
-        // Act
-        _pool.Shutdown();
-
-        // Assert
-        AssertPoolMetrics();
-    }
-
-    [Fact]
-    public void PoolShutdown_WhileConnectionHeld_NoException()
-    {
-        // Arrange
-        using var scope = new TransactionScope();
-        var owner = new SqlConnection();
-        var conn = GetConnection(owner);
-        Assert.NotNull(conn);
-
-        // Act - shutdown while connection is held (not yet returned)
-        _pool.Shutdown();
-
-        // Return after shutdown — the pool deactivates and disposes the connection
-        // rather than returning it to the pool. Verify this doesn't throw.
-        ReturnConnection(conn, owner);
-
-        // Assert
-        // The connection should have been deactivated and disposed (not returned to the pool).
-        // After Dispose(), IsConnectionDoomed is set to true and Pool is set to null.
-        Assert.True(conn.IsConnectionDoomed,
-            "Connection should be doomed after returning to a shut-down pool.");
-        Assert.Null(conn.Pool);
-    }
-
-    #endregion
-
-    #region Transaction Complete Before Return Tests
-
-    [Fact]
-    public void TransactionComplete_ThenReturn_ConnectionStillReturned()
-    {
-        // Arrange
-        var owner = new SqlConnection();
-        DbConnectionInternal conn;
-
-        using (var scope = new TransactionScope())
-        {
-            conn = GetConnection(owner);
-            Assert.NotNull(conn);
-            scope.Complete();
-        }
-        // Transaction is fully disposed here
-
-        // Act - return connection after transaction ended
-        ReturnConnection(conn, owner);
-
-        // Assert - no leak, pool metrics consistent
-        AssertPoolMetrics();
-        Assert.True(_pool.Count > 0, "Pool should still have the connection");
-    }
-
-    #endregion
-
-    #region Sequential Transaction Isolation Tests
-
-    [Fact]
-    public void SequentialTransactions_EachGetsOwnTransactedEntry()
-    {
-        // Act - create multiple sequential transactions
-        for (int i = 0; i < 5; i++)
-        {
-            using var scope = new TransactionScope();
-            var transaction = Transaction.Current;
-            Assert.NotNull(transaction);
-
-            var owner = new SqlConnection();
-            var conn = GetConnection(owner);
-            Assert.NotNull(conn);
-            ReturnConnection(conn, owner);
-
-            // Only the current transaction should be tracked
-            Assert.Single(_pool.TransactedConnectionPool.TransactedConnections);
-            Assert.True(_pool.TransactedConnectionPool.TransactedConnections.ContainsKey(transaction));
-
-            scope.Complete();
-        }
-
-        // Assert - after all are done, pool should be clean
-        AssertPoolMetrics();
-    }
-
-    [Fact]
-    public async Task SequentialTransactions_Async_EachGetsOwnTransactedEntry()
-    {
-        // Act - create multiple sequential transactions
-        for (int i = 0; i < 5; i++)
-        {
-            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-            var transaction = Transaction.Current;
-            Assert.NotNull(transaction);
-
-            var owner = new SqlConnection();
-            var conn = await GetConnectionAsync(owner, transaction: transaction);
-            Assert.NotNull(conn);
-            ReturnConnection(conn, owner);
-
-            Assert.Single(_pool.TransactedConnectionPool.TransactedConnections);
-            Assert.True(_pool.TransactedConnectionPool.TransactedConnections.ContainsKey(transaction));
-
+            // Act
             scope.Complete();
         }
 
         // Assert
-        AssertPoolMetrics();
-    }
+        AssertPoolState(count: 1, idleCount: 1, transactedCount: 0);
 
-    [Fact]
-    public void SequentialTransactions_CanReuseConnections()
-    {
-        // Act
-        DbConnectionInternal conn1;
-        DbConnectionInternal conn2;
-        Transaction? txn1;
-        Transaction? txn2;
-
-        using (var scope1 = new TransactionScope())
-        {
-            txn1 = Transaction.Current;
-            var owner1 = new SqlConnection();
-            conn1 = GetConnection(owner1);
-            Assert.NotNull(conn1);
-            ReturnConnection(conn1, owner1);
-            scope1.Complete();
-        }
-
-        using (var scope2 = new TransactionScope())
-        {
-            txn2 = Transaction.Current;
-            var owner2 = new SqlConnection();
-            conn2 = GetConnection(owner2);
-            Assert.NotNull(conn2);
-            ReturnConnection(conn2, owner2);
-            scope2.Complete();
-        }
-
-        // Assert
-        // The connection was returned to the general pool and picked up by the second transaction
-        Assert.NotSame(txn1, txn2);
-        Assert.Same(conn1, conn2);
-        AssertPoolMetrics();
-    }
-
-    #endregion
-
-    #region Transacted Pool Plumbing Tests
-
-    [Fact]
-    public void TransactionCompletion_ReturnsConnectionToIdleChannel()
-    {
-        // Arrange - park a connection in the transacted pool.
-        DbConnectionInternal conn;
-        using (var scope = new TransactionScope())
-        {
-            var owner = new SqlConnection();
-            conn = GetConnection(owner);
-            Assert.NotNull(conn);
-            ReturnConnection(conn, owner);
-
-            // While the transaction is live the connection is held by the transacted pool and is
-            // deliberately absent from the idle channel.
-            Assert.Single(_pool.TransactedConnectionPool.TransactedConnections);
-            Assert.Equal(0, _pool.IdleCount);
-
-            scope.Complete();
-        }
-
-        // Assert - completion drives TransactionEnded -> PutObjectFromTransactedPool, which puts
-        // the connection back into general circulation.
-        Assert.Empty(_pool.TransactedConnectionPool.TransactedConnections);
-        Assert.Equal(1, _pool.IdleCount);
-        Assert.Equal(1, _pool.Count);
-
-        // The connection is now reusable by a caller with no ambient transaction.
+        // The released connection is reusable by a caller with no ambient transaction.
         var owner2 = new SqlConnection();
-        var conn2 = GetConnection(owner2);
-        Assert.Same(conn, conn2);
-        ReturnConnection(conn2, owner2);
+        var connection2 = GetConnection(owner2);
+        Assert.Same(connection, connection2);
+        ReturnConnection(connection2, owner2);
     }
 
+    /// <summary>
+    /// Rolling back must release the parked connection just as committing does; otherwise an
+    /// aborted transaction would strand its connection in the transacted store forever.
+    /// </summary>
+    [Fact]
+    public void TransactionRollback_ReturnsParkedConnectionToIdleChannel()
+    {
+        // Arrange
+        using (new TransactionScope())
+        {
+            var owner = new SqlConnection();
+            var connection = GetConnection(owner);
+            ReturnConnection(connection, owner);
+            AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
+
+            // Act - leaving the scope without calling Complete rolls the transaction back.
+        }
+
+        // Assert
+        AssertPoolState(count: 1, idleCount: 1, transactedCount: 0);
+    }
+
+    /// <summary>
+    /// A connection parked in the transacted store survives pool shutdown, because closing it
+    /// would abort a possibly distributed transaction. Once that transaction ends, the shut-down
+    /// pool must destroy the connection rather than return it to circulation.
+    /// </summary>
     [Fact]
     public void TransactionCompletion_AfterShutdown_DestroysConnection()
     {
-        // Arrange - park a connection in the transacted pool, then shut the pool down. The
-        // transacted connection survives the shutdown drain because closing it would abort the
-        // (possibly distributed) transaction.
-        DbConnectionInternal conn;
+        // Arrange
+        DbConnectionInternal connection;
         using (var scope = new TransactionScope())
         {
             var owner = new SqlConnection();
-            conn = GetConnection(owner);
-            Assert.NotNull(conn);
-            ReturnConnection(conn, owner);
+            connection = GetConnection(owner);
+            ReturnConnection(connection, owner);
+            AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
 
-            // Act
+            // Act - the shutdown drain must leave the transacted connection alone.
             _pool.Shutdown();
+            AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
+
             scope.Complete();
         }
 
-        // Assert - a shut-down pool must not re-pool the connection when the transaction ends.
-        Assert.Empty(_pool.TransactedConnectionPool.TransactedConnections);
-        Assert.Equal(0, _pool.IdleCount);
-        Assert.Equal(0, _pool.Count);
-        Assert.True(conn.IsConnectionDoomed);
+        // Assert
+        AssertPoolState(count: 0, idleCount: 0, transactedCount: 0);
+        Assert.True(connection.IsConnectionDoomed,
+            "A shut-down pool must destroy a connection released by its transaction.");
     }
 
+    /// <summary>
+    /// TransactionEnded for a connection that was never parked must be a no-op. It must not push a
+    /// connection that is still checked out into the idle channel, where a second caller could
+    /// pick it up while the first is still using it.
+    /// </summary>
     [Fact]
-    public void TransactionEnded_UnknownConnection_DoesNotPoolConnection()
+    public void TransactionEnded_ForConnectionThatWasNeverParked_LeavesItCheckedOut()
     {
-        // Arrange - a connection that was never parked in the transacted pool.
+        // Arrange
         var owner = new SqlConnection();
-        var conn = GetConnection(owner);
-        Assert.NotNull(conn);
+        var connection = GetConnection(owner);
+        Assert.NotNull(connection);
 
         using var scope = new TransactionScope();
-        var transaction = Transaction.Current;
+        Transaction? transaction = Transaction.Current;
         Assert.NotNull(transaction);
 
         // Act
-        _pool.TransactionEnded(transaction!, conn);
+        _pool.TransactionEnded(transaction!, connection);
 
-        // Assert - nothing to remove, so the connection stays checked out.
-        Assert.Equal(0, _pool.IdleCount);
-        Assert.Equal(1, _pool.Count);
+        // Assert
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
 
-        ReturnConnection(conn, owner);
+        ReturnConnection(connection, owner);
         scope.Complete();
     }
 
+    #endregion
+
+    #region Connection Replacement
+
+    /// <summary>
+    /// Replacing a connection mid-transaction must carry the enlistment across, so the replacement
+    /// is the one that parks in the transacted store when it is returned.
+    /// </summary>
     [Fact]
     public void ReplaceConnection_CarriesEnlistedTransactionToNewConnection()
     {
         // Arrange
         using var scope = new TransactionScope();
-        var transaction = Transaction.Current;
+        Transaction? transaction = Transaction.Current;
         Assert.NotNull(transaction);
 
         var owner = new SqlConnection();
         var oldConnection = GetConnection(owner);
         Assert.NotNull(oldConnection);
-        Assert.Equal(1, _pool.Count);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
 
         // Act
         var newConnection = _pool.ReplaceConnection(
@@ -1005,36 +546,36 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
             oldConnection,
             TimeoutTimer.StartNew(TimeSpan.FromSeconds(15)));
 
-        // Assert - a distinct connection took over the old connection's slot and enlistment.
+        // Assert - a distinct connection took over the old connection's slot.
         Assert.NotNull(newConnection);
         Assert.NotSame(oldConnection, newConnection);
-        Assert.Equal(1, _pool.Count);
         Assert.True(oldConnection.IsConnectionDoomed);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
 
         ReturnConnection(newConnection, owner);
 
-        // The replacement inherited the transaction, so it parks in the transacted pool.
-        Assert.Single(_pool.TransactedConnectionPool.TransactedConnections[transaction!]);
+        // The replacement inherited the transaction, so it parks in the transacted store.
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
+        Assert.Equal(1, TransactedConnectionsFor(transaction!));
 
         scope.Complete();
     }
 
     #endregion
 
-    #region Async Ambient Transaction Flow Tests
+    #region Async Ambient Transaction Flow
 
     /// <summary>
     /// A <see cref="TransactionScope"/> created without <see cref="TransactionScopeAsyncFlowOption.Enabled"/>
-    /// keeps the ambient transaction in thread-static storage, so it is not observable from the thread
-    /// pool thread the pool opens on. The pool must therefore take the transaction from the
-    /// <see cref="TaskCompletionSource{TResult}"/>'s AsyncState, which is where SqlConnection.OpenAsync
-    /// captures it.
+    /// keeps the ambient transaction in thread-static storage, so it is not observable from the
+    /// thread pool thread the pool opens on. The pool must therefore take the transaction from the
+    /// <see cref="TaskCompletionSource{TResult}"/>'s AsyncState. This test uses a transaction that
+    /// is never ambient anywhere, so AsyncState is the only way the pool can learn about it.
     /// </summary>
     [Fact]
     public async Task GetConnectionAsync_AmbientTransactionNotFlowed_StillEnlistsFromAsyncState()
     {
-        // Arrange - a transaction that is never ambient on any thread, so AsyncState is the only
-        // way the pool can learn about it.
+        // Arrange
         using var transaction = new CommittableTransaction();
         Assert.Null(Transaction.Current);
         Assert.Null(await Task.Run(() => Transaction.Current));
@@ -1048,10 +589,8 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         Assert.Equal(transaction, connection.EnlistedTransaction);
 
         ReturnConnection(connection, owner);
-
-        // Being enlisted, the connection parks in the transacted pool rather than the idle channel.
-        Assert.Single(_pool.TransactedConnectionPool.TransactedConnections[transaction]);
-        Assert.Equal(0, _pool.IdleCount);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
+        Assert.Equal(1, TransactedConnectionsFor(transaction));
 
         transaction.Rollback();
     }
@@ -1059,8 +598,8 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
     /// <summary>
     /// Assigning <see cref="Transaction.Current"/> writes to thread-static storage that the
     /// ExecutionContext does not unwind, so doing it on a thread pool thread would leave a stale
-    /// transaction behind for unrelated work later scheduled onto that same thread -- including the
-    /// login-time auto-enlistment that non-pooled connections perform against the ambient
+    /// transaction behind for unrelated work later scheduled onto that same thread -- including
+    /// the login-time auto-enlistment that non-pooled connections perform against the ambient
     /// transaction. The pool must pass the transaction explicitly instead of assigning it.
     /// </summary>
     [Fact]
@@ -1085,17 +624,18 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
 
     /// <summary>
     /// The synchronous path runs on the caller's thread, where the ambient transaction set by a
-    /// TransactionScope is directly observable and must still be honored.
+    /// TransactionScope is directly observable and must still be honored even though no
+    /// transaction is handed to the pool explicitly.
     /// </summary>
     [Fact]
     public void GetConnection_Sync_UsesAmbientTransactionFromCallersThread()
     {
         // Arrange
         using var scope = new TransactionScope();
-        var transaction = Transaction.Current;
+        Transaction? transaction = Transaction.Current;
         Assert.NotNull(transaction);
 
-        // Act - no transaction is handed to the pool explicitly; it must read Transaction.Current.
+        // Act
         var owner = new SqlConnection();
         var connection = GetConnection(owner);
 
@@ -1104,7 +644,7 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         Assert.Equal(transaction, connection.EnlistedTransaction);
 
         ReturnConnection(connection, owner);
-        Assert.Single(_pool.TransactedConnectionPool.TransactedConnections[transaction!]);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
 
         scope.Complete();
     }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
@@ -633,6 +633,10 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
     /// (SqlConnection.OpenAsyncRetry.Retry) the pool is re-entered from a continuation running on
     /// an arbitrary thread, which has no ambient transaction. Reading Transaction.Current there
     /// would silently drop the enlistment, or worse, pick up an unrelated transaction.
+    ///
+    /// No TransactionScope is opened here, so this thread already stands in for that continuation:
+    /// the transaction exists but is not ambient anywhere, and AsyncState is the only channel
+    /// carrying it.
     /// </summary>
     [Fact]
     public async Task GetConnectionAsync_EnteredFromThreadWithoutAmbientTransaction_EnlistsFromAsyncState()
@@ -640,14 +644,10 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         // Arrange
         using var transaction = new CommittableTransaction();
         var owner = new SqlConnection();
+        Assert.Null(Transaction.Current);
 
-        // Act - enter the pool from a thread pool thread with no ambient transaction, the way a
-        // retry continuation does, carrying the transaction only in AsyncState.
-        var connection = await Task.Run(async () =>
-        {
-            Assert.Null(Transaction.Current);
-            return await GetConnectionAsync(owner, transaction);
-        });
+        // Act - carry the transaction only in AsyncState, the way a retry continuation does.
+        var connection = await GetConnectionAsync(owner, transaction);
 
         // Assert
         Assert.NotNull(connection);

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
@@ -573,23 +573,42 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
     #region Async Ambient Transaction Flow
 
     /// <summary>
-    /// A <see cref="TransactionScope"/> created without <see cref="TransactionScopeAsyncFlowOption.Enabled"/>
-    /// keeps the ambient transaction in thread-static storage, so it is not observable from the
-    /// thread pool thread the pool opens on. The pool must therefore take the transaction from the
-    /// <see cref="TaskCompletionSource{TResult}"/>'s AsyncState. This test uses a transaction that
-    /// is never ambient anywhere, so AsyncState is the only way the pool can learn about it.
+    /// The case the AsyncState mechanism exists for. A <see cref="TransactionScope"/> created
+    /// without <see cref="TransactionScopeAsyncFlowOption.Enabled"/> -- the default -- keeps its
+    /// ambient transaction in thread-static storage, so it is ambient on the calling thread but
+    /// does not flow across an await onto the thread pool thread the pool opens on. The connection
+    /// must still enlist, because the transaction is captured on the caller's thread before the
+    /// open is scheduled (see SqlConnection.InternalOpenAsync).
+    ///
+    /// The open is started inside the scope but awaited outside it. That is not incidental: when
+    /// async flow is suppressed the continuation may resume on another thread, and a
+    /// TransactionScope must be disposed on the thread that created it. The scope is given an
+    /// explicit <see cref="CommittableTransaction"/> so that leaving the scope ends the scope
+    /// without ending the transaction the pool is still enlisting in.
     /// </summary>
     [Fact]
-    public async Task GetConnectionAsync_AmbientTransactionNotFlowed_StillEnlistsFromAsyncState()
+    public async Task GetConnectionAsync_WithAsyncFlowDisabled_StillEnlistsInAmbientTransaction()
     {
         // Arrange
         using var transaction = new CommittableTransaction();
-        Assert.Null(Transaction.Current);
-        Assert.Null(await Task.Run(() => Transaction.Current));
-
-        // Act
         var owner = new SqlConnection();
-        var connection = await GetConnectionAsync(owner, transaction);
+        Task<DbConnectionInternal> openTask;
+
+        using (var scope = new TransactionScope(transaction))
+        {
+            Assert.Equal(transaction, Transaction.Current);
+
+            // The transaction really is confined to this thread, so AsyncState is the only way
+            // the pool can learn about it.
+            Assert.Null(Task.Run(() => Transaction.Current).GetAwaiter().GetResult());
+
+            // Act - starting the open captures the ambient transaction synchronously, here, and
+            // hands the rest of the work to a thread pool thread.
+            openTask = GetConnectionAsync(owner);
+            scope.Complete();
+        }
+
+        var connection = await openTask;
 
         // Assert
         Assert.NotNull(connection);
@@ -603,7 +622,38 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
     }
 
     /// <summary>
-    /// Assigning <see cref="Transaction.Current"/> writes to thread-static storage that the
+    /// The pool must take the transaction from AsyncState rather than from whatever is ambient on
+    /// the thread that happens to enter it. TryGetConnection is normally called synchronously from
+    /// the caller's thread, where the two agree -- but on the retry path
+    /// (SqlConnection.OpenAsyncRetry.Retry) the pool is re-entered from a continuation running on
+    /// an arbitrary thread, which has no ambient transaction. Reading Transaction.Current there
+    /// would silently drop the enlistment, or worse, pick up an unrelated transaction.
+    /// </summary>
+    [Fact]
+    public async Task GetConnectionAsync_EnteredFromThreadWithoutAmbientTransaction_EnlistsFromAsyncState()
+    {
+        // Arrange
+        using var transaction = new CommittableTransaction();
+        var owner = new SqlConnection();
+
+        // Act - enter the pool from a thread pool thread with no ambient transaction, the way a
+        // retry continuation does, carrying the transaction only in AsyncState.
+        var connection = await Task.Run(async () =>
+        {
+            Assert.Null(Transaction.Current);
+            return await GetConnectionAsync(owner, transaction);
+        });
+
+        // Assert
+        Assert.NotNull(connection);
+        Assert.Equal(transaction, connection.EnlistedTransaction);
+
+        ReturnConnection(connection, owner);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
+        Assert.Equal(1, TransactedConnectionsFor(transaction));
+
+        transaction.Rollback();
+    }
     /// ExecutionContext does not unwind, so doing it on a thread pool thread would leave a stale
     /// transaction behind for unrelated work later scheduled onto that same thread -- including
     /// the login-time auto-enlistment that non-pooled connections perform against the ambient

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
@@ -150,6 +150,20 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         _pool.ReturnInternalConnection(connection, owner);
 
     /// <summary>
+    /// Awaits a task with a timeout so a test that expects a waiter to be served fails with a clear
+    /// message instead of hanging. Written against <see cref="Task.WhenAny(Task[])"/> because
+    /// Task.WaitAsync does not exist on .NET Framework.
+    /// </summary>
+    private static async Task<T> WithTimeout<T>(Task<T> task, TimeSpan timeout)
+    {
+        Task completed = await Task.WhenAny(task, Task.Delay(timeout)).ConfigureAwait(false);
+        Assert.True(
+            ReferenceEquals(completed, task),
+            $"Timed out after {timeout.TotalSeconds:0.#}s waiting for the task to complete.");
+        return await task.ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Asserts the pool's accounting after a step.
     /// </summary>
     /// <param name="count">Total connections owned by the pool, checked out or not. A connection
@@ -773,7 +787,7 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         }
 
         // Assert - the waiter was handed the released connection rather than timing out.
-        DbConnectionInternal servedConnection = await waiter.Task.WaitAsync(TimeSpan.FromSeconds(15));
+        DbConnectionInternal servedConnection = await WithTimeout(waiter.Task, TimeSpan.FromSeconds(15));
         Assert.Same(parkedConnection, servedConnection);
         AssertEnlistedIn(null, servedConnection);
         AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
@@ -573,18 +573,23 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
     #region Async Ambient Transaction Flow
 
     /// <summary>
-    /// The case the AsyncState mechanism exists for. A <see cref="TransactionScope"/> created
-    /// without <see cref="TransactionScopeAsyncFlowOption.Enabled"/> -- the default -- keeps its
-    /// ambient transaction in thread-static storage, so it is ambient on the calling thread but
-    /// does not flow across an await onto the thread pool thread the pool opens on. The connection
-    /// must still enlist, because the transaction is captured on the caller's thread before the
-    /// open is scheduled (see SqlConnection.InternalOpenAsync).
+    /// A <see cref="TransactionScope"/> created without
+    /// <see cref="TransactionScopeAsyncFlowOption.Enabled"/> -- the default -- keeps its ambient
+    /// transaction in thread-static storage, so it does not flow across an await onto the thread
+    /// pool thread the pool opens on. The connection must still enlist, because the transaction is
+    /// captured on the caller's thread before the open is scheduled (see
+    /// SqlConnection.InternalOpenAsync). This covers that end to end; it does not distinguish
+    /// AsyncState from the caller's ambient transaction, which agree here. See
+    /// <see cref="GetConnectionAsync_EnteredFromThreadWithoutAmbientTransaction_EnlistsFromAsyncState"/>
+    /// for the case that separates them.
     ///
-    /// The open is started inside the scope but awaited outside it. That is not incidental: when
-    /// async flow is suppressed the continuation may resume on another thread, and a
-    /// TransactionScope must be disposed on the thread that created it. The scope is given an
-    /// explicit <see cref="CommittableTransaction"/> so that leaving the scope ends the scope
-    /// without ending the transaction the pool is still enlisting in.
+    /// The open is started inside the scope but awaited outside it. That is not incidental:
+    /// awaiting inside resumes the continuation on a thread pool thread, and disposing the scope
+    /// there throws "A TransactionScope must be disposed on the same thread that it was created."
+    /// That is the very limitation TransactionScopeAsyncFlowOption.Enabled exists to remove, so a
+    /// test of the suppressed case cannot avoid it. The scope is given an explicit
+    /// <see cref="CommittableTransaction"/> so that leaving the scope ends the scope without
+    /// ending the transaction the pool is still enlisting in.
     /// </summary>
     [Fact]
     public async Task GetConnectionAsync_WithAsyncFlowDisabled_StillEnlistsInAmbientTransaction()
@@ -597,16 +602,6 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         using (var scope = new TransactionScope(transaction))
         {
             Assert.Equal(transaction, Transaction.Current);
-
-            // The transaction really is confined to this thread, so AsyncState is the only way
-            // the pool can learn about it. Probed on a dedicated thread rather than with
-            // Task.Run: blocking on a queued task lets the runtime execute it inline on this
-            // thread, which would observe this thread's own ambient transaction and prove nothing.
-            Transaction? observedOnAnotherThread = null;
-            var probe = new Thread(() => observedOnAnotherThread = Transaction.Current);
-            probe.Start();
-            probe.Join();
-            Assert.Null(observedOnAnotherThread);
 
             // Act - starting the open captures the ambient transaction synchronously, here, and
             // hands the rest of the work to a thread pool thread.

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
@@ -168,6 +168,19 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
             ? connections.Count
             : 0;
 
+    /// <summary>
+    /// Asserts which transaction a connection is bound to, complementing the pool-state assertions:
+    /// AssertPoolState says where the connection was filed, this says what it is actually enlisted
+    /// in. Pass null to assert the connection is not enlisted at all.
+    /// </summary>
+    /// <remarks>
+    /// Compared by equality rather than reference because the EnlistedTransaction setter stores a
+    /// clone, so that the connection does not hold the caller's transaction past the end of its
+    /// using block.
+    /// </remarks>
+    private static void AssertEnlistedIn(Transaction? expected, DbConnectionInternal connection) =>
+        Assert.Equal(expected, connection.EnlistedTransaction);
+
     #endregion
 
     #region Connection Return Routing
@@ -188,6 +201,7 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         var owner = new SqlConnection();
         var connection = GetConnection(owner);
         Assert.NotNull(connection);
+        AssertEnlistedIn(transaction, connection);
         AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
 
         // Act
@@ -196,6 +210,10 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         // Assert
         AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
         Assert.Equal(1, TransactedConnectionsFor(transaction!));
+
+        // The connection stays bound to the transaction while parked, which is what makes it
+        // ineligible for a caller in any other transaction.
+        AssertEnlistedIn(transaction, connection);
 
         scope.Complete();
     }
@@ -211,20 +229,22 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         var owner = new SqlConnection();
         var connection = GetConnection(owner);
         Assert.NotNull(connection);
+        AssertEnlistedIn(null, connection);
         AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
 
         // Act
         ReturnConnection(connection, owner);
 
         // Assert
+        AssertEnlistedIn(null, connection);
         AssertPoolState(count: 1, idleCount: 1, transactedCount: 0);
     }
 
     /// <summary>
-    /// The pool deactivates a returning connection before reading its enlistment, and deactivation
-    /// is what detaches a completed transaction. A connection returned after its transaction has
-    /// already ended must therefore land in the idle channel, not be parked under a dead
-    /// transaction where nothing would ever release it.
+    /// A connection whose transaction has already ended must land in the idle channel, not be
+    /// parked under a dead transaction where nothing would ever release it. The enlistment is
+    /// dropped when the transaction completes, so by the time the connection is returned there is
+    /// nothing left to park it under.
     /// </summary>
     [Fact]
     public void ReturnConnection_AfterTransactionCompleted_ReturnsToIdleChannel()
@@ -236,8 +256,12 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         {
             connection = GetConnection(owner);
             Assert.NotNull(connection);
+            AssertEnlistedIn(Transaction.Current, connection);
             scope.Complete();
         }
+
+        // The completed transaction detached itself from the connection.
+        AssertEnlistedIn(null, connection);
 
         // Act - the transaction is fully disposed by this point.
         ReturnConnection(connection, owner);
@@ -261,10 +285,15 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         var connection = GetConnection(owner);
         Assert.NotNull(connection);
 
+        // The ambient transaction exists but must not reach the connection.
+        Assert.NotNull(Transaction.Current);
+        AssertEnlistedIn(null, connection);
+
         // Act
         ReturnConnection(connection, owner);
 
         // Assert
+        AssertEnlistedIn(null, connection);
         AssertPoolState(count: 1, idleCount: 1, transactedCount: 0);
 
         scope.Complete();
@@ -326,6 +355,7 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
 
         // Assert
         Assert.Same(connection1, connection2);
+        AssertEnlistedIn(transaction, connection2);
         AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
 
         ReturnConnection(connection2, owner2);
@@ -350,6 +380,7 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         var owner1 = new SqlConnection();
         var connection1 = await GetConnectionAsync(owner1, transaction);
         Assert.NotNull(connection1);
+        AssertEnlistedIn(transaction, connection1);
         ReturnConnection(connection1, owner1);
         AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
 
@@ -359,6 +390,7 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
 
         // Assert
         Assert.Same(connection1, connection2);
+        AssertEnlistedIn(transaction, connection2);
         AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
 
         ReturnConnection(connection2, owner2);
@@ -381,13 +413,15 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
 
         var owner1 = new SqlConnection();
         var connection1 = GetConnection(owner1);
+        AssertEnlistedIn(outerTransaction, connection1);
         ReturnConnection(connection1, owner1);
         AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
 
         // Act - RequiresNew starts an unrelated transaction.
+        Transaction? innerTransaction;
         using (var innerScope = new TransactionScope(TransactionScopeOption.RequiresNew))
         {
-            Transaction? innerTransaction = Transaction.Current;
+            innerTransaction = Transaction.Current;
             Assert.NotEqual(outerTransaction, innerTransaction);
 
             var owner2 = new SqlConnection();
@@ -395,7 +429,14 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
 
             // Assert - a fresh connection, because connection1 belongs to the outer transaction.
             Assert.NotSame(connection1, connection2);
+            AssertEnlistedIn(innerTransaction, connection2);
+            AssertEnlistedIn(outerTransaction, connection1);
             AssertPoolState(count: 2, idleCount: 0, transactedCount: 1);
+
+            // The store holds only the outer transaction's connection, so connection2 was newly
+            // created rather than taken from the store.
+            Assert.Equal(1, TransactedConnectionsFor(outerTransaction!));
+            Assert.Equal(0, TransactedConnectionsFor(innerTransaction!));
 
             ReturnConnection(connection2, owner2);
             AssertPoolState(count: 2, idleCount: 0, transactedCount: 2);
@@ -409,6 +450,7 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         // connection stays parked.
         AssertPoolState(count: 2, idleCount: 1, transactedCount: 1);
         Assert.Equal(1, TransactedConnectionsFor(outerTransaction!));
+        Assert.Equal(0, TransactedConnectionsFor(innerTransaction!));
 
         outerScope.Complete();
     }
@@ -440,10 +482,14 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         // Assert
         AssertPoolState(count: 1, idleCount: 1, transactedCount: 0);
 
+        // The transaction released it, so it carries no enlistment into general circulation.
+        AssertEnlistedIn(null, connection);
+
         // The released connection is reusable by a caller with no ambient transaction.
         var owner2 = new SqlConnection();
         var connection2 = GetConnection(owner2);
         Assert.Same(connection, connection2);
+        AssertEnlistedIn(null, connection2);
         ReturnConnection(connection2, owner2);
     }
 
@@ -455,10 +501,11 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
     public void TransactionRollback_ReturnsParkedConnectionToIdleChannel()
     {
         // Arrange
+        DbConnectionInternal connection;
         using (new TransactionScope())
         {
             var owner = new SqlConnection();
-            var connection = GetConnection(owner);
+            connection = GetConnection(owner);
             ReturnConnection(connection, owner);
             AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
 
@@ -467,6 +514,7 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
 
         // Assert
         AssertPoolState(count: 1, idleCount: 1, transactedCount: 0);
+        AssertEnlistedIn(null, connection);
     }
 
     /// <summary>
@@ -500,30 +548,69 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
     }
 
     /// <summary>
-    /// TransactionEnded for a connection that was never parked must be a no-op. It must not push a
-    /// connection that is still checked out into the idle channel, where a second caller could
-    /// pick it up while the first is still using it.
+    /// TransactionEnded on its own, with none of the surrounding lifecycle events, must be a no-op
+    /// for a connection that was never parked. Only parking hands the connection to the pool, so
+    /// even an enlisted connection is still checked out here, and pushing it into the idle channel
+    /// would let a second caller pick it up while the first is still using it.
     /// </summary>
     [Fact]
-    public void TransactionEnded_ForConnectionThatWasNeverParked_LeavesItCheckedOut()
+    public void TransactionEnded_ForEnlistedConnectionThatWasNeverParked_LeavesItCheckedOut()
     {
         // Arrange
-        var owner = new SqlConnection();
-        var connection = GetConnection(owner);
-        Assert.NotNull(connection);
-
         using var scope = new TransactionScope();
         Transaction? transaction = Transaction.Current;
         Assert.NotNull(transaction);
 
-        // Act
+        var owner = new SqlConnection();
+        var connection = GetConnection(owner);
+        Assert.NotNull(connection);
+
+        // The connection is enlisted, but checked out rather than parked.
+        AssertEnlistedIn(transaction, connection);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
+
+        // Act - the completion notification arrives on its own, with no detach and no return.
         _pool.TransactionEnded(transaction!, connection);
+
+        // Assert - nothing to release, and the enlistment is untouched.
+        AssertEnlistedIn(transaction, connection);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
+
+        // It still reaches the pool through the normal return path.
+        ReturnConnection(connection, owner);
+        AssertPoolState(count: 1, idleCount: 0, transactedCount: 1);
+
+        scope.Complete();
+    }
+
+    /// <summary>
+    /// A transaction can complete while the application still holds its connection. The connection
+    /// was never parked, so there is nothing for the completion to release, and pushing it into the
+    /// idle channel would hand a connection that is still in use to a second caller.
+    /// </summary>
+    [Fact]
+    public void TransactionCompletes_WhileConnectionStillCheckedOut_LeavesItCheckedOut()
+    {
+        // Arrange
+        var owner = new SqlConnection();
+        DbConnectionInternal connection;
+        using (var scope = new TransactionScope())
+        {
+            connection = GetConnection(owner);
+            Assert.NotNull(connection);
+            AssertEnlistedIn(Transaction.Current, connection);
+            AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
+
+            // Act - the transaction completes with the connection still checked out.
+            scope.Complete();
+        }
 
         // Assert
         AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
 
+        // It reaches the pool only when its owner returns it.
         ReturnConnection(connection, owner);
-        scope.Complete();
+        AssertPoolState(count: 1, idleCount: 1, transactedCount: 0);
     }
 
     #endregion
@@ -545,6 +632,7 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         var owner = new SqlConnection();
         var oldConnection = GetConnection(owner);
         Assert.NotNull(oldConnection);
+        AssertEnlistedIn(transaction, oldConnection);
         AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
 
         // Act
@@ -553,9 +641,11 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
             oldConnection,
             TimeoutTimer.StartNew(TimeSpan.FromSeconds(15)));
 
-        // Assert - a distinct connection took over the old connection's slot.
+        // Assert - a distinct connection took over the old connection's slot, carrying the
+        // enlistment with it.
         Assert.NotNull(newConnection);
         Assert.NotSame(oldConnection, newConnection);
+        AssertEnlistedIn(transaction, newConnection);
         Assert.True(oldConnection.IsConnectionDoomed);
         AssertPoolState(count: 1, idleCount: 0, transactedCount: 0);
 

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTransactionTest.cs
@@ -598,9 +598,12 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         {
             Assert.Equal(transaction, Transaction.Current);
 
+#if NET
             // The transaction really is confined to this thread, so AsyncState is the only way
-            // the pool can learn about it.
+            // the pool can learn about it. .NET Framework flows the ambient transaction through
+            // ExecutionContext whatever the async flow option says, so this only holds on .NET.
             Assert.Null(Task.Run(() => Transaction.Current).GetAwaiter().GetResult());
+#endif
 
             // Act - starting the open captures the ambient transaction synchronously, here, and
             // hands the rest of the work to a thread pool thread.
@@ -674,10 +677,10 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         var owner = new SqlConnection();
         var connection = await GetConnectionAsync(owner, transaction);
 
-        // Assert - the open really did happen off the calling thread, and the pool left that
+        // Assert - the open really did happen on a thread pool thread, and the pool left that
         // thread's ambient transaction alone while still enlisting the connection.
         Assert.Equal(1, _connectionFactory.CreateCount);
-        Assert.NotEqual(Environment.CurrentManagedThreadId, _connectionFactory.CreateThreadId);
+        Assert.True(_connectionFactory.CreatedOnThreadPoolThread);
         Assert.Null(_connectionFactory.AmbientTransactionAtCreate);
         Assert.Equal(transaction, connection.EnlistedTransaction);
 
@@ -760,9 +763,10 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
         public Transaction? AmbientTransactionAtCreate { get; private set; }
 
         /// <summary>
-        /// The managed thread the pool created the connection on.
+        /// Whether the pool created the connection on a thread pool thread, which is what makes
+        /// assigning the ambient transaction there unsafe.
         /// </summary>
-        public int CreateThreadId { get; private set; }
+        public bool CreatedOnThreadPoolThread { get; private set; }
 
         public int CreateCount { get; private set; }
 
@@ -775,7 +779,7 @@ public class ChannelDbConnectionPoolTransactionTest : IDisposable
             TimeoutTimer timeout)
         {
             AmbientTransactionAtCreate = Transaction.Current;
-            CreateThreadId = Environment.CurrentManagedThreadId;
+            CreatedOnThreadPoolThread = Thread.CurrentThread.IsThreadPoolThread;
             CreateCount++;
             return new MockDbConnectionInternal();
         }


### PR DESCRIPTION
Rebased onto `main` now that #4429 has merged. Unit tests: 834 passed / 0 failed.

## Summary

Implements transaction support in `ChannelDbConnectionPool`, using `WaitHandleDbConnectionPool` as the reference for correct behavior. Before this change the channel pool constructed a `TransactedConnectionPool` but never used it, and three `IDbConnectionPool` members threw `NotImplementedException`.

## Changes

- **`PutObjectFromTransactedPool`** (was `NotImplementedException`) — returns a connection to general circulation once its transaction has ended, or destroys it if the pool is no longer running or the connection can't be pooled.
- **`TransactionEnded`** (was `NotImplementedException`) — delegates to `TransactedConnectionPool.TransactionEnded`, which calls back into `PutObjectFromTransactedPool`.
- **`ReturnInternalConnection`** — rewritten to mirror `WaitHandleDbConnectionPool.DeactivateObject`. It now deactivates *first* (deactivation is what detaches a completed transaction, so reading `EnlistedTransaction` beforehand could park a connection under an already-ended transaction), then decides under the connection lock between the transacted pool, stasis, the idle channel, and destruction. The idle-channel path moved into a new `PutConnectionInIdleChannel` helper.
- **`GetFromTransactedPool`** (new) — vends a connection already enlisted in the ambient transaction. Transacted connections are exempt from idle-timeout and clear-generation eviction, since closing them would abort a possibly-distributed transaction, so only liveness is checked. A dead transaction root rethrows rather than silently retrying, because its delegated transaction cannot be recovered on another connection.
- **`GetInternalConnection` / `PrepareConnection`** — consult the transacted pool when the pool group has transaction affinity, and pass the ambient transaction through to `ActivateConnection`.
- **Async acquisition path** — takes the ambient transaction from `taskCompletionSource.Task.AsyncState` and threads it explicitly through the open, rather than assigning `Transaction.Current` on the thread pool thread. See the section below.
- **`RemoveConnection`** — no longer disposes a transaction root that is still waiting for its delegated transaction to end (parity with `DestroyObject`). It comes back through `PutObjectFromTransactedPool` when the transaction completes.
- **`ReplaceConnection`** — no functional change; the two `TODO: Full transaction enlistment support (Story 2)` markers from #4429 are removed now that enlistment is wired through.

## How connections move between the idle channel and the transacted store

The transacted store (`TransactedConnectionPool`, keyed by `Transaction`) reserves a connection for one specific transaction, so reusing it avoids promoting that transaction to a distributed one. The only edge **into** it is a return while still enlisted; the only edges **out** are a pop by a caller in the same transaction, or the transaction ending.

### Return path (`ReturnInternalConnection`)

```mermaid
flowchart TD
    R["ReturnInternalConnection"] --> V["ValidateOwnershipAndSetPoolingState"]
    V --> D["DeactivateConnection"]
    D --> Doomed{"IsConnectionDoomed?"}
    Doomed -- yes --> Destroy["RemoveConnection (Destroy)"]
    Doomed -- no --> Poolable{"State is Running and CanBePooled?"}

    Poolable -- no --> Root{"IsTransactionRoot?"}
    Root -- yes --> Stasis["SetInStasis (HeldByTransaction)"]
    Root -- no --> Destroy

    Poolable -- yes --> Enl{"EnlistedTransaction is not null?"}
    Enl -- yes --> Park["PutTransactedObject (HeldByTransaction)"]
    Enl -- no --> Reuse["PutConnectionInIdleChannel (Reuse)"]
```

`DeactivateConnection` runs **before** `EnlistedTransaction` is read, because deactivation is what detaches an already-completed transaction. Reading first would park the connection under a transaction that has already ended, and it would never be released.

### Transaction end: back to general circulation

```mermaid
flowchart TD
    Sig["System.Transactions signals completion"] --> Where{"where is the connection?"}
    Where -- "parked in the transacted store" --> TE["pool.TransactionEnded"]
    TE --> TCP["TransactedConnectionPool.TransactionEnded removes it from the list"]
    TCP --> Put["PutObjectFromTransactedPool"]
    Where -- "in stasis" --> DTE["DelegatedTransactionEnded then TerminateStasis(true)"]
    DTE --> Put
    Where -- "never parked, still checked out" --> NoOp["no-op: stays with its owner"]

    Put --> Ok{"State is Running and CanBePooled?"}
    Ok -- yes --> Reset["ResetConnection then PutConnectionInIdleChannel"]
    Ok -- no --> Rm["RemoveConnection"]
```

A connection in stasis reaches `PutObjectFromTransactedPool` too, but by definition it got there because the pool was stopping or it was unpoolable, so it always takes the `RemoveConnection` branch.

A parked connection keeps its `_connectionSlots` reservation, so it still counts toward `Count` and `MaxPoolSize`, but not `IdleCount`. Only `RemoveConnection` releases the slot.

## Tests

- New `ChannelDbConnectionPoolTransactionTest` (18 tests): return routing (enlisted, not enlisted, completed transaction, `Enlist=false`, shut-down pool), vending from the transacted store under the same and different transactions, commit/rollback, completion after shutdown, `TransactionEnded` for a connection that was never parked, enlistment carry-over through `ReplaceConnection`, and the ambient-transaction flow cases below. Every test asserts full pool state (`Count`, `IdleCount`, transacted count) after each step, and the pool is built with a frozen `TimeProvider`.
- Removed the stale tests asserting `NotImplementedException` from the three now-implemented members.

## Validation

Unit tests: 834 passed / 0 failed on `net9.0`.

Manual/integration tests were run against a local SQL Server with `Switch.Microsoft.Data.SqlClient.UseConnectionPoolV2` enabled, across `TransactionEnlistmentTest`, `TransactionPoolTest`, `SQL.TransactionTest`, `ParallelTransactionsTest`, `ConnectionPoolTest`, `PoolBlockPeriodTest` and `DistributedTransactionTest` (48 tests):

| Run | Passed | Failed |
| --- | --- | --- |
| V1 (WaitHandle) baseline | 39 | 6 |
| V2 without this change | 36 | 9 |
| V2 with this change | 37 | 8 |

This change fixes three previously failing tests: `TestAutoEnlistment_TxScopeNonComplete`, `TestManualEnlistment_Enlist` and `TestManualEnlistment_Enlist_TxScopeComplete`.

The 6 failures shared with the V1 baseline are all `PlatformNotSupportedException: This platform does not support distributed transactions` — MSDTC isn't available on the test machine. The 2 remaining failures (`ConnectionPoolTest.ReclaimEmancipatedOnOpenTest`) are a pre-existing V2 gap: `ReclaimEmancipatedObjects` has never been implemented in `ChannelDbConnectionPool`. Both were confirmed by reverting this change and reproducing.

A broader V2 sweep (`SqlCommand`, `AsyncTest`, `MARSTest`, `DataReaderTest`, `ConnectivityTests`, `WeakRefTest`, `AdapterTest`, `ExceptionTest`, `RetryLogic`) gave 213 passed / 9 failed, where all 9 are named-pipe tests that fail identically on V1.

## Ambient transaction flow on the async path

`Transaction.Current` does **not** flow into a `Task.Run` unless the `TransactionScope` was created with `TransactionScopeAsyncFlowOption.Enabled` (the default is `Suppress`, which keeps the ambient transaction in thread-static storage). The async open path therefore cannot simply read `Transaction.Current` — it has to take the transaction from the `TaskCompletionSource`'s `AsyncState`, which is where `SqlConnection.InternalOpenAsync` captures it. That is the only site in the repo that constructs a `TaskCompletionSource<DbConnectionInternal>`, and it always passes the ambient transaction, so the mechanism is reliable (including across `OpenAsyncRetry.Retry`, which reuses the same TCS).

The original approach was to restore it by assigning `ADP.SetCurrentTransaction(...)` inside the `Task.Run`. That is unsafe here: assigning `Transaction.Current` writes to thread-static storage that `ExecutionContext` does **not** unwind, so the transaction outlives the open and is observable by unrelated work later scheduled onto the same thread pool thread — most notably the login-time auto-enlistment that non-pooled connections perform against `Transaction.Current`. A `try`/`finally` restore doesn't fix it either, because the async continuation may resume on a different thread than the one that was polluted. (`WaitHandleDbConnectionPool` does the same assignment safely because `WaitForPendingOpen` asserts it is *not* on a thread pool thread.)

The fix is to never mutate `Transaction.Current` in the pool: the transaction is captured on the caller's thread and threaded explicitly through `GetInternalConnection` into `GetFromTransactedPool` and `PrepareConnection`. The sync path passes `ADP.GetCurrentTransaction()` directly, since it runs on the caller's thread.

Four regression tests cover this:

| Test | What it pins |
| --- | --- |
| `GetConnection_Sync_UsesAmbientTransactionFromCallersThread` | the sync path reads `Transaction.Current`, which is correct because it runs on the caller's thread |
| `GetConnectionAsync_UsesAmbientTransactionCapturedOnCallersThread` | a scope with `AsyncFlowOption.Enabled` still enlists |
| `GetConnectionAsync_WithAsyncFlowDisabled_StillEnlistsInAmbientTransaction` | a **default** (`Suppress`) scope still enlists, even though the transaction provably does not flow off the caller's thread |
| `GetConnectionAsync_EnteredFromThreadWithoutAmbientTransaction_EnlistsFromAsyncState` | the transaction comes from `AsyncState`, not from whatever is ambient on the entering thread — this is the `OpenAsyncRetry.Retry` case |

The last one is load-bearing and not redundant: `TryGetConnection` reads `AsyncState` while still on the caller's thread, so in the scope-based tests `Transaction.Current` happens to agree with `AsyncState`. Only entering the pool from a thread with no ambient transaction distinguishes them. Verified by mutation — replacing the `AsyncState` read with `null` fails 5 tests, and replacing it with `ADP.GetCurrentTransaction()` fails only the retry-path and no-leak tests.

## Checklist

- [x] Tests added or updated
- [x] Public API changes documented — n/a, no public API change
- [x] Verified against customer repro (if applicable) — n/a
- [x] Ensure no breaking changes introduced — behavior is behind the existing `UseConnectionPoolV2` switch, which defaults to off

## Notes

- `ReclaimEmancipatedObjects` remains unimplemented in the channel pool; it is orthogonal to transactions and left for a follow-up.
