### PR TITLE
Enable MSAL broker on macOS and Linux

### DIFF
--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/doc/ActiveDirectoryAuthenticationProvider.xml
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/doc/ActiveDirectoryAuthenticationProvider.xml
@@ -160,11 +160,11 @@ See the LICENSE file in the project root for more information.
         Pass <see langword="null" /> to clear a previously installed callback and revert to the provider's default behavior.
       </param>
       <summary>
-        Sets a function to return the parent window handle to be used for WAM (Windows Account Manager) broker authentication prompts.
+        Sets a function to return the parent window handle to be used for interactive authentication prompts.
       </summary>
       <remarks>
-        On Windows, this handle is used to parent the WAM broker dialog. If not set, the provider will attempt to automatically detect the console window handle.
-        On non-Windows platforms, this callback is forwarded to MSAL so interactive flows can parent their UI to the host Activity / UIViewController (or platform equivalent).
+        On Windows, this handle is used to parent the WAM (Windows Account Manager) broker dialog. If not set, the provider will attempt to automatically detect the console window handle.
+        On non-Windows platforms, this callback is forwarded to MSAL so interactive flows can parent their UI to the host Activity / UIViewController (or platform equivalent). MSAL currently ignores the handle when the Linux or macOS broker is in effect, so the broker dialog is centered on screen.
 
         Exceptions thrown by <paramref name="parentActivityOrWindowFunc" /> when it is invoked by MSAL are not caught by the provider; they propagate up to the caller of the originating <c>AcquireToken</c> request so that bugs in the callback surface where they are most diagnosable.
       </remarks>

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/doc/ActiveDirectoryAuthenticationProviderOptions.xml
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/doc/ActiveDirectoryAuthenticationProviderOptions.xml
@@ -7,7 +7,7 @@
             <remarks>
                 Prefer this options-bag constructor over the positional-argument overloads in new code. Additional options can be added here in future versions without introducing new constructor overloads.
                 <para>
-                    <see cref="P:Microsoft.Data.SqlClient.ActiveDirectoryAuthenticationProviderOptions.UseWamBroker" /> is a Windows-only setting: it has no effect on non-Windows platforms, where interactive Entra ID flows always use the system browser.
+                    <see cref="P:Microsoft.Data.SqlClient.ActiveDirectoryAuthenticationProviderOptions.UseWamBroker" /> enables the native authentication broker on Windows, Linux and macOS. Each platform expects a different redirect URI and requires an operating system component that may not be installed.
                 </para>
             </remarks>
         </ActiveDirectoryAuthenticationProviderOptions>
@@ -20,15 +20,36 @@
         </DeviceCodeFlowCallback>
         <ApplicationClientId>
             <summary>
-                Optional Entra ID application (client) id. When <see langword="null"/>, the SqlClient first-party application id is used and WAM broker mode is forced on (regardless of <see cref="UseWamBroker"/>) when running on Windows.
+                Optional Entra ID application (client) id. When <see langword="null"/>, the SqlClient first-party application id is used and broker mode is forced on (regardless of <see cref="UseWamBroker"/>).
             </summary>
         </ApplicationClientId>
         <UseWamBroker>
             <summary>
-                Windows-only setting to control whether the provider uses the WAM broker for interactive authentication. 
+                Controls whether the provider uses the native authentication broker for interactive authentication: the Windows Account Manager (WAM) on Windows, and the msalruntime broker on Linux and macOS. 
                 Defaults to <see langword="false"/> when you provide a custom <see cref="ApplicationClientId"/>.
-                Otherwise, WAM broker mode is used automatically on Windows.
+                Otherwise, broker mode is used automatically.
             </summary>
