### PR TITLE
Fix APIScan pipeline token and registered version

### DIFF
--- a/eng/pipelines/onebranch/jobs/build-buildproj-job.yml
+++ b/eng/pipelines/onebranch/jobs/build-buildproj-job.yml
@@ -102,6 +102,11 @@ jobs:
 
       ob_outputDirectory: '$(JOB_OUTPUT)'
 
+      # Expose the pipeline OAuth token to the auto-injected APIScan task as shown in the Guardian
+      # APIScan YAML sample:
+      # https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-mohanb/security-integration/guardian-wiki/sdl-azdo-extension/apiscan-build-task#yaml-samples
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
       # APIScan per-job configuration for the DLL and PDB folders.
       ob_sdl_apiscan_softwareFolder: ${{ parameters.apiScanDllPath }}
       ob_sdl_apiscan_symbolsFolder: ${{ parameters.apiScanPdbPath }}

--- a/eng/pipelines/onebranch/jobs/build-buildproj-job.yml
+++ b/eng/pipelines/onebranch/jobs/build-buildproj-job.yml
@@ -102,11 +102,6 @@ jobs:
 
       ob_outputDirectory: '$(JOB_OUTPUT)'
 
-      # Expose the pipeline OAuth token to the auto-injected APIScan task as shown in the Guardian
-      # APIScan YAML sample:
-      # https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-mohanb/security-integration/guardian-wiki/sdl-azdo-extension/apiscan-build-task#yaml-samples
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-
       # APIScan per-job configuration for the DLL and PDB folders.
       ob_sdl_apiscan_softwareFolder: ${{ parameters.apiScanDllPath }}
       ob_sdl_apiscan_symbolsFolder: ${{ parameters.apiScanPdbPath }}

--- a/eng/pipelines/onebranch/sqlclient-non-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-non-official.yml
@@ -185,7 +185,7 @@ extends:
         # Similar to the software name, we have a single version registered as well.  This has
         # nothing to do with the NuGet package version.  It is purely an APIScan registration
         # value that points to our backend configuration.
-        versionNumber: '6.10'
+        versionNumber: $(ApiScanSoftwareVersion)
 
         # We want the standard level of logging.
         verbosityLevel: standard

--- a/eng/pipelines/onebranch/sqlclient-non-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-non-official.yml
@@ -185,7 +185,7 @@ extends:
         # Similar to the software name, we have a single version registered as well.  This has
         # nothing to do with the NuGet package version.  It is purely an APIScan registration
         # value that points to our backend configuration.
-        softwareVersion: '6.10'
+        versionNumber: '6.10'
 
         # We want the standard level of logging.
         verbosityLevel: standard

--- a/eng/pipelines/onebranch/sqlclient-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-official.yml
@@ -200,7 +200,7 @@ extends:
         # Similar to the software name, we have a single version registered as well.  This has
         # nothing to do with the NuGet package version.  It is purely an APIScan registration
         # value that points to our backend configuration.
-        versionNumber: '6.10'
+        versionNumber: $(ApiScanSoftwareVersion)
 
         # We want the standard level of logging.
         verbosityLevel: standard

--- a/eng/pipelines/onebranch/sqlclient-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-official.yml
@@ -200,7 +200,7 @@ extends:
         # Similar to the software name, we have a single version registered as well.  This has
         # nothing to do with the NuGet package version.  It is purely an APIScan registration
         # value that points to our backend configuration.
-        softwareVersion: '6.10'
+        versionNumber: '6.10'
 
         # We want the standard level of logging.
         verbosityLevel: standard

--- a/eng/pipelines/onebranch/variables/onebranch-variables.yml
+++ b/eng/pipelines/onebranch/variables/onebranch-variables.yml
@@ -54,6 +54,11 @@ variables:
   - name: Packaging.EnableSBOMSigning
     value: true
 
+  # Keep this as a runtime variable reference in globalSdl.apiscan.versionNumber. Passing the
+  # quoted value directly through an Azure template expression perturbs '6.10' to the number 6.1.
+  - name: ApiScanSoftwareVersion
+    value: '6.10'
+
   # OneBranch supplies a variety of container images we must use for our jobs.
 
   # Windows jobs use this image.


### PR DESCRIPTION
## Description

Fix APIScan configuration in the official and non-official OneBranch pipelines:

- Expose `$(System.AccessToken)` as `SYSTEM_ACCESSTOKEN` in the shared package-build job, following the Guardian APIScan YAML guidance. This covers all six package build jobs that receive the auto-injected APIScan task.
- Rename the global APIScan `softwareVersion` setting to OneBranch's documented `versionNumber` setting so the registered version `6.10` is passed instead of falling back to the Azure Pipelines build ID.

In [sqlclient-official run 26212.1](https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=163917), all six APIScan tasks reported the missing `SYSTEM_ACCESSTOKEN`. APIScan then received version `163917` and failed release registration validation because that version was not registered.

This is an engineering pipeline-only change. It introduces no product or public API changes.

## Issues

No linked issue.

Related pipeline run:  [sqlclient-official run 26212.1](https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=163917)

## Testing

- [x] break-on-SDL-error Enabled: sqlclient-non-official: [26216.1](https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=164447&view=results)
- [x] break-on-SDL-error Disabled: sqlclient-non-official: [26216.2](https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=164461&view=results)
