### PR TITLE
Fix AppContext switch race in unit tests

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTest.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
     /// Unit tests for <see cref="ChannelDbConnectionPool"/> covering connection acquisition,
     /// timeouts, reuse, pool clearing, blocking-period behavior, and timeout-budget propagation.
     /// </summary>
+    [Collection(AppContextSwitchTestCollection.Name)]
     public class ChannelDbConnectionPoolTest
     {
         private static readonly SqlConnectionFactory SuccessfulConnectionFactory = new SuccessfulSqlConnectionFactory();

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolWarmupTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolWarmupTest.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
     /// Unit tests for background pool warmup and replenishment in
     /// <see cref="ChannelDbConnectionPool"/>. See <c>specs/003-pool-warmup/spec.md</c>.
     /// </summary>
+    [Collection(AppContextSwitchTestCollection.Name)]
     public class ChannelDbConnectionPoolWarmupTest
     {
         #region Helpers

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/WaitHandleDbConnectionPoolBudgetTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/WaitHandleDbConnectionPoolBudgetTest.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool;
 /// budget-propagation coverage already in place for
 /// <c>ChannelDbConnectionPool</c>.
 /// </summary>
+[Collection(AppContextSwitchTestCollection.Name)]
 public class WaitHandleDbConnectionPoolBudgetTest : IDisposable
 {
     private const int DefaultMaxPoolSize = 50;

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/WaitHandleDbConnectionPoolIdleTimeoutTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/WaitHandleDbConnectionPoolIdleTimeoutTest.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool;
 /// Mirrors the corresponding tests in <see cref="ChannelDbConnectionPoolTest"/> so that the
 /// retrieval-side idle-expiry behavior is covered for both pool implementations.
 /// </summary>
+[Collection(AppContextSwitchTestCollection.Name)]
 public class WaitHandleDbConnectionPoolIdleTimeoutTest : IDisposable
 {
     private const int DefaultMaxPoolSize = 50;

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/LocalAppContextSwitchesTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/LocalAppContextSwitchesTest.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Data.SqlClient.UnitTests;
 /// <summary>
 /// Provides unit tests for verifying the default values of all SqlClient-specific AppContext switches.
 /// </summary>
+[Collection(AppContextSwitchTestCollection.Name)]
 public class LocalAppContextSwitchesTest
 {
     /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionInternalTimeoutTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionInternalTimeoutTests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Data.SqlClient.UnitTests;
 /// <see cref="SqlConnectionInternal.ResolveLoginTimeout"/> helper keeps this
 /// branch coverage free of any real network connection.
 /// </summary>
+[Collection(AppContextSwitchTestCollection.Name)]
 public class SqlConnectionInternalTimeoutTests
 {
     /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionOptionsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionOptionsTest.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
 {
+    [Collection(AppContextSwitchTestCollection.Name)]
     public class SqlConnectionOptionsTest : IDisposable
     {
         // Ensure we restore the original app context switch values after each

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionEnhancedRoutingTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionEnhancedRoutingTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests;
 /// </summary>
 // TODO: Do we need this collection?  It serializes all tests within it, which we probably don't
 // need since each test uses its own TDS Server with ephemeral listen port.
-[Collection("SimulatedServerTests")]
+[Collection(SimulatedServerTestCollection.Name)]
 public class ConnectionEnhancedRoutingTests
 {
     /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionFailoverTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionFailoverTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
 {
     // TODO: Do we need this collection?  It serializes all tests within it, which we probably don't
     // need since each test uses its own TDS Server with ephemeral listen port.
-    [Collection("SimulatedServerTests")]
+    [Collection(SimulatedServerTestCollection.Name)]
     public class ConnectionFailoverTests
     {
         //TODO parameterize for transient errors
@@ -443,6 +443,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
                 ConnectTimeout = 30,
                 ConnectRetryInterval = 1,
                 Encrypt = false,
+                MultiSubnetFailover = false,
                 Pooling = false, // Disable pooling to ensure a fresh connection attempt is made
             };
             using SqlConnection connection = new(builder.ConnectionString);

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionReadOnlyRoutingTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionReadOnlyRoutingTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
 {
     // TODO: Do we need this collection?  It serializes all tests within it, which we probably don't
     // need since each test uses its own TDS Server with ephemeral listen port.
-    [Collection("SimulatedServerTests")]
+    [Collection(SimulatedServerTestCollection.Name)]
     public class ConnectionReadOnlyRoutingTests
     {
         [Fact]

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionRoutingTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionRoutingTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
 {
     // TODO: Do we need this collection?  It serializes all tests within it, which we probably don't
     // need since each test uses its own TDS Server with ephemeral listen port.
-    [Collection("SimulatedServerTests")]
+    [Collection(SimulatedServerTestCollection.Name)]
     public class ConnectionRoutingTests
     {
         [Theory]

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionRoutingTestsAzure.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionRoutingTestsAzure.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
 {
     // TODO: Do we need this collection?  It serializes all tests within it, which we probably don't
     // need since each test uses its own TDS Server with ephemeral listen port.
-    [Collection("SimulatedServerTests")]
+    [Collection(SimulatedServerTestCollection.Name)]
     public class ConnectionRoutingTestsAzure : IDisposable
     {
         private ADPHelper adpHelper;

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/FeatureExtAckBoundsTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/FeatureExtAckBoundsTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests;
 /// </summary>
 // TODO: Do we need this collection?  It serializes all tests within it, which we probably don't
 // need since each test uses its own TDS Server with ephemeral listen port.
-[Collection("SimulatedServerTests")]
+[Collection(SimulatedServerTestCollection.Name)]
 public class FeatureExtAckBoundsTests : IDisposable
 {
     private readonly TdsServerFixture _fixture;

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/FeatureExtensionNegotiationTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/FeatureExtensionNegotiationTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests;
 
 // Serializes execution with other SimulatedServerTests classes to avoid port/resource conflicts.
 // Required here because IClassFixture shares a single TdsServer instance across all tests in this class.
-[Collection("SimulatedServerTests")]
+[Collection(SimulatedServerTestCollection.Name)]
 public class FeatureExtensionNegotiationTests : IClassFixture<TdsServerFixture>
 {
     private TdsServer _server;

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/TdsTokenBoundsTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/TdsTokenBoundsTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests;
 // Serializes execution with other SimulatedServerTests classes.  Required here because
 // DebugAssertSuppressor mutates the global Trace.Listeners collection, which is not
 // safe to do concurrently with other tests that may trigger Debug.Assert.
-[Collection("SimulatedServerTests")]
+[Collection(SimulatedServerTestCollection.Name)]
 public class TdsTokenBoundsTests : IDisposable
 {
     private readonly TdsServerFixture _fixture;

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/TestIsolationCollections.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/TestIsolationCollections.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests;
+
+/// <summary>
+/// Serializes tests that mutate process-wide cached AppContext switch values so other test
+/// collections cannot observe temporary settings.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class AppContextSwitchTestCollection
+{
+    public const string Name = "AppContextSwitchTests";
+}
+
+/// <summary>
+/// Serializes simulated-server tests with all other collections because some scenarios mutate
+/// process-wide cached AppContext switch values while exercising connections.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class SimulatedServerTestCollection
+{
+    public const string Name = "SimulatedServerTests";
+}


### PR DESCRIPTION
## Description

Fixes a unit-test race where `SqlConnectionOptionsTest` temporarily enables the process-wide cached `EnableMultiSubnetFailoverByDefault` switch while simulated-server failover tests run concurrently.

- Adds non-parallel xUnit collections for tests that mutate cached AppContext switches and for simulated-server tests that include switch-mutating scenarios.
- Assigns all `LocalAppContextSwitchesHelper` users to the AppContext isolation collection.
- Explicitly sets `MultiSubnetFailover = false` in `TransientFault_ShouldConnectToPrimary` so the scenario does not inherit the process-wide default.
- No public API or product behavior changes.

## Issues

Investigated from [CI-SqlClient-Package run 21207](https://sqlclientdrivers.visualstudio.com/public/_build/results?buildId=163911&view=logs&j=53294477-5d1d-5da0-656b-22e89987627d&t=fcaa67f5-386d-5ac7-84e8-512fbb02f2a2).

## Testing

- Full regular .NET 8 unit suite: 984 passed, 9 skipped, 0 failed.
- Original concurrent reproducer: passed 12 consecutive runs after failing 12/12 before the fix.
- Focused final run: 11 passed, 0 failed.

## Checklist

- [x] Tests added or updated
- [x] Public API changes documented (not applicable; no public API changes)
- [x] Verified against customer repro (not applicable; verified against CI failure)
- [x] Ensure no breaking changes introduced