+            <remarks>
+                Broker mode requires the Entra ID app registration for <see cref="ApplicationClientId"/> to list a redirect URI under "Mobile and desktop applications". Each broker uses a different one:
+                <list type="bullet">
+                    <item><description>Windows: <c>ms-appx-web://microsoft.aad.brokerplugin/{clientId}</c>.</description></item>
+                    <item><description>Linux: <c>https://login.microsoftonline.com/common/oauth2/nativeclient</c>. This URI must be explicitly enabled on the app registration.</description></item>
+                    <item><description>macOS, bundled application: <c>msauth.{bundleIdentifier}://auth</c>, where <c>bundleIdentifier</c> is the host application's <c>CFBundleIdentifier</c>.</description></item>
+                    <item><description>macOS, executable or script that is not a bundled application: <c>msauth.com.msauth.unsignedapp://auth</c>.</description></item>
+                </list>
+                <para>
+                    The broker also requires an operating system component: the Windows Account Manager on Windows 10 or later, the <c>microsoft-identity-broker</c> package on Linux, or the Microsoft Company Portal on macOS.
+                </para>
+                <para>
+                    On Linux the broker is only used on x64 glibc runtimes where the native msalruntime library can be loaded. That library is not published for other Linux runtime identifiers, and it links against <c>libwebkit2gtk</c>, <c>libsecret</c> and <c>libx11</c>, which are absent from most server and container images. Linux hosts that cannot load it use the system browser instead.
+                </para>
+                <para>
+                    On macOS, a bundled application cannot use the built-in SqlClient application id, because its redirect URI is derived from the application's own bundle identifier. Set <see cref="ApplicationClientId"/> to an Entra ID application you control and register <c>msauth.{bundleIdentifier}://auth</c> on it. Connecting with the built-in application id from a bundled application throws, except for <c>SqlAuthenticationMethod.ActiveDirectoryDeviceCodeFlow</c>, which does not use the broker.
+                </para>
+                <para>
+                    On macOS, MSAL requires interactive token acquisition to run on the process main thread when the host is not running an AppKit message loop. A console application must therefore drive its work through <c>MacMainThreadScheduler</c> so that <c>SqlConnection.Open</c> resolves on the main thread. Applications that do not do so fail with <c>MsalClientException</c> ("Interactive requests with mac broker enabled must be executed on the main thread on macOS") when interactive sign-in is needed. This does not affect <c>SqlAuthenticationMethod.ActiveDirectoryIntegrated</c> or any flow satisfied from the token cache.
+                </para>
+            </remarks>
         </UseWamBroker>
     </members>
 </docs>

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.Broker.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.Broker.cs
@@ -1,0 +1,266 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Microsoft.Identity.Client;
+
+namespace Microsoft.Data.SqlClient;
+
+/// <summary>
+/// Cross-platform broker plumbing for <see cref="ActiveDirectoryAuthenticationProvider"/>. The
+/// other parts of the partial class live in <c>ActiveDirectoryAuthenticationProvider.cs</c> and
+/// <c>ActiveDirectoryAuthenticationProvider.Windows.cs</c>.
+/// </summary>
+/// <remarks>
+/// MSAL routes brokered authentication through the native <c>msalruntime</c> library shipped by
+/// the <c>Microsoft.Identity.Client.NativeInterop</c> package. That package only carries native
+/// binaries for a subset of runtime identifiers, and the Linux binary additionally links against
+/// desktop libraries that are absent from most server and container images. MSAL throws
+/// <c>MsalClientException("wam_runtime_init_failed")</c> on the first token request when the
+/// native library cannot be loaded, with no fallback to the system browser. This file decides,
+/// once per process, whether the broker can actually be used on the current platform so that
+/// unsupported runtimes fall back to the browser instead of failing outright.
+/// </remarks>
+public sealed partial class ActiveDirectoryAuthenticationProvider
+{
+    // The broker operating system flag matching the current runtime, or None when the broker
+    // cannot be used here. Computed at most once because none of the inputs (OS, process
+    // architecture, whether the native library can be loaded) change during the process lifetime.
+    //
+    // Deliberately lazy rather than a plain static field initializer. SqlAuthenticationProviderManager
+    // constructs this provider from its own static constructor, so a field initializer would run
+    // the Linux probe -- an assembly load plus dlopen of libmsalruntime.so and its libwebkit2gtk,
+    // libsecret and libx11 dependencies -- during class initialization for every process using
+    // Entra ID authentication. Managed identity, workload identity, service principal and default
+    // credential flows never build a PublicClientApplication, so they must not pay for it, and
+    // triggering an assembly load from a nested type initializer is a loader-ordering hazard.
+    private static readonly Lazy<BrokerOptions.OperatingSystems> s_brokerOperatingSystem =
+        new(DetectBrokerOperatingSystem);
+
+    /// <summary>
+    /// The <see cref="BrokerOptions.OperatingSystems"/> flag supported by the current runtime, or
+    /// <see cref="BrokerOptions.OperatingSystems.None"/> when brokered authentication is not
+    /// available. Exposed as <c>internal</c> for tests.
+    /// </summary>
+    internal static BrokerOptions.OperatingSystems SupportedBrokerOperatingSystem =>
+        s_brokerOperatingSystem.Value;
+
+    /// <summary>
+    /// Whether this provider instance will actually enable the broker: it must be opted in (see
+    /// <see cref="UseWamBroker"/>) and running on a platform where the broker is available.
+    /// Exposed as <c>internal</c> for tests.
+    /// </summary>
+    internal bool IsBrokerEnabledOnCurrentPlatform =>
+        _useWamBroker && s_brokerOperatingSystem.Value != BrokerOptions.OperatingSystems.None;
+
+    /// <summary>
+    /// Resolves the MSAL redirect URI for this provider instance.
+    /// </summary>
+    /// <param name="authenticationMethod">
+    /// The authentication method being attempted, used to describe failures.
+    /// </param>
+    /// <remarks>
+    /// Each broker uses a different redirect URI scheme, and the Entra ID app registration for the
+    /// configured client id must list the URI selected here.
+    /// </remarks>
+    /// <exception cref="Extensions.Azure.AuthenticationException">
+    /// The host is a bundled macOS application using SqlClient's first-party application id. Such
+    /// applications need a redirect URI derived from their own bundle identifier, which can only
+    /// be registered on an app registration the caller controls.
+    /// </exception>
+    internal string GetRedirectUri(SqlAuthenticationMethod authenticationMethod)
+    {
+        if (IsBrokerEnabledOnCurrentPlatform)
+        {
+            switch (s_brokerOperatingSystem.Value)
+            {
+                case BrokerOptions.OperatingSystems.Windows:
+                    return s_wamBrokerRedirectUriPrefix + _applicationClientId;
+
+                case BrokerOptions.OperatingSystems.Linux:
+                    // The Linux broker requires the native client redirect URI, which must be
+                    // explicitly enabled on the app registration.
+                    return s_nativeClientRedirectUri;
+
+                case BrokerOptions.OperatingSystems.OSX:
+                    return GetMacBrokerRedirectUri(authenticationMethod);
+            }
+        }
+
+        #if NETFRAMEWORK
+        // .NET Framework falls back to the embedded WebView, which uses the native client
+        // redirect URI rather than a loopback address.
+        return s_nativeClientRedirectUri;
+        #else
+        return s_systemBrowserRedirectUri;
+        #endif
+    }
+
+    /// <summary>
+    /// Resolves the redirect URI expected by the macOS broker for the current host process.
+    /// </summary>
+    /// <remarks>
+    /// The macOS broker keys the redirect URI off the host application rather than the client id.
+    /// A bundled application must use <c>msauth.[bundle_id]://auth</c>, while a loose executable
+    /// or script uses the fixed <c>msauth.com.msauth.unsignedapp://auth</c> URI. Because a bundle
+    /// identifier is specific to the calling application, it can never be registered on SqlClient's
+    /// first-party app registration, so that combination is rejected with an actionable error.
+    /// </remarks>
+    private string GetMacBrokerRedirectUri(SqlAuthenticationMethod authenticationMethod)
+    {
+        string? bundleIdentifier = Interop.NSBundle.TryGetMainBundleIdentifier();
+
+        if (bundleIdentifier is null)
+        {
+            return s_macUnsignedAppRedirectUri;
+        }
+
+        // Device code flow never reaches the broker: MSAL's DeviceCodeRequest has no broker
+        // strategy, and the user completes sign-in on a separate device. Rejecting it here would
+        // remove the one interactive flow a bundled application can still use with the built-in
+        // application id, so fall back to a redirect URI that is registered on it.
+        if (_applicationClientId == s_sqlClientApplicationId)
+        {
+            if (authenticationMethod == SqlAuthenticationMethod.ActiveDirectoryDeviceCodeFlow)
+            {
+                return s_macUnsignedAppRedirectUri;
+            }
+
+            throw new Extensions.Azure.AuthenticationException(
+                authenticationMethod,
+                $"The macOS authentication broker requires the redirect URI " +
+                $"'{s_macBrokerRedirectUriPrefix}{bundleIdentifier}{s_macBrokerRedirectUriSuffix}' for bundled applications, " +
+                $"which cannot be registered on SqlClient's built-in application id. Register that redirect URI on your " +
+                $"own Entra ID application and supply its client id via " +
+                $"{nameof(ActiveDirectoryAuthenticationProviderOptions)}.{nameof(ActiveDirectoryAuthenticationProviderOptions.ApplicationClientId)}, " +
+                $"or use {nameof(SqlAuthenticationMethod.ActiveDirectoryDeviceCodeFlow)} instead.");
+        }
+
+        return s_macBrokerRedirectUriPrefix + bundleIdentifier + s_macBrokerRedirectUriSuffix;
+    }
+
+    private static BrokerOptions.OperatingSystems DetectBrokerOperatingSystem()
+    {
+        // Microsoft.Identity.Client.NativeInterop ships msalruntime for win-x86, win-x64 and
+        // win-arm64, so every Windows architecture we support is covered.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return BrokerOptions.OperatingSystems.Windows;
+        }
+
+        // osx-x64 and osx-arm64 binaries both ship, and the broker itself is provided by the
+        // Company Portal app rather than a native dependency of our own.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return BrokerOptions.OperatingSystems.OSX;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && IsLinuxBrokerRuntimeAvailable())
+        {
+            return BrokerOptions.OperatingSystems.Linux;
+        }
+
+        return BrokerOptions.OperatingSystems.None;
+    }
+
+    /// <summary>
+    /// Whether the native msalruntime binary can be loaded on the current Linux runtime.
+    /// </summary>
+    /// <remarks>
+    /// Microsoft.Identity.Client.NativeInterop only ships <c>linux-x64</c>. There is no
+    /// <c>linux-arm64</c>, <c>linux-arm</c> or <c>linux-musl-*</c> binary, and the musl RIDs do
+    /// not fall back to <c>linux-x64</c> in the RID graph. Even on <c>linux-x64</c> the binary
+    /// links against <c>libwebkit2gtk</c>, <c>libsecret</c> and <c>libX11</c>, which are absent
+    /// from most server and container images. Rather than guess at that dependency list, this
+    /// attempts the load MSAL would perform and treats a failure as "no broker here".
+    /// </remarks>
+    private static bool IsLinuxBrokerRuntimeAvailable()
+    {
+        #if NETFRAMEWORK
+        // .NET Framework only runs on Windows, so this is unreachable.
+        return false;
+        #else
+        if (RuntimeInformation.ProcessArchitecture != Architecture.X64)
+        {
+            return false;
+        }
+
+        // RuntimeInformation.RuntimeIdentifier is not available on netstandard2.0, but it is a
+        // thin wrapper over this AppContext entry, which the host populates on .NET Core and
+        // later. A null value means we cannot tell, in which case the x64 check above is the
+        // best signal we have.
+        string? runtimeIdentifier = AppContext.GetData("RUNTIME_IDENTIFIER") as string;
+        if (runtimeIdentifier is not null &&
+            runtimeIdentifier.IndexOf("musl", StringComparison.OrdinalIgnoreCase) >= 0)
+        {
+            return false;
+        }
+
+        return CanLoadMsalRuntime();
+        #endif
+    }
+
+    // The name Microsoft.Identity.Client.NativeInterop's P/Invokes use for the native library on
+    // linux-x64. That package picks an architecture-specific name ("msalruntime_x86",
+    // "msalruntime_arm64", and so on), so this value is only correct because the Linux broker is
+    // restricted to x64 above. It resolves to "libmsalruntime.so".
+    private const string LinuxMsalRuntimeLibraryName = "msalruntime";
+
+    /// <summary>
+    /// Attempts to load the native msalruntime library the same way MSAL's P/Invokes would.
+    /// </summary>
+    /// <remarks>
+    /// This resolves through the <c>Microsoft.Identity.Client.NativeInterop</c> assembly so that
+    /// the runtime applies the same deps.json and RID-specific probing paths a <c>DllImport</c>
+    /// from that assembly would use. On Linux that is the whole story: the package's own explicit
+    /// preload builds its path with Windows separators, so the file is never found there and
+    /// resolution falls through to the plain <c>DllImport</c>. Loading the library is side-effect
+    /// free, because the global <c>MSALRUNTIME_Startup</c> initialization only happens when MSAL
+    /// constructs its <c>NativeInterop.Core</c>, and <c>dlopen</c> is reference counted so the
+    /// later load reuses this handle. <c>System.Runtime.InteropServices.NativeLibrary</c> is not
+    /// part of netstandard2.0, so it is invoked reflectively; when it is unavailable (which
+    /// includes .NET Framework, where this path is unreachable anyway) the broker is left
+    /// disabled.
+    /// </remarks>
+    private static bool CanLoadMsalRuntime()
+    {
+        try
+        {
+            Assembly? nativeInterop = Type
+                .GetType("Microsoft.Identity.Client.NativeInterop.Core, Microsoft.Identity.Client.NativeInterop", throwOnError: false)
+                ?.Assembly;
+            if (nativeInterop is null)
+            {
+                return false;
+            }
+
+            Type? nativeLibrary = Type.GetType(
+                "System.Runtime.InteropServices.NativeLibrary, System.Runtime.InteropServices",
+                throwOnError: false);
+            MethodInfo? tryLoad = nativeLibrary
+                ?.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .FirstOrDefault(static method =>
+                    method.Name == "TryLoad" &&
+                    method.GetParameters() is { Length: 4 } parameters &&
+                    parameters[0].ParameterType == typeof(string) &&
+                    parameters[1].ParameterType == typeof(Assembly));
+            if (tryLoad is null)
+            {
+                return false;
+            }
+
+            object?[] arguments = new object?[] { LinuxMsalRuntimeLibraryName, nativeInterop, null, null };
+
+            return tryLoad.Invoke(null, arguments) is true;
+        }
+        catch (Exception)
+        {
+            // A missing dependency surfaces as a TargetInvocationException wrapping
+            // DllNotFoundException; anything else means we could not determine support. Either
+            // way, leaving the broker disabled keeps the browser fallback available.
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.Windows.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.Windows.cs
@@ -9,15 +9,18 @@ namespace Microsoft.Data.SqlClient;
 /// <summary>
 /// Windows-only portion of <see cref="ActiveDirectoryAuthenticationProvider"/>. Kept in a
 /// separate file so the Windows-specific P/Invoke helpers (console-window discovery, root-owner
-/// lookup) live next to the broker plumbing they support. The other half of the partial class
-/// lives in <c>ActiveDirectoryAuthenticationProvider.cs</c> and is fully cross-platform.
+/// lookup) live next to the broker plumbing they support. The other halves of the partial class
+/// live in <c>ActiveDirectoryAuthenticationProvider.cs</c> and
+/// <c>ActiveDirectoryAuthenticationProvider.Broker.cs</c> and are fully cross-platform.
 /// </summary>
 /// <remarks>
 /// Responsibilities of this part:
 /// <list type="bullet">
 ///   <item><description>
 ///     Resolve the parent window handle handed to MSAL's WAM broker (and to the embedded WebView
-///     on .NET Framework) via <c>WithParentActivityOrWindow</c>.
+///     on .NET Framework) via <c>WithParentActivityOrWindow</c>. Windows is the only platform
+///     where MSAL requires a real handle: it throws <c>window_handle_required</c> when the
+///     handle is zero, whereas the Linux and macOS brokers ignore the value entirely.
 ///   </description></item>
 ///   <item><description>
 ///     Honor the caller-supplied <c>SetParentActivityOrWindowFunc</c> callback when present, and

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.cs
@@ -33,20 +33,29 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
     private const int s_accountPwCacheTtlInHours = 2;
 
     // SqlClient's first-party Entra ID application id. When the provider is constructed without
-    // a caller-supplied application id (or with this id explicitly), WAM broker mode is forced on
-    // because the corresponding app registration is configured for the WAM broker redirect URI.
+    // a caller-supplied application id (or with this id explicitly), broker mode is forced on
+    // because the corresponding app registration is configured for the broker redirect URI.
     private const string s_sqlClientApplicationId = "2fd908ad-0664-4344-b9be-cd3e8b574c38";
 
-    // MSAL redirect URI used when WAM brokered authentication is in effect on Windows. MSAL
-    // expects the suffix to match the client id of the registered application.
+    // Redirect URI used by the Windows Account Manager broker. MSAL expects the suffix to match
+    // the client id of the registered application.
     private const string s_wamBrokerRedirectUriPrefix = "ms-appx-web://microsoft.aad.brokerplugin/";
 
-    // Non-broker redirect URI used on .NET Framework when WAM is not in use (legacy embedded
-    // WebView path).
-    private const string s_windowsNativeRedirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
+    // Redirect URI required by the Linux broker, and used on .NET Framework when the broker is
+    // not in use (legacy embedded WebView path).
+    private const string s_nativeClientRedirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
 
-    // Loopback redirect URI used by MSAL's system browser flow on non-Windows platforms and on
-    // .NET (non-framework) Windows without WAM.
+    // Redirect URI the macOS broker expects from a bundled application. The host application's
+    // bundle identifier goes between the prefix and the suffix.
+    private const string s_macBrokerRedirectUriPrefix = "msauth.";
+    private const string s_macBrokerRedirectUriSuffix = "://auth";
+
+    // Redirect URI the macOS broker expects from an unsigned, non-bundled executable or script.
+    // Unlike the bundled form this is a fixed value, so it can be registered up front.
+    private const string s_macUnsignedAppRedirectUri = "msauth.com.msauth.unsignedapp://auth";
+
+    // Loopback redirect URI used by MSAL's system browser flow on .NET when the broker is not in
+    // use.
     private const string s_systemBrowserRedirectUri = "http://localhost";
 
     // Suffix MSAL requires on Entra ID resource scopes (e.g. "https://database.windows.net/.default").
@@ -57,9 +66,10 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
     // single-string overload.
     private readonly string _applicationClientId = s_sqlClientApplicationId;
 
-    // True when this provider should enable the Windows Account Manager (WAM) broker for
-    // interactive Entra ID flows on Windows. Always true for the SqlClient first-party app id;
-    // for caller-supplied app ids, opt-in via the Options-pattern constructor.
+    // True when this provider should enable the native authentication broker (Windows Account
+    // Manager on Windows, msalruntime broker on Linux and macOS) for interactive Entra ID flows.
+    // Always true for the SqlClient first-party app id; for caller-supplied app ids, opt-in via
+    // the Options-pattern constructor.
     private readonly bool _useWamBroker = false;
 
     private readonly string _type = typeof(ActiveDirectoryAuthenticationProvider).Name;
@@ -106,22 +116,26 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
         {
             _applicationClientId = options.ApplicationClientId;
         }
-        // WAM broker mode is always enabled for the SqlClient first-party application id (its
-        // app registration is configured for the WAM broker redirect URI). For a caller-supplied
-        // application id, WAM is opt-in via ProviderOptions.UseWamBroker.
+        // Broker mode is always enabled for the SqlClient first-party application id (its app
+        // registration is configured for the broker redirect URI). For a caller-supplied
+        // application id, the broker is opt-in via ProviderOptions.UseWamBroker.
         _useWamBroker = _applicationClientId == s_sqlClientApplicationId || options.UseWamBroker;
     }
 
     /// <summary>
-    /// Indicates whether this provider instance has the Windows Account Manager (WAM) broker
-    /// enabled for interactive Entra ID flows on Windows. Exposed as <c>internal</c> for tests.
+    /// Indicates whether this provider instance has the native authentication broker enabled for
+    /// interactive Entra ID flows. Exposed as <c>internal</c> for tests.
     /// </summary>
+    /// <remarks>
+    /// This reflects the caller's intent only. Use <see cref="IsBrokerEnabledOnCurrentPlatform"/>
+    /// to know whether the broker is actually usable on the current runtime.
+    /// </remarks>
     internal bool UseWamBroker => _useWamBroker;
 
     /// <summary>
     /// The Entra ID application client id used by this provider instance. Exposed as <c>internal</c> for tests.
-    /// The client id is used in the redirect URI when WAM broker mode is enabled, so it must match the client id configured
-    /// in the app registration for the Entra ID application to successfully broker with WAM on Windows.
+    /// The client id is used in the redirect URI when broker mode is enabled, so it must match the client id configured
+    /// in the app registration for the Entra ID application to successfully broker authentication.
     /// </summary>
     internal string ApplicationClientId => _applicationClientId;
 
@@ -298,21 +312,14 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
                 * For the remaining Active Directory authentication methods, we use MSAL.NET to acquire tokens.
                 * To do that, we need to construct a PublicClientApplication instance.
                 *
-                * With WAM broker support in MSAL enabled, on Windows we use a fixed redirect URI in the format
-                * "ms-appx-web://microsoft.aad.brokerplugin/{clientId}" where {clientId} is the client ID configured for this provider
-                * (by default SqlClient's first-party app id, but it can be overridden via the constructor).
-                * This is required for MSAL to correctly route the authentication request to the WAM broker and for WAM to route the response back to MSAL.
+                * The redirect URI depends on which broker, if any, is in play: the WAM URI on
+                * Windows, the native client URI on Linux, and a bundle-derived URI on macOS. See
+                * GetRedirectUri for details.
                 *
-                * This means the Entra ID app registration for that client ID must include the above redirect URI to use WAM brokered authentication on Windows.
+                * The Entra ID app registration for the configured client id must list the
+                * resulting redirect URI for brokered authentication to succeed.
             */
-            string redirectUri = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                ? (_useWamBroker ? s_wamBrokerRedirectUriPrefix + _applicationClientId
-                #if NETFRAMEWORK
-                    : s_windowsNativeRedirectUri)
-                #else
-                    : s_systemBrowserRedirectUri)
-                #endif
-                : s_systemBrowserRedirectUri;
+            string redirectUri = GetRedirectUri(parameters.AuthenticationMethod);
 
             PublicClientAppKey pcaKey =
             #if NETFRAMEWORK
@@ -520,9 +527,11 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
                 $"Azure.Identity error: {ex.Message}",
                 ex);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not Extensions.Azure.AuthenticationException)
         {
-            // These errors aren't retryable.
+            // These errors aren't retryable. AuthenticationException is excluded because it is
+            // already the shape we want to surface; re-wrapping it would bury its message behind
+            // "Unexpected error" and reset its failure code to "Unknown".
             throw new Extensions.Azure.AuthenticationException(
                 parameters.AuthenticationMethod,
                 failureCode: "Unknown",
@@ -816,16 +825,23 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
             //      tenant.
             .WithAuthority(publicClientAppKey.Authority);
 
+        if (IsBrokerEnabledOnCurrentPlatform)
+        {
+            // Enable the native authentication broker for all supported authentication modes:
+            // the Windows Account Manager (WAM) on Windows, and the msalruntime broker on Linux
+            // and macOS. The broker provides enhanced security by enabling device-based
+            // Conditional Access policies.
+            //
+            // MSAL only degrades to a browser flow when the broker is unusable on Windows. On
+            // Linux and macOS it surfaces the broker failure to the caller instead, so
+            // s_brokerOperatingSystem is already restricted to runtimes where msalruntime loads.
+            // Whether the OS broker itself is present (the microsoft-identity-broker package on
+            // Linux, the Company Portal on macOS) can only be determined at request time.
+            builder.WithBroker(new BrokerOptions(s_brokerOperatingSystem.Value));
+        }
+
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            if (_useWamBroker)
-            {
-                // Enable WAM broker on Windows for all supported authentication modes.
-                // The broker provides enhanced security by enabling device-based Conditional Access
-                // policies through the Windows Account Manager (WAM).
-                builder.WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows));
-            }
-
             // Set the parent window handle for broker UI.
             // On .NET Framework, prefer the IWin32WindowFunc if provided by the caller.
             #if NETFRAMEWORK
