### PR TITLE
Address follow-up review feedback on the perf test pipeline

### DIFF
--- a/eng/pipelines/perf/scripts/ingest_kusto.py
+++ b/eng/pipelines/perf/scripts/ingest_kusto.py
@@ -298,6 +298,20 @@ def _verify(cluster, database, run_table, results_table, pipeline_ids,
               file=sys.stderr)
         return 1
 
+    # None means the '.show ingestion failures' diagnostic itself could not run (typically a missing
+    # monitoring role), which is NOT the same as "no failures".  Report it as the unknown that it is
+    # rather than reusing the reassuring "no failures were reported" wording below, which would be
+    # factually wrong and would hide a real, repeatable permissions problem behind a soft warning.
+    if failures is None:
+        print(f"##vso[task.logissue type=warning]Kusto ingestion not yet queryable after "
+              f"{timeout_s}s ({run_table}={run_have}/{expected_run}, "
+              f"{results_table}={res_have}/{expected_results}), AND the ingestion-failure "
+              f"diagnostic could not be run (see above), so it is unknown whether ingestion "
+              f"actually failed. Not failing the step, but treat this run's telemetry as "
+              f"unverified and grant the ingestion principal the Database Monitor role so this "
+              f"check can do its job.", file=sys.stderr)
+        return 0
+
     print(f"##vso[task.logissue type=warning]Kusto ingestion not yet queryable after "
           f"{timeout_s}s ({run_table}={run_have}/{expected_run}, "
           f"{results_table}={res_have}/{expected_results}), but no ingestion failures were "

--- a/eng/pipelines/perf/scripts/interleave_perf.py
+++ b/eng/pipelines/perf/scripts/interleave_perf.py
@@ -113,10 +113,36 @@ def run_unit_process(exe_dir, assembly, unit, cwd, cpus, log_path):
     env["PERF_BENCHMARK"] = unit
     env.pop("PERF_LIST_BENCHMARKS", None)
 
+    # Pin between fork() and exec() where the platform allows it.  apply_affinity() can only run
+    # after Popen() returns, by which point the child has already started executing: process
+    # startup, the .NET host, assembly loading and JIT all run unpinned, potentially on the CPUs
+    # reserved for SQL Server.  This is the interleaved (default) run mode, so without this it is
+    # LESS isolated than the legacy sequential path, which wraps the whole process in 'taskset'.
+    preexec = None
+    if cpus and os.name == "posix" and hasattr(os, "sched_setaffinity"):
+        cpu_set = set(cpus)
+
+        def _pin_to_cpus():
+            """Runs in the forked child, after fork() and before exec()."""
+            os.sched_setaffinity(0, cpu_set)
+
+        preexec = _pin_to_cpus
+
     with open(log_path, "w", encoding="utf-8") as log:
-        proc = subprocess.Popen(cmd, cwd=cwd, env=env, stdout=log,
-                                stderr=subprocess.STDOUT)
-        apply_affinity(proc, cpus)
+        try:
+            proc = subprocess.Popen(cmd, cwd=cwd, env=env, stdout=log,
+                                    stderr=subprocess.STDOUT, preexec_fn=preexec)
+        except Exception as exc:  # noqa: BLE001 - preexec_fn failure must not abort the run
+            if preexec is None:
+                raise
+            print(f"WARNING: could not pin CPUs {cpus} before exec ({exc}); falling back to "
+                  f"post-start pinning.", file=sys.stderr)
+            proc = subprocess.Popen(cmd, cwd=cwd, env=env, stdout=log,
+                                    stderr=subprocess.STDOUT)
+            apply_affinity(proc, cpus)
+        else:
+            if preexec is None:
+                apply_affinity(proc, cpus)
         return proc.wait()
 
 
@@ -236,11 +262,30 @@ def orchestrate(runner, units, results_dir, threshold, reps):
 
     # Which units contain a rep-1 regression?  Those are the best-of-N candidates.
     candidate_units = []
+    unmappable = []
     for e in entries:
         if e["status"] == "regression":
             unit = type_to_unit.get(e["benchmarkName"])
-            if unit and unit not in candidate_units:
-                candidate_units.append(unit)
+            if unit:
+                if unit not in candidate_units:
+                    candidate_units.append(unit)
+            elif e["benchmarkName"] not in unmappable:
+                unmappable.append(e["benchmarkName"])
+
+    # A regression whose benchmark Type cannot be mapped back to a unit is never re-run, so its
+    # tally is stuck at 1.  With reps > 1 the strict-majority test below can then never pass, and
+    # the regression would be silently downgraded to "unconfirmed" and slip through the gate - a
+    # false negative caused by bookkeeping, not by the measurement.  Surface it loudly and (see the
+    # verdict loop) judge it against the number of reps actually performed for it, so an
+    # unconfirmable regression is reported rather than quietly discarded.
+    unmappable_keys = {e["key"] for e in entries
+                       if e["status"] == "regression" and e["benchmarkName"] in unmappable}
+    if unmappable:
+        print("WARNING: these regressed benchmark type(s) could not be mapped back to a benchmark "
+              "unit, so best-of-N cannot re-run them: " + ", ".join(sorted(unmappable)) +
+              ". They are reported as confirmed regressions (they cannot be disproved). This "
+              "usually means the unit list and the reported Type names have drifted apart.",
+              file=sys.stderr)
 
     # Per-key regression tally across reps (rep 1 counts once).
     reg_counts = {k: 1 for k in reg_keys_1}
@@ -264,10 +309,15 @@ def orchestrate(runner, units, results_dir, threshold, reps):
         key = e["key"]
         if e["status"] == "regression":
             count = reg_counts.get(key, 0)
-            confirmed = (count * 2) > total_reps
+            # An unmappable key was only ever measured once, so score it against the single rep that
+            # actually ran instead of against N reps it was never eligible for.
+            key_reps = 1 if key in unmappable_keys else total_reps
+            confirmed = (count * 2) > key_reps
             e["regressionReps"] = count
-            e["totalReps"] = total_reps
+            e["totalReps"] = key_reps
             e["confirmedRegression"] = confirmed
+            if key in unmappable_keys:
+                e["confirmationSkipped"] = True
             if not confirmed:
                 e["status"] = "regression-unconfirmed"
         else:

--- a/eng/pipelines/perf/scripts/run-perf-tests.ps1
+++ b/eng/pipelines/perf/scripts/run-perf-tests.ps1
@@ -130,6 +130,66 @@ if ([string]::IsNullOrEmpty($SqlPassword)) {
 
 New-Item -ItemType Directory -Force -Path $ResultsDir | Out-Null
 
+####################################################################################################
+# Resolve the Python 3 interpreter up front.
+#
+# The harness shells out to python for the interleave/compare/result-count steps, but 'python3' is a
+# Unix-ism: on Windows the interpreter is normally 'python.exe' (or the 'py' launcher), and a stock
+# image additionally ships App Execution Alias STUBS named python.exe/python3.exe under WindowsApps
+# that resolve via Get-Command yet only open the Microsoft Store.  So both "command not found" and
+# "command found but useless" are realistic here.
+#
+# Failing on that later is actively misleading: Get-BenchmarkResultCount swallows a failed python
+# call and returns 0, so a missing interpreter surfaces as "the run produced no benchmark results"
+# - a benchmark problem - instead of "python is not installed".  Resolve once, probe it for real,
+# and fail fast with an accurate message.
+####################################################################################################
+
+function Resolve-Python3 {
+    foreach ($candidate in @(
+        @{ Name = 'python3'; Pre = @() },
+        @{ Name = 'python';  Pre = @() },
+        @{ Name = 'py';      Pre = @('-3') }
+    )) {
+        $cmd = Get-Command $candidate.Name -CommandType Application -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+        if (-not $cmd) { continue }
+
+        # Probe the interpreter instead of trusting that it resolved: the Store alias stubs exit
+        # non-zero (or print a Store prompt) rather than reporting a version.
+        $previousPreference = $ErrorActionPreference
+        $ErrorActionPreference = 'Continue'
+        $global:LASTEXITCODE = 0
+        try {
+            $version = (& $cmd.Source @($candidate.Pre + '--version') 2>&1 | Out-String).Trim()
+        } catch {
+            $version = ''
+        } finally {
+            $ErrorActionPreference = $previousPreference
+        }
+
+        if ($LASTEXITCODE -eq 0 -and $version -match 'Python\s+3\.') {
+            return [pscustomobject]@{
+                Source  = $cmd.Source
+                PreArgs = $candidate.Pre
+                Version = $version
+            }
+        }
+        Write-Host "  '$($candidate.Name)' resolved to $($cmd.Source) but is not a usable Python 3 (ignored)."
+    }
+    return $null
+}
+
+$python = Resolve-Python3
+if (-not $python) {
+    throw ("Python 3 is required by the perf harness (interleave_perf.py / compare_perf.py) but no " +
+           "usable interpreter was found. Tried 'python3', 'python' and 'py -3' on PATH. Install " +
+           "Python 3 on the perf VM (and make sure it is not just the Microsoft Store alias stub).")
+}
+$PythonExe = $python.Source
+$PythonPreArgs = $python.PreArgs
+Write-Host "Using Python interpreter: $PythonExe ($($python.Version))"
+
 # Record VM-side run metadata (e.g. the perf VM hostname) for the agent-side Kusto translation.
 "MACHINE_NAME=$env:COMPUTERNAME" | Set-Content -Path (Join-Path $ResultsDir "runinfo.env") -Encoding ASCII
 
@@ -204,6 +264,13 @@ try { Invoke-Native { dotnet --info } "dotnet --info failed" } catch { Write-War
 
 Write-Host "Ensuring database [$DbName] exists on $SqlServer ..."
 
+# Pass the 'sa' password to sqlcmd via SQLCMDPASSWORD rather than -P.  A process's command line is
+# readable by other users on the box (Get-CimInstance Win32_Process, Process Explorer, WMI auditing),
+# so -P leaks the password for the lifetime of each sqlcmd invocation, whereas another process's
+# environment block is not.  sqlcmd reads SQLCMDPASSWORD natively; set it once here for every sqlcmd
+# call below.
+$env:SQLCMDPASSWORD = $SqlPassword
+
 $sqlcmd = Get-Command sqlcmd -ErrorAction SilentlyContinue
 if ($sqlcmd) {
     # Relax Stop around the native sqlcmd call so a benign stderr write cannot abort the run before
@@ -211,7 +278,7 @@ if ($sqlcmd) {
     $previousPreference = $ErrorActionPreference
     $ErrorActionPreference = 'Continue'
     try {
-        & $sqlcmd.Source -S $SqlServer -U sa -P $SqlPassword -C -b -l 30 `
+        & $sqlcmd.Source -S $SqlServer -U sa -C -b -l 30 `
             -Q "IF DB_ID('$DbName') IS NULL CREATE DATABASE [$DbName];"
     } finally {
         $ErrorActionPreference = $previousPreference
@@ -244,7 +311,7 @@ try {
 
 # --- §2.11 Capture the SQL instance configuration (confirm the lab tuning actually took effect) ---
 try {
-    & $sqlcmd.Source -S $SqlServer -U sa -P $SqlPassword -C -b -l 30 -h -1 -W `
+    & $sqlcmd.Source -S $SqlServer -U sa -C -b -l 30 -h -1 -W `
         -Q "SET NOCOUNT ON;
             SELECT name, value_in_use FROM sys.configurations
               WHERE name IN ('max degree of parallelism','cost threshold for parallelism',
@@ -262,7 +329,7 @@ try {
 $previousPreference = $ErrorActionPreference
 $ErrorActionPreference = 'Continue'
 try {
-    & $sqlcmd.Source -S $SqlServer -U sa -P $SqlPassword -C -b -l 15 `
+    & $sqlcmd.Source -S $SqlServer -U sa -C -b -l 15 `
         -Q "SET NOCOUNT ON; USE [$DbName]; SELECT 1;" *> $null
 } finally {
     $ErrorActionPreference = $previousPreference
@@ -400,7 +467,7 @@ print(total)
     $previousPreference = $ErrorActionPreference
     $ErrorActionPreference = 'Continue'
     try {
-        $out = $py | python3 - $Root
+        $out = $py | & $PythonExe @PythonPreArgs - $Root
     } finally {
         $ErrorActionPreference = $previousPreference
     }
@@ -437,20 +504,51 @@ function Invoke-PerfPass([string]$Label, [string[]]$ExtraArgs) {
         $psi.UseShellExecute = $false
         $psi.WorkingDirectory = $runDir
 
-        $proc = [System.Diagnostics.Process]::Start($psi)
-
         $mask = Get-AffinityMask $env:PERF_CLIENT_CPUS
         # Use a non-zero check, not '-gt 0': a mask that pins CPU 63 sets the [long] sign bit and
         # is therefore negative, yet is still a valid ProcessorAffinity value.
-        if ($null -ne $mask -and $mask -ne 0) {
+        $pinning = ($null -ne $mask -and $mask -ne 0)
+
+        # Pin BEFORE Start(), not after.  On Windows a new process inherits the creating process's
+        # affinity, so temporarily narrowing this PowerShell process's affinity means the child is
+        # constrained from its very first instruction.  Assigning $proc.ProcessorAffinity after
+        # Start() returns leaves process startup, assembly loading, JIT and BenchmarkDotNet's own
+        # setup running on arbitrary cores - including the CPUs reserved for SQL Server - which is
+        # precisely the cross-talk the pinning exists to eliminate.
+        $self = Get-Process -Id $PID
+        $previousAffinity = $null
+        if ($pinning) {
+            try {
+                $previousAffinity = $self.ProcessorAffinity
+                $self.ProcessorAffinity = [System.IntPtr]$mask
+            } catch {
+                Write-Warning "Could not pre-set affinity on the launching process: $_"
+                $previousAffinity = $null
+            }
+        } else {
+            Write-Warning "PERF_CLIENT_CPUS unset; running without CPU pinning."
+        }
+
+        try {
+            $proc = [System.Diagnostics.Process]::Start($psi)
+        } finally {
+            # Restore the harness's own affinity immediately; the child has already inherited the
+            # narrowed mask, and leaving the harness pinned would also constrain the build and
+            # result-collection work that follows.
+            if ($null -ne $previousAffinity) {
+                try { $self.ProcessorAffinity = $previousAffinity } catch { }
+            }
+        }
+
+        if ($pinning) {
+            # Belt and braces: re-assert on the child in case inheritance did not apply, and confirm
+            # the effective mask in the log.
             try {
                 $proc.ProcessorAffinity = [System.IntPtr]$mask
                 Write-Host "Pinned benchmark client (PID $($proc.Id)) to CPUs $($env:PERF_CLIENT_CPUS) (mask 0x$($mask.ToString('X')))."
             } catch {
                 Write-Warning "Failed to set ProcessorAffinity: $_"
             }
-        } else {
-            Write-Warning "PERF_CLIENT_CPUS unset; running without CPU pinning."
         }
 
         Save-CpuTelemetry $Label "before"
@@ -531,7 +629,7 @@ if ((-not [string]::IsNullOrEmpty($BaselineVersion)) -and ($RunMode -eq "interle
         $interleaveArgs += "--fail-on-regression"
     }
     Write-Host "Running interleaved benchmarks (best-of-$ConfirmationRuns) ..."
-    Invoke-Native { python3 (Join-Path $ScriptDir "interleave_perf.py") @interleaveArgs } "Interleaved run failed"
+    Invoke-Native { & $PythonExe @PythonPreArgs (Join-Path $ScriptDir "interleave_perf.py") @interleaveArgs } "Interleaved run failed"
 
 } elseif (-not [string]::IsNullOrEmpty($BaselineVersion)) {
     # --- Legacy sequential path: full baseline pass, then full candidate pass, then compare -------
@@ -559,7 +657,7 @@ if ((-not [string]::IsNullOrEmpty($BaselineVersion)) -and ($RunMode -eq "interle
         Write-Host "Regression gate ENABLED: a candidate-slower regression (> $RegressionThreshold%) will fail the run."
         $compareArgs += "--fail-on-regression"
     }
-    Invoke-Native { python3 (Join-Path $ScriptDir "compare_perf.py") @compareArgs } "Comparison failed"
+    Invoke-Native { & $PythonExe @PythonPreArgs (Join-Path $ScriptDir "compare_perf.py") @compareArgs } "Comparison failed"
     # Surface the comparison as the top-level run summary (collect-results.yml attaches results\*.md).
     Copy-Item -Force (Join-Path $comparisonDir "comparison.md") (Join-Path $ResultsDir "summary.md")
 

--- a/eng/pipelines/perf/scripts/run-perf-tests.sh
+++ b/eng/pipelines/perf/scripts/run-perf-tests.sh
@@ -243,9 +243,17 @@ find_sqlcmd() {
 }
 
 echo "Ensuring database [${DB_NAME}] exists on ${SQL_SERVER} ..."
+
+# Pass the 'sa' password to sqlcmd via SQLCMDPASSWORD rather than -P.  Arguments are visible to every
+# user on the box through /proc/<pid>/cmdline (ps, top, auditd, container tooling), so -P leaks the
+# password for the lifetime of each sqlcmd invocation.  The environment of another user's process is
+# not readable, so SQLCMDPASSWORD - which sqlcmd supports natively - keeps it out of the process
+# table.  Exported once here and consumed by every sqlcmd call below.
+export SQLCMDPASSWORD="${SQL_PASSWORD}"
+
 if SQLCMD="$(find_sqlcmd)"; then
     # -C trusts the server certificate (mssql-tools18 requires encryption by default).
-    "${SQLCMD}" -S "${SQL_SERVER}" -U sa -P "${SQL_PASSWORD}" -C -b -l 30 \
+    "${SQLCMD}" -S "${SQL_SERVER}" -U sa -C -b -l 30 \
         -Q "IF DB_ID('${DB_NAME}') IS NULL CREATE DATABASE [${DB_NAME}];"
     echo "Database [${DB_NAME}] is ready."
 else
@@ -278,8 +286,14 @@ export MALLOC_TRIM_THRESHOLD_="${MALLOC_TRIM_THRESHOLD_:--1}"          # never t
 # widen the range and allow TIME_WAIT reuse so socket setup latency stays stable.  'sudo -n' keeps
 # this non-interactive: on a VM without passwordless sudo it fails immediately instead of blocking
 # on a password prompt, then we fall back to a non-sudo sysctl (and finally give up quietly).
+#
+# The low bound is 10000, NOT 1024: SQL Server and sshd live on this same VM, so a range starting at
+# 1024 lets an outbound connection grab 1433 or 22 as its EPHEMERAL SOURCE port.  Once that happens
+# the listener cannot rebind (or a later connection to the real service collides), which shows up as
+# an intermittent, benchmark-corrupting connection failure that looks like a perf anomaly.  Starting
+# above the well-known/registered range keeps the churn benches away from the services under test.
 if command -v sysctl >/dev/null 2>&1; then
-    for kv in "net.ipv4.ip_local_port_range=1024 65535" "net.ipv4.tcp_tw_reuse=1"; do
+    for kv in "net.ipv4.ip_local_port_range=10000 65535" "net.ipv4.tcp_tw_reuse=1"; do
         sudo -n sysctl -w "${kv}" >/dev/null 2>&1 || sysctl -w "${kv}" >/dev/null 2>&1 || true
     done
 fi
@@ -288,7 +302,7 @@ fi
 { command -v lscpu >/dev/null 2>&1 && lscpu; } > "${DIAG_DIR}/cpu-info.txt" 2>&1 || true
 
 # --- §2.11 Capture the SQL instance configuration (confirm the lab tuning actually took effect) ---
-"${SQLCMD}" -S "${SQL_SERVER}" -U sa -P "${SQL_PASSWORD}" -C -b -l 30 -h -1 -W \
+"${SQLCMD}" -S "${SQL_SERVER}" -U sa -C -b -l 30 -h -1 -W \
     -Q "SET NOCOUNT ON;
         SELECT name, value_in_use FROM sys.configurations
           WHERE name IN ('max degree of parallelism','cost threshold for parallelism',
@@ -304,7 +318,7 @@ fi
 # A benchmark suite that "skips" when the server is down produces an empty comparison that reads
 # green; verify connectivity up front and touch the target DB so the first measured benchmark is not
 # paying cold-cache costs.
-if ! "${SQLCMD}" -S "${SQL_SERVER}" -U sa -P "${SQL_PASSWORD}" -C -b -l 15 \
+if ! "${SQLCMD}" -S "${SQL_SERVER}" -U sa -C -b -l 15 \
         -Q "SET NOCOUNT ON; USE [${DB_NAME}]; SELECT 1;" >/dev/null 2>&1; then
     echo "ERROR: SQL Server ${SQL_SERVER} (db ${DB_NAME}) is unreachable; refusing to run so an empty perf comparison cannot be reported as a pass." >&2
     exit 1

--- a/eng/pipelines/perf/scripts/tests/test_perf_scripts.py
+++ b/eng/pipelines/perf/scripts/tests/test_perf_scripts.py
@@ -1,0 +1,327 @@
+"""Unit tests for the perf pipeline's comparison and best-of-N confirmation logic.
+
+These cover the decision-making code that the regression gate depends on
+(``compare_perf.build_comparison`` and ``interleave_perf.orchestrate``).  That logic decides
+whether a pipeline run passes or fails once ``failOnRegression`` is turned on, so it needs to
+be exercised without a SQL Server, without BenchmarkDotNet and without an ADX cluster.
+
+Run from anywhere:
+
+    python3 -m unittest discover -s eng/pipelines/perf/scripts/tests -v
+
+Only the standard library is used, so this runs on any agent that already has Python 3.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import compare_perf  # noqa: E402
+import interleave_perf  # noqa: E402
+
+
+NS_PER_MS = 1_000_000.0
+
+
+def write_report(directory, type_name, mean_ms, alloc=None, method="Run", params=""):
+    """Write a minimal BenchmarkDotNet ``*-report-full.json`` for one benchmark."""
+    os.makedirs(directory, exist_ok=True)
+    bench = {
+        "Type": type_name,
+        "Method": method,
+        "Parameters": params,
+        "Statistics": {"Mean": mean_ms * NS_PER_MS},
+    }
+    if alloc is not None:
+        bench["Memory"] = {"BytesAllocatedPerOperation": alloc}
+    path = os.path.join(directory, f"{type_name}.{method}-report-full.json")
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump({"Benchmarks": [bench]}, handle)
+    return path
+
+
+class TempDirTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="perf-tests-")
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+
+    def path(self, *parts):
+        return os.path.join(self.tmp, *parts)
+
+
+class PctTests(unittest.TestCase):
+    """``_pct`` guards the zero-baseline case that would otherwise divide by zero."""
+
+    def test_regular_change(self):
+        self.assertAlmostEqual(compare_perf._pct(100.0, 110.0), 10.0)
+        self.assertAlmostEqual(compare_perf._pct(100.0, 90.0), -10.0)
+
+    def test_zero_to_zero_is_no_change(self):
+        self.assertEqual(compare_perf._pct(0, 0), 0.0)
+
+    def test_zero_to_nonzero_is_undefined_not_infinite(self):
+        # Undefined rather than a bogus percentage; the raw byte counts keep it visible.
+        self.assertIsNone(compare_perf._pct(0, 512))
+
+    def test_missing_side_is_undefined(self):
+        self.assertIsNone(compare_perf._pct(None, 1.0))
+        self.assertIsNone(compare_perf._pct(1.0, None))
+
+
+class BuildComparisonTests(TempDirTestCase):
+    """Classification is what the gate reads, so pin down each status boundary."""
+
+    def _compare(self, threshold=5.0):
+        return compare_perf.build_comparison(self.path("baseline"), self.path("current"), threshold)
+
+    def _by_type(self, entries):
+        return {e["benchmarkName"]: e for e in entries}
+
+    def test_status_classification(self):
+        write_report(self.path("baseline"), "Slower", 100.0)
+        write_report(self.path("current"), "Slower", 120.0)      # +20% -> regression
+        write_report(self.path("baseline"), "Faster", 100.0)
+        write_report(self.path("current"), "Faster", 80.0)       # -20% -> improvement
+        write_report(self.path("baseline"), "Same", 100.0)
+        write_report(self.path("current"), "Same", 102.0)        # +2% -> within threshold
+
+        entries = self._by_type(self._compare(threshold=5.0))
+        self.assertEqual(entries["Slower"]["status"], "regression")
+        self.assertEqual(entries["Faster"]["status"], "improvement")
+        self.assertEqual(entries["Same"]["status"], "unchanged")
+
+    def test_threshold_is_exclusive(self):
+        # Exactly at the threshold must NOT trip the gate; just past it must.
+        write_report(self.path("baseline"), "AtThreshold", 100.0)
+        write_report(self.path("current"), "AtThreshold", 105.0)
+        self.assertEqual(self._by_type(self._compare(5.0))["AtThreshold"]["status"], "unchanged")
+
+        write_report(self.path("current"), "AtThreshold", 105.1)
+        self.assertEqual(self._by_type(self._compare(5.0))["AtThreshold"]["status"], "regression")
+
+    def test_one_sided_benchmarks(self):
+        write_report(self.path("baseline"), "Removed", 100.0)
+        write_report(self.path("current"), "Added", 100.0)
+        entries = self._by_type(self._compare())
+        self.assertEqual(entries["Removed"]["status"], "baseline-only")
+        self.assertEqual(entries["Added"]["status"], "current-only")
+        # Neither side can be a regression: there is nothing to compare against.
+        self.assertIsNone(entries["Removed"]["meanDeltaPct"])
+        self.assertIsNone(entries["Added"]["meanDeltaPct"])
+
+    def test_zero_byte_baseline_allocation_is_not_dropped(self):
+        # A 0-byte baseline is a legitimate value; gating on truthiness would hide a 0 -> X
+        # allocation regression entirely.
+        write_report(self.path("baseline"), "Alloc", 100.0, alloc=0)
+        write_report(self.path("current"), "Alloc", 100.0, alloc=4096)
+        entry = self._by_type(self._compare())["Alloc"]
+        self.assertEqual(entry["baselineAllocBytes"], 0)
+        self.assertEqual(entry["currentAllocBytes"], 4096)
+        self.assertIsNone(entry["allocDeltaPct"])  # undefined percentage, raw values retained
+
+    def test_worst_regression_sorts_first(self):
+        write_report(self.path("baseline"), "Mild", 100.0)
+        write_report(self.path("current"), "Mild", 110.0)
+        write_report(self.path("baseline"), "Severe", 100.0)
+        write_report(self.path("current"), "Severe", 200.0)
+        entries = self._compare()
+        self.assertEqual(entries[0]["benchmarkName"], "Severe")
+
+    def test_unparseable_report_is_skipped_not_fatal(self):
+        write_report(self.path("baseline"), "Good", 100.0)
+        write_report(self.path("current"), "Good", 100.0)
+        os.makedirs(self.path("current"), exist_ok=True)
+        with open(self.path("current", "broken-report-full.json"), "w", encoding="utf-8") as fh:
+            fh.write("{ not json")
+        entries = self._by_type(self._compare())
+        self.assertEqual(entries["Good"]["status"], "unchanged")
+
+
+class FakeRunner:
+    """Stands in for the real benchmark runner in ``orchestrate``.
+
+    *plan* maps unit -> {type_name: {rep: (baseline_ms, current_ms)}}.  *reported_types* lets a
+    test simulate the unit list and the reported benchmark Type names drifting apart.
+    """
+
+    def __init__(self, plan, reported_types=None):
+        self.plan = plan
+        self.reported_types = reported_types
+        self.calls = []
+
+    def interleave(self, units, rep, baseline_dir, current_dir):
+        self.calls.append((tuple(units), rep))
+        result = {}
+        for unit in units:
+            types = self.plan[unit]
+            for type_name, per_rep in types.items():
+                baseline_ms, current_ms = per_rep.get(rep, per_rep[max(per_rep)])
+                write_report(baseline_dir, type_name, baseline_ms)
+                write_report(current_dir, type_name, current_ms)
+            if self.reported_types is not None:
+                result[unit] = set(self.reported_types.get(unit, []))
+            else:
+                result[unit] = set(types)
+        return result
+
+
+class OrchestrateTests(TempDirTestCase):
+    """Best-of-N confirmation decides whether a flagged regression fails the pipeline."""
+
+    def _run(self, runner, units, reps, threshold=5.0):
+        return interleave_perf.orchestrate(runner, units, self.tmp, threshold, reps)
+
+    def test_persistent_regression_is_confirmed(self):
+        runner = FakeRunner({"UnitA": {"Bench": {1: (100.0, 130.0),
+                                                2: (100.0, 130.0),
+                                                3: (100.0, 130.0)}}})
+        entries, confirmed, unconfirmed = self._run(runner, ["UnitA"], reps=3)
+        self.assertEqual([e["benchmarkName"] for e in confirmed], ["Bench"])
+        self.assertEqual(unconfirmed, [])
+        self.assertEqual(entries[0]["regressionReps"], 3)
+        self.assertTrue(entries[0]["confirmedRegression"])
+
+    def test_flaky_regression_is_not_confirmed(self):
+        # Slow on rep 1 only: noise, not a regression. Must not fail the gate.
+        runner = FakeRunner({"UnitA": {"Bench": {1: (100.0, 130.0),
+                                                2: (100.0, 100.0),
+                                                3: (100.0, 100.0)}}})
+        entries, confirmed, unconfirmed = self._run(runner, ["UnitA"], reps=3)
+        self.assertEqual(confirmed, [])
+        self.assertEqual([e["benchmarkName"] for e in unconfirmed], ["Bench"])
+        self.assertEqual(entries[0]["status"], "regression-unconfirmed")
+        self.assertEqual(entries[0]["regressionReps"], 1)
+
+    def test_strict_majority_two_of_three(self):
+        runner = FakeRunner({"UnitA": {"Bench": {1: (100.0, 130.0),
+                                                2: (100.0, 130.0),
+                                                3: (100.0, 100.0)}}})
+        _, confirmed, _ = self._run(runner, ["UnitA"], reps=3)
+        self.assertEqual(len(confirmed), 1)
+
+    def test_only_regressed_units_are_rerun(self):
+        runner = FakeRunner({
+            "Slow": {"SlowBench": {1: (100.0, 130.0)}},
+            "Fine": {"FineBench": {1: (100.0, 100.0)}},
+        })
+        self._run(runner, ["Slow", "Fine"], reps=3)
+        # Pass 1 covers everything; passes 2..N only the candidates.
+        self.assertEqual(runner.calls[0], (("Slow", "Fine"), 1))
+        self.assertEqual([c[0] for c in runner.calls[1:]], [("Slow",), ("Slow",)])
+
+    def test_single_rep_confirms_immediately(self):
+        runner = FakeRunner({"UnitA": {"Bench": {1: (100.0, 130.0)}}})
+        _, confirmed, _ = self._run(runner, ["UnitA"], reps=1)
+        self.assertEqual(len(confirmed), 1)
+        self.assertEqual(len(runner.calls), 1)
+
+    def test_unmappable_regression_is_reported_not_silently_cleared(self):
+        # The runner reports no Type names, so the regression cannot be traced back to a unit and
+        # can never be re-run.  Its tally is therefore stuck at 1; scoring that against reps=3
+        # would silently downgrade a real regression to "unconfirmed" and let it through the gate.
+        runner = FakeRunner({"UnitA": {"Ghost": {1: (100.0, 130.0)}}},
+                            reported_types={"UnitA": []})
+        entries, confirmed, unconfirmed = self._run(runner, ["UnitA"], reps=3)
+        self.assertEqual([e["benchmarkName"] for e in confirmed], ["Ghost"])
+        self.assertEqual(unconfirmed, [])
+        self.assertTrue(entries[0]["confirmationSkipped"])
+        self.assertEqual(entries[0]["totalReps"], 1)
+        # It was never eligible for a re-run.
+        self.assertEqual(len(runner.calls), 1)
+
+    def test_improvement_never_counts_as_a_regression(self):
+        runner = FakeRunner({"UnitA": {"Bench": {1: (130.0, 100.0)}}})
+        entries, confirmed, unconfirmed = self._run(runner, ["UnitA"], reps=3)
+        self.assertEqual(entries[0]["status"], "improvement")
+        self.assertFalse(entries[0]["confirmedRegression"])
+        self.assertEqual(confirmed, [])
+        self.assertEqual(unconfirmed, [])
+
+
+class _FakeProc:
+    pid = 4242
+
+    def wait(self):
+        return 0
+
+
+class AffinityTests(unittest.TestCase):
+    """The benchmark child must be pinned before it starts executing, not after."""
+
+    def _capture_popen_kwargs(self, cpus):
+        captured = {}
+        real_popen = subprocess.Popen
+
+        def fake_popen(cmd, **kwargs):
+            captured.update(kwargs)
+            return _FakeProc()
+
+        subprocess.Popen = fake_popen
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                rc = interleave_perf.run_unit_process(
+                    tmp, "PerformanceTests.dll", "UnitA", tmp, cpus,
+                    os.path.join(tmp, "log.txt"))
+        finally:
+            subprocess.Popen = real_popen
+        return rc, captured
+
+    @unittest.skipUnless(os.name == "posix", "preexec_fn is POSIX-only")
+    def test_cpus_are_pinned_via_preexec_fn(self):
+        # macOS is POSIX but has no sched_setaffinity, so inject one to exercise the pinning path
+        # that matters on the Linux perf VM.
+        injected = not hasattr(os, "sched_setaffinity")
+        if injected:
+            os.sched_setaffinity = lambda pid, mask: None
+        try:
+            rc, captured = self._capture_popen_kwargs([0, 1])
+        finally:
+            if injected:
+                del os.sched_setaffinity
+
+        self.assertEqual(rc, 0)
+        preexec = captured.get("preexec_fn")
+        self.assertIsNotNone(preexec,
+                             "affinity must be applied between fork() and exec() so that process "
+                             "startup and JIT are pinned too")
+
+        # The hook must actually request the CPUs it was given.
+        requested = {}
+        real = getattr(os, "sched_setaffinity", None)
+        os.sched_setaffinity = lambda pid, mask: requested.update(pid=pid, mask=set(mask))
+        try:
+            preexec()
+        finally:
+            if real is None:
+                del os.sched_setaffinity
+            else:
+                os.sched_setaffinity = real
+        self.assertEqual(requested, {"pid": 0, "mask": {0, 1}})
+
+    @unittest.skipUnless(os.name == "posix", "preexec_fn is POSIX-only")
+    def test_falls_back_to_post_start_pinning_when_platform_cannot_pin(self):
+        # No sched_setaffinity (e.g. macOS): must still start the process, just unpinned here.
+        real = getattr(os, "sched_setaffinity", None)
+        if real is not None:
+            del os.sched_setaffinity
+        try:
+            rc, captured = self._capture_popen_kwargs([0, 1])
+        finally:
+            if real is not None:
+                os.sched_setaffinity = real
+        self.assertEqual(rc, 0)
+        self.assertIsNone(captured.get("preexec_fn"))
+
+    def test_no_preexec_when_no_cpus_requested(self):
+        _, captured = self._capture_popen_kwargs([])
+        self.assertIsNone(captured.get("preexec_fn"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eng/pipelines/perf/sqlclient-perf-pipeline.yml
+++ b/eng/pipelines/perf/sqlclient-perf-pipeline.yml
@@ -167,6 +167,12 @@ parameters:
 variables:
   - group: ADX Cluster Variables
 
+  # Pinned version of the Azure Data Explorer Python SDKs used by the ingestion step.  Kept as a
+  # single variable so the pin is bumped deliberately in one place (and so the eventual move to an
+  # internal governed feed only has to change the install command, not the version).
+  - name: KustoSdkVersion
+    value: '6.0.4'
+
   # Pre-computed testScriptArgs chunks (paulmedynski's review suggestion).  The Windows entry point
   # is PowerShell and binds '-PascalCase' params, while the Linux one is bash and parses
   # '--kebab-case' flags, so the argument STYLE differs by platform.  Assembling the final args from
@@ -335,8 +341,22 @@ extends:
             # python3-venv package (no ensurepip), so both a plain 'pip install' and
             # 'python3 -m venv' fail. pip itself is available, so install the Kusto SDKs
             # into the per-user site and bypass the PEP 668 marker.
-            python3 -m pip install --quiet --upgrade --user --break-system-packages \
-              azure-kusto-data azure-kusto-ingest
+            #
+            # Versions are pinned deliberately, for two reasons:
+            #   1. This step runs inside an authenticated AzureCLI@2 context holding a token for the
+            #      ADX cluster, so an unpinned floating install would let any newly published version
+            #      of these packages (or of their transitive deps) execute with those credentials.
+            #      A pinned version also keeps perf runs reproducible instead of silently changing
+            #      whenever upstream publishes.
+            #   2. Direct access to public PyPI is expected to be withdrawn for this org in the near
+            #      future, following the same path as npm and NuGet. When that happens this install
+            #      must be repointed at the governed internal feed; pinning now means that migration
+            #      is a feed swap rather than also absorbing an unbounded version jump.
+            # TODO: repoint at the internal governed Python feed once it is available, and drop the
+            #       public PyPI dependency entirely.
+            python3 -m pip install --quiet --user --break-system-packages \
+              --disable-pip-version-check --no-input \
+              "azure-kusto-data==$(KustoSdkVersion)" "azure-kusto-ingest==$(KustoSdkVersion)"
 
             runFiles=""
             resFiles=""

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Microsoft.Data.SqlClient.PerformanceTests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Microsoft.Data.SqlClient.PerformanceTests.csproj
@@ -42,6 +42,10 @@
                       VersionOverride="$(MdsPackageVersion)" />
   </ItemGroup>
 
+  <!-- TODO (tracked by the perf-pipeline follow-up): remove this ItemGroup once the perf baseline    -->
+  <!-- moves off 7.1.0-preview1.26124.5, or once those two prerelease dependencies are published.    -->
+  <!-- This is a workaround pinned to one exact baseline version, so it is dead weight the moment    -->
+  <!-- the baseline is bumped - and silently so, since a stale condition simply never matches.       -->
   <!-- Microsoft.Data.SqlClient 7.1.0-preview1.26124.5 declares transitive dependencies on the      -->
   <!-- prerelease Microsoft.Data.SqlClient.Extensions.Abstractions and                              -->
   <!-- Microsoft.Data.SqlClient.Internal.Logging 1.0.0-preview1.26124.5 packages, which were never  -->


### PR DESCRIPTION
Follow-up to #4473, which was merged with six non-blocking review comments outstanding. This picks those up, plus the one Copilot comment on that PR that was never resolved.

Nothing here changes what the pipeline measures or how it reports — it's hardening of the harness, the credentials it handles, and the logic the regression gate depends on.

## Security / supply chain

**Pin the Kusto SDK install** (`sqlclient-perf-pipeline.yml`) — `pip install --upgrade azure-kusto-data azure-kusto-ingest` ran unpinned from public PyPI *inside* the `AzureCLI@2` task, i.e. in a context already holding a token for the ADX cluster. Any newly published version of those packages or their transitive dependencies would have executed with those credentials, and perf runs would silently change whenever upstream published. Now pinned to `6.0.4` via a single `KustoSdkVersion` variable, with `--upgrade` dropped.

There's also a TODO to repoint this at the internal governed Python feed. Direct access to public PyPI is expected to be withdrawn for the org before long, following npm and NuGet — pinning now means that migration is a feed swap rather than a feed swap *plus* an unbounded version jump.

**Keep the `sa` password out of the process table** (`run-perf-tests.sh`, `run-perf-tests.ps1`) — `sqlcmd -P <password>` puts the password in the command line, which is readable by any other user on the box (`/proc/<pid>/cmdline` on Linux; `Win32_Process` / Process Explorer on Windows). Another process's *environment block* is not readable, and `sqlcmd` reads `SQLCMDPASSWORD` natively, so all six call sites now use that.

## Pipeline reliability

**Ephemeral port range** (`run-perf-tests.sh`) — `net.ipv4.ip_local_port_range=1024 65535` let the connection-churn benchmarks grab 1433 or 22 as an outbound *source* port, on a VM where SQL Server and sshd are both listening. That shows up as an intermittent connection failure that reads as a perf anomaly. Raised the low bound to 10000.

**Python interpreter resolution** (`run-perf-tests.ps1`) — the Windows harness called `python3`, which is a Unix-ism; on Windows the interpreter is `python.exe` or the `py` launcher, and a stock image ships App Execution Alias stubs that resolve via `Get-Command` but only open the Store. The failure was also misleading: `Get-BenchmarkResultCount` swallows a failed python call and returns 0, so a missing interpreter surfaced as *"the run produced no benchmark results"*. Now resolved once up front (`python3` → `python` → `py -3`), probed for real rather than trusted, and failing fast with an accurate message.

**Distinguish "unknown" from "no ingestion failures"** (`ingest_kusto.py`) — this is Copilot's unresolved comment. `_dump_failures()` returns `None` when the `.show ingestion failures` diagnostic itself can't run (typically a missing monitoring role), but `if failures:` treated that identically to a confirmed zero and printed *"no ingestion failures were reported... the rows will land shortly"*. That's factually wrong in the `None` case and hides a repeatable permissions problem behind a soft, reassuring warning. The step still doesn't fail (it genuinely doesn't know), but it now says so and points at the fix.

## Benchmark methodology

**Pin CPU affinity before the process starts, not after** (`run-perf-tests.ps1`, `interleave_perf.py`) — both harnesses started the benchmark process and *then* assigned affinity, leaving process startup, assembly loading, JIT and BenchmarkDotNet's own setup running on arbitrary cores, including the ones reserved for SQL Server. That's exactly the cross-talk the pinning exists to remove.

- Windows: narrow the launching PowerShell process's affinity across `Process.Start()` so the child inherits it from its first instruction, then restore it immediately (the child already has the mask, and leaving the harness pinned would constrain the build and collection work that follows). The explicit assignment on the child is kept as a belt-and-braces re-assert and for the log line.
- Linux: use `preexec_fn` so the pin lands between `fork()` and `exec()`, with a fallback to the old post-start path if that fails. Worth noting this was the *interleaved* mode, which is the default — so it was less isolated than the legacy sequential path, which correctly wraps the process in `taskset`.

**Don't silently drop an unmappable regression** (`interleave_perf.py`) — if a regressed benchmark `Type` can't be mapped back to a unit, it's never re-run, so its tally is stuck at 1. Scored against `reps=3`, the strict-majority test `count * 2 > total_reps` could then *never* pass, so a real regression was quietly downgraded to "unconfirmed" and slipped through the gate — a false negative caused by bookkeeping rather than by the measurement. It's now scored against the number of reps actually performed for it (so it's reported rather than discarded) and logged loudly, since it means the unit list and the reported Type names have drifted apart.

## Tests

Added `eng/pipelines/perf/scripts/tests/test_perf_scripts.py` — 20 stdlib `unittest` tests over the comparison and best-of-N confirmation logic that `failOnRegression` depends on. No SQL Server, no BenchmarkDotNet, no ADX cluster required:

```
python3 -m unittest discover -s eng/pipelines/perf/scripts/tests -v
```

Coverage: `_pct` zero-baseline handling, every `build_comparison` status boundary (including that the threshold is exclusive, and that a 0-byte baseline allocation isn't dropped), unparseable-report tolerance, and the confirmation verdict — persistent vs. flaky regressions, strict majority, only-candidates-are-re-run, single-rep, improvements never counting as regressions, and the unmappable-regression case above.

## Validation

Since this is mostly pipeline code that can't be exercised locally, I verified what I could:

- `python3 -m unittest discover` — 20/20 pass, no skips
- `bash -n run-perf-tests.sh`, `python3 -m py_compile` on all perf scripts — clean
- PowerShell AST parse of `run-perf-tests.ps1` — clean
- Extracted `Resolve-Python3` from the file via AST and executed it for real: resolves the interpreter, and both call-site invocation styles (piped stdin and argument array) work. Also verified with a fake Store-stub `python3` on `PATH` that the stub is rejected and the chain falls through to a working `python`.
- Pipeline YAML parses, `KustoSdkVersion` resolves

## Deliberately not included

- Copilot's comment on `interleave_perf.py` `_fmt_alloc` in the interleaved report — @cheenamalhotra replied "Not needed" on #4473, so I've left that call alone.
- @paulmedynski's suggestion to move the large inline script blocks into script files was mostly addressed during #4473 (`show_perf_results.sh` and `translate_results_to_kusto.sh` were extracted). The Kusto ingestion `AzureCLI@2` block is the one that's left. Converting it from `inlineScript` to `scriptPath` changes the task wiring on a pipeline that can't be validated locally, so I'd rather do that as its own change than bundle it here.
- Every other Copilot comment on #4473 was checked against merged `main` and is already fixed.

## Checklist

- [x] Tests added or updated
- [x] Public API changes documented — n/a, no public API surface is touched
- [x] Verified against customer repro (if applicable) — n/a
- [x] Ensure no breaking changes introduced

## Suggested release note

None — this is test-infrastructure and pipeline-only, with no effect on the shipped driver.