@@ -843,9 +859,10 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
         }
         else
         {
-            // Non-Windows (Android / iOS / MAUI on .NET). Forward the caller-supplied callback
-            // to MSAL so interactive flows can parent their UI to the host Activity /
-            // UIViewController. WAM broker remains Windows-only and is intentionally skipped.
+            // Non-Windows (Linux / macOS / Android / iOS / MAUI on .NET). Forward the
+            // caller-supplied callback to MSAL so interactive flows can parent their UI to the
+            // host Activity / UIViewController. MSAL currently ignores the parent handle when the
+            // Linux or macOS broker is in effect, so the broker dialog is centered on screen.
             // The callback is snapshotted at PCA build time; callers who update the callback
             // after the PCA is cached must invoke ClearUserTokenCache() to pick up the change.
             Func<object>? parentActivityOrWindowFunc = _parentActivityOrWindowFunc;

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/AuthenticationException.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/AuthenticationException.cs
@@ -19,7 +19,16 @@ internal class AuthenticationException : SqlAuthenticationProviderException
     internal AuthenticationException(
         SqlAuthenticationMethod method,
         string message)
-    : base($"Failed to acquire access token for {method}: {message}", null)
+    // Chains to the six-parameter base ctor rather than the two-parameter one so that Method is
+    // carried on the exception itself, not just interpolated into the message. ADP.CreateSqlException
+    // surfaces Method as SqlError.Procedure, which would otherwise read "NotSpecified".
+    : base(
+        method,
+        failureCode: "Unknown",
+        shouldRetry: false,
+        retryPeriod: 0,
+        $"Failed to acquire access token for {method}: {message}",
+        null)
     {
     }
 

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/Interop/Interop.NSBundle.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/Interop/Interop.NSBundle.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Data.SqlClient;
+
+/// <summary>
+/// Objective-C runtime P/Invoke wrappers used by <see cref="ActiveDirectoryAuthenticationProvider" />
+/// to read the host process' bundle identifier on macOS. Follows the .NET runtime's <c>Interop</c>
+/// convention: imports grouped into a nested <c>Interop.&lt;module&gt;</c> static class that
+/// mirrors the native library it targets.
+/// </summary>
+internal static partial class Interop
+{
+    internal static partial class NSBundle
+    {
+        private const string LibObjcLib = "/usr/lib/libobjc.dylib";
+
+        // The main bundle identifier is fixed for the lifetime of the process, and -[NSString
+        // UTF8String] hands back an autoreleased buffer that nothing drains on a .NET thread
+        // pool thread. Resolve it once so repeated connections don't accumulate those buffers.
+        private static readonly Lazy<string?> s_mainBundleIdentifier =
+            new(ResolveMainBundleIdentifier);
+
+        /// <summary>
+        /// Equivalent to the Objective-C expression <c>[[NSBundle mainBundle] bundleIdentifier]</c>.
+        /// </summary>
+        /// <returns>
+        /// The bundle identifier of the host application (for example <c>com.contoso.myapp</c>),
+        /// or <see langword="null"/> when the process is not a bundled application. Loose
+        /// executables and scripts launched from a terminal have a main bundle whose
+        /// <c>bundleIdentifier</c> is <c>nil</c>.
+        /// </returns>
+        /// <remarks>
+        /// The macOS broker derives the expected redirect URI from the host application's bundle
+        /// identifier, so this determines which redirect URI MSAL must be configured with. Any
+        /// failure to resolve the class or selectors is treated as "not bundled", which selects
+        /// the redirect URI registered for unsigned, non-bundled executables.
+        /// </remarks>
+        internal static string? TryGetMainBundleIdentifier() => s_mainBundleIdentifier.Value;
+
+        private static string? ResolveMainBundleIdentifier()
+        {
+            try
+            {
+                IntPtr bundleClass = objc_getClass("NSBundle");
+                if (bundleClass == IntPtr.Zero)
+                {
+                    return null;
+                }
+
+                IntPtr mainBundle = SendMessage(bundleClass, "mainBundle");
+                if (mainBundle == IntPtr.Zero)
+                {
+                    return null;
+                }
+
+                IntPtr bundleIdentifier = SendMessage(mainBundle, "bundleIdentifier");
+                if (bundleIdentifier == IntPtr.Zero)
+                {
+                    return null;
+                }
+
+                IntPtr utf8 = SendMessage(bundleIdentifier, "UTF8String");
+                if (utf8 == IntPtr.Zero)
+                {
+                    return null;
+                }
+
+                // Bundle identifiers are reverse-DNS strings, so ANSI marshalling is lossless
+                // here. Marshal.PtrToStringUTF8 is not available on netstandard2.0.
+                string? identifier = Marshal.PtrToStringAnsi(utf8);
+
+                return string.IsNullOrEmpty(identifier) ? null : identifier;
+            }
+            catch (Exception)
+            {
+                // DllNotFoundException / EntryPointNotFoundException on a runtime without the
+                // Objective-C runtime, or any other interop failure.
+                return null;
+            }
+        }
+
+        private static IntPtr SendMessage(IntPtr receiver, string selectorName)
+        {
+            IntPtr selector = sel_registerName(selectorName);
+
+            return selector == IntPtr.Zero ? IntPtr.Zero : objc_msgSend(receiver, selector);
+        }
+
+        [DllImport(LibObjcLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr objc_getClass(string name);
+
+        [DllImport(LibObjcLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr sel_registerName(string name);
+
+        [DllImport(LibObjcLib, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr objc_msgSend(IntPtr receiver, IntPtr selector);
+    }
+}

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/test/WamBrokerTests.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/test/WamBrokerTests.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
+using System.Runtime.InteropServices;
+using Microsoft.Identity.Client;
 
 namespace Microsoft.Data.SqlClient.Extensions.Azure.Test;
 
@@ -11,6 +13,16 @@ public class WamBrokerTests
 {
     // The SqlClient first-party application client id that is hard-coded in the provider.
     private const string SqlClientApplicationId = "2fd908ad-0664-4344-b9be-cd3e8b574c38";
+
+    // MSAL's fixed Windows broker redirect URI prefix. Must match the constant in the provider.
+    private const string BrokerRedirectUriPrefix = "ms-appx-web://microsoft.aad.brokerplugin/";
+
+    // Redirect URI required by the Linux broker. Must match the constant in the provider.
+    private const string NativeClientRedirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
+
+    // Redirect URI the macOS broker expects from a non-bundled executable or script. Must match
+    // the constant in the provider.
+    private const string MacUnsignedAppRedirectUri = "msauth.com.msauth.unsignedapp://auth";
 
     // A fixed, deterministic stand-in for a caller-supplied application id. Hard-coded (instead
     // of Guid.NewGuid()) so test outcomes don't depend on RNG and so a single point asserts
@@ -313,4 +325,303 @@ public class WamBrokerTests
             }
         }
     }
+
+    /// <summary>
+    /// The broker is supported on Windows, macOS and x64 glibc Linux where the native
+    /// msalruntime binary can be loaded. This asserts the platform detection agrees with the
+    /// runtime we are executing on, so the matrix legs each cover their own platform.
+    /// </summary>
+    [Fact]
+    public void SupportedBrokerOperatingSystem_MatchesCurrentPlatform()
+    {
+        BrokerOptions.OperatingSystems actual =
+            ActiveDirectoryAuthenticationProvider.SupportedBrokerOperatingSystem;
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.Equal(BrokerOptions.OperatingSystems.Windows, actual);
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            // Microsoft.Identity.Client.NativeInterop ships both osx-x64 and osx-arm64 binaries,
+            // so the broker is available on every macOS host.
+            Assert.Equal(BrokerOptions.OperatingSystems.OSX, actual);
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            // Microsoft.Identity.Client.NativeInterop only ships a linux-x64 msalruntime, and
+            // that binary needs desktop libraries most images lack, so unsupported runtimes must
+            // fall back to the system browser.
+            string? rid = AppContext.GetData("RUNTIME_IDENTIFIER") as string;
+            bool architectureSupported =
+                RuntimeInformation.ProcessArchitecture == Architecture.X64 &&
+                (rid is null || rid.IndexOf("musl", StringComparison.OrdinalIgnoreCase) < 0);
+
+            if (!architectureSupported)
+            {
+                Assert.Equal(BrokerOptions.OperatingSystems.None, actual);
+            }
+            else
+            {
+                // Whether msalruntime loads depends on which packages the agent has installed,
+                // so resolve it independently here rather than hard-coding an expectation. This
+                // is the only leg that exercises the native probe, so it has to pin the
+                // correlation instead of accepting either answer.
+                Assert.Equal(
+                    CanLoadMsalRuntime() ? BrokerOptions.OperatingSystems.Linux : BrokerOptions.OperatingSystems.None,
+                    actual);
+            }
+        }
+        else
+        {
+            Assert.Equal(BrokerOptions.OperatingSystems.None, actual);
+        }
+    }
+
+    /// <summary>
+    /// The detected broker operating system must be a single flag that MSAL will accept, never a
+    /// combination. Guards against a future edit that ORs multiple platforms together.
+    /// </summary>
+    [Fact]
+    public void SupportedBrokerOperatingSystem_IsASingleFlag()
+    {
+        BrokerOptions.OperatingSystems actual =
+            ActiveDirectoryAuthenticationProvider.SupportedBrokerOperatingSystem;
+
+        Assert.Contains(actual, new[]
+        {
+            BrokerOptions.OperatingSystems.None,
+            BrokerOptions.OperatingSystems.Windows,
+            BrokerOptions.OperatingSystems.Linux,
+            BrokerOptions.OperatingSystems.OSX,
+        });
+    }
+
+    /// <summary>
+    /// Opting out of the broker must keep it disabled no matter which platform the tests run on.
+    /// </summary>
+    [Fact]
+    public void IsBrokerEnabledOnCurrentPlatform_CustomAppIdWithoutOptIn_IsFalse()
+    {
+        var provider = new ActiveDirectoryAuthenticationProvider(TestCustomAppId);
+
+        Assert.False(provider.IsBrokerEnabledOnCurrentPlatform);
+    }
+
+    /// <summary>
+    /// The broker is enabled for the first-party application id on every platform where the
+    /// native msalruntime binary is available, which now includes Linux and macOS.
+    /// </summary>
+    [Fact]
+    public void IsBrokerEnabledOnCurrentPlatform_FirstPartyAppId_TracksPlatformSupport()
+    {
+        var provider = new ActiveDirectoryAuthenticationProvider();
+
+        Assert.True(provider.UseWamBroker);
+        Assert.Equal(
+            ActiveDirectoryAuthenticationProvider.SupportedBrokerOperatingSystem
+                != BrokerOptions.OperatingSystems.None,
+            provider.IsBrokerEnabledOnCurrentPlatform);
+    }
+
+    /// <summary>
+    /// Each broker expects its own redirect URI scheme. Windows uses the WAM URI suffixed with
+    /// the client id, Linux requires the native client URI, and macOS derives the URI from the
+    /// host application bundle.
+    /// </summary>
+    [Fact]
+    public void GetRedirectUri_BrokerEnabled_UsesPlatformBrokerRedirectUri()
+    {
+        var provider = new ActiveDirectoryAuthenticationProvider();
+
+        if (!provider.IsBrokerEnabledOnCurrentPlatform)
+        {
+            // Broker unsupported on this runtime; covered by the fallback test below.
+            return;
+        }
+
+        Assert.Equal(
+            ExpectedBrokerRedirectUri(SqlClientApplicationId),
+            provider.GetRedirectUri(SqlAuthenticationMethod.ActiveDirectoryInteractive));
+    }
+
+    /// <summary>
+    /// The Linux broker rejects the WAM redirect URI; it requires the native client URI to be
+    /// enabled on the app registration. Pinning the value here guards against reintroducing the
+    /// WAM URI on non-Windows platforms.
+    /// </summary>
+    [Fact]
+    public void GetRedirectUri_LinuxBroker_UsesNativeClientRedirectUri()
+    {
+        if (ActiveDirectoryAuthenticationProvider.SupportedBrokerOperatingSystem
+            != BrokerOptions.OperatingSystems.Linux)
+        {
+            return;
+        }
+
+        var provider = new ActiveDirectoryAuthenticationProvider();
+
+        Assert.Equal(
+            NativeClientRedirectUri,
+            provider.GetRedirectUri(SqlAuthenticationMethod.ActiveDirectoryInteractive));
+    }
+
+    /// <summary>
+    /// The macOS broker derives the redirect URI from the host application bundle. The test host
+    /// is not a bundled application, so it must get the fixed unsigned-app URI.
+    /// </summary>
+    [Fact]
+    public void GetRedirectUri_MacBroker_NonBundledHost_UsesUnsignedAppRedirectUri()
+    {
+        if (ActiveDirectoryAuthenticationProvider.SupportedBrokerOperatingSystem
+            != BrokerOptions.OperatingSystems.OSX)
+        {
+            return;
+        }
+
+        var provider = new ActiveDirectoryAuthenticationProvider();
+
+        Assert.Equal(
+            MacUnsignedAppRedirectUri,
+            provider.GetRedirectUri(SqlAuthenticationMethod.ActiveDirectoryInteractive));
+    }
+
+    /// <summary>
+    /// Without the broker, modern .NET uses the loopback system-browser redirect URI. .NET
+    /// Framework keeps the native client URI used by the embedded WebView.
+    /// </summary>
+    [Fact]
+    public void GetRedirectUri_BrokerDisabled_UsesNonBrokerRedirectUri()
+    {
+        var provider = new ActiveDirectoryAuthenticationProvider(TestCustomAppId);
+
+        Assert.False(provider.IsBrokerEnabledOnCurrentPlatform);
+
+        #if NETFRAMEWORK
+        Assert.Equal(
+            NativeClientRedirectUri,
+            provider.GetRedirectUri(SqlAuthenticationMethod.ActiveDirectoryInteractive));
+        #else
+        Assert.Equal(
+            "http://localhost",
+            provider.GetRedirectUri(SqlAuthenticationMethod.ActiveDirectoryInteractive));
+        #endif
+    }
+
+    /// <summary>
+    /// A custom application id that opts into the broker must get a redirect URI suffixed with
+    /// its own client id, not the SqlClient first-party id. Only Windows embeds the client id in
+    /// the redirect URI, so the other platforms are unaffected by the client id in use.
+    /// </summary>
+    [Fact]
+    public void GetRedirectUri_CustomAppIdWithOptIn_UsesCustomClientId()
+    {
+        var provider = new ActiveDirectoryAuthenticationProvider(
+            new ActiveDirectoryAuthenticationProviderOptions
+            {
+                ApplicationClientId = TestCustomAppId,
+                UseWamBroker = true,
+            });
+
+        if (!provider.IsBrokerEnabledOnCurrentPlatform)
+        {
+            return;
+        }
+
+        Assert.Equal(
+            ExpectedBrokerRedirectUri(TestCustomAppId),
+            provider.GetRedirectUri(SqlAuthenticationMethod.ActiveDirectoryInteractive));
+    }
+
+    /// <summary>
+    /// The redirect URI must never carry a client id on Linux or macOS. Those brokers key off a
+    /// fixed URI or the host bundle, so a client-id-suffixed URI would silently fail to match the
+    /// app registration.
+    /// </summary>
+    [Fact]
+    public void GetRedirectUri_NonWindowsBroker_DoesNotEmbedClientId()
+    {
+        BrokerOptions.OperatingSystems brokerOs =
+            ActiveDirectoryAuthenticationProvider.SupportedBrokerOperatingSystem;
+
+        if (brokerOs != BrokerOptions.OperatingSystems.Linux &&
+            brokerOs != BrokerOptions.OperatingSystems.OSX)
+        {
+            return;
+        }
+
+        var provider = new ActiveDirectoryAuthenticationProvider();
+        string redirectUri = provider.GetRedirectUri(SqlAuthenticationMethod.ActiveDirectoryInteractive);
+
+        Assert.DoesNotContain(SqlClientApplicationId, redirectUri, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(BrokerRedirectUriPrefix, redirectUri, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The redirect URI is part of the PublicClientApplication cache key, so it must be stable
+    /// across calls for a given provider instance.
+    /// </summary>
+    [Fact]
+    public void GetRedirectUri_IsStableAcrossCalls()
+    {
+        var provider = new ActiveDirectoryAuthenticationProvider();
+
+        Assert.Equal(
+            provider.GetRedirectUri(SqlAuthenticationMethod.ActiveDirectoryInteractive),
+            provider.GetRedirectUri(SqlAuthenticationMethod.ActiveDirectoryIntegrated));
+    }
+
+    /// <summary>
+    /// The two-argument AuthenticationException constructor must carry the authentication method
+    /// on the exception, not just interpolate it into the message. ADP.CreateSqlException
+    /// surfaces Method as SqlError.Procedure, and AcquireTokenAsync no longer re-wraps
+    /// AuthenticationException, so this is the only thing keeping Procedure from reading
+    /// "NotSpecified".
+    /// </summary>
+    [Fact]
+    public void AuthenticationException_TwoArgumentConstructor_PreservesMethod()
+    {
+        var exception = new AuthenticationException(
+            SqlAuthenticationMethod.ActiveDirectoryInteractive,
+            "test message");
+
+        Assert.Equal(SqlAuthenticationMethod.ActiveDirectoryInteractive, exception.Method);
+        Assert.False(exception.ShouldRetry);
+        Assert.Equal(0, exception.RetryPeriod);
+        Assert.Contains("test message", exception.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Independently resolves whether the native msalruntime library can be loaded, mirroring
+    /// what the provider does but without reusing its implementation. Only meaningful on
+    /// linux-x64, the single runtime identifier the library ships for on Linux.
+    /// </summary>
+    private static bool CanLoadMsalRuntime()
+    {
+        try
+        {
+            Assembly? nativeInterop = Type
+                .GetType("Microsoft.Identity.Client.NativeInterop.Core, Microsoft.Identity.Client.NativeInterop", throwOnError: false)
+                ?.Assembly;
+
+            return nativeInterop is not null &&
+                NativeLibrary.TryLoad("msalruntime", nativeInterop, null, out _);
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Returns the redirect URI the current platform's broker expects for a given client id.
+    /// </summary>
+    private static string ExpectedBrokerRedirectUri(string applicationClientId) =>
+        ActiveDirectoryAuthenticationProvider.SupportedBrokerOperatingSystem switch
+        {
+            BrokerOptions.OperatingSystems.Windows => BrokerRedirectUriPrefix + applicationClientId,
+            BrokerOptions.OperatingSystems.Linux => NativeClientRedirectUri,
+            BrokerOptions.OperatingSystems.OSX => MacUnsignedAppRedirectUri,
+            _ => throw new InvalidOperationException("The broker is not supported on this platform."),
+        };
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Data.SqlClient
                 // configured in <SqlClientAuthenticationProviders>:
                 //  * Neither applicationClientId nor useWamBroker -> use the
                 //    parameterless constructor (defaults to the SqlClient
-                //    first-party app id and enables WAM brokering on Windows).
+                //    first-party app id and enables brokering where supported).
                 //  * applicationClientId only -> prefer the
                 //    (ActiveDirectoryAuthenticationProviderOptions) constructor
                 //    when the Azure extension exposes it; otherwise fall back
@@ -238,8 +238,8 @@ namespace Microsoft.Data.SqlClient
         // Optional override for ActiveDirectoryAuthenticationProviderOptions.UseWamBroker
         // read from the app.config <SqlClientAuthenticationProviders useWamBroker="..."/> attribute.
         // null means the app did not configure the value, in which case we leave the
-        // provider's default behavior (WAM is implied by the SqlClient first-party app id and
-        // off otherwise) untouched.
+        // provider's default behavior (brokering is implied by the SqlClient first-party app id
+        // and off otherwise) untouched.
         private readonly bool? _useWamBroker = null;
 
         /// <summary>


### PR DESCRIPTION
Extends the recently added Windows broker support to macOS and Linux via `BrokerOptions.OperatingSystems.Linux` and `.OSX`. The broker is force-enabled for the SqlClient first-party app id, matching existing Windows behavior. Custom app ids continue to opt in through `UseWamBroker`.

## Redirect URIs

MSAL forwards the app-configured redirect URI straight to msalruntime, so it has to be correct per platform. `WamAdapters.GetExpectedRedirectUri` is dead code in 4.84.2 and does not fix this up.

| Platform | URI |
| --- | --- |
| Windows / WSL | `ms-appx-web://microsoft.aad.brokerplugin/{clientId}` |
| Linux | `https://login.microsoftonline.com/common/oauth2/nativeclient` |
| macOS, bundled | `msauth.{CFBundleIdentifier}://auth` |
| macOS, not bundled | `msauth.com.msauth.unsignedapp://auth` |

Values come from the [macOS](https://learn.microsoft.com/entra/msal/dotnet/acquiring-tokens/desktop-mobile/macos-broker-dotnet-sdk#redirect-uri) and Linux broker docs.

## Platform guards

**macOS.** The broker is enabled for all hosts. A bundled app running on the default app id throws, because its redirect URI derives from the host's bundle identifier and cannot be registered on the first-party app. Device code flow is exempt, since `DeviceCodeRequest` never consults the broker and `SilentRequest` skips it for accounts sourced from that flow.

**Linux.** Gated on x64, non-musl, plus a `NativeLibrary.TryLoad` probe. Without the probe, hosts missing `libwebkit2gtk`, `libsecret`, or `libX11` fail hard with `wam_runtime_init_failed`, as `RuntimeBroker` offers no browser fallback. With it, they degrade to the browser.

Platform detection is lazy, so managed identity, workload identity, service principal, and default credential flows never load the native library.

## Behavioral changes

- Bundled macOS GUI apps on the default app id now throw. There is no opt-out short of supplying an `ApplicationClientId` or using device code flow.
- macOS terminal apps need `MacMainThreadScheduler` for `ActiveDirectoryInteractive`; MSAL throws `wam_ui_thread` off thread 1. Silent and integrated flows are unaffected.
- Unenrolled Macs no longer fall back to the browser for `ActiveDirectoryInteractive`.

## Also

`AuthenticationException`'s two-argument constructor now chains to the six-parameter base so `Method` survives into `SqlError.Procedure` instead of reading `NotSpecified`.

## Blocker before merge

The first-party app registration `2fd908ad-0664-4344-b9be-cd3e8b574c38` needs `https://login.microsoftonline.com/common/oauth2/nativeclient` explicitly enabled and `msauth.com.msauth.unsignedapp://auth` added. Without both, Linux and macOS fail at the broker. This cannot be verified from the repo and needs someone with access to the registration.

## Testing

`WamBrokerTests` expanded from 18 to 29 tests, passing on net8.0/9.0/10.0. Interop and native-load behavior was verified empirically rather than inferred: bundle-id lookup against a real `.app` bundle and a loose executable, the reflective `NativeLibrary.TryLoad` path returning a live handle, and `NativeInterop` 0.20.6 decompiled to confirm the arch-specific library name and that its Linux preload path is unreachable. The `Method` regression test was confirmed to fail against the old constructor.

Two `Azure.Test` failures (`AADConnectionTest.ADIntegratedUsingSSPI`, `ActiveDirectoryInteractiveTests.TestConnection`) are pre-existing and need a live server or Windows SSPI.

- [x] Tests added or updated
- [x] Public API changes documented
- [ ] Verified against customer repro
- [ ] Ensure no breaking changes introduced (see Behavioral changes)