### PR TITLE
Update central package versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -149,7 +149,7 @@
 
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
     <PackageVersion Include="Microsoft.Bcl.Cryptography" Version="9.0.18" />
-    <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="9.0.16" />
+    <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="9.0.18" />
     <PackageVersion Include="System.Threading.RateLimiting" Version="9.0.18" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="9.0.18" />
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.18" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -99,7 +99,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.13" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.18" />
   </ItemGroup>
 
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
@@ -148,11 +148,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
-    <PackageVersion Include="Microsoft.Bcl.Cryptography" Version="9.0.13" />
+    <PackageVersion Include="Microsoft.Bcl.Cryptography" Version="9.0.18" />
     <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="9.0.16" />
-    <PackageVersion Include="System.Threading.RateLimiting" Version="9.0.13" />
-    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="9.0.13" />
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.13" />
+    <PackageVersion Include="System.Threading.RateLimiting" Version="9.0.18" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="9.0.18" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.18" />
   </ItemGroup>
 
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">

--- a/src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.nuspec
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.nuspec
@@ -52,6 +52,7 @@
         <dependency id="System.Security.Cryptography.Pkcs" version="8.0.1" />
         <dependency id="System.Text.Json" version="10.0.3" />
         <dependency id="System.Threading.Channels" version="10.0.3" />
+        <dependency id="System.Threading.RateLimiting" version="8.0.0" />
         <dependency id="System.ValueTuple" version="4.6.2" />
       </group>
       <group targetFramework="net8.0">
@@ -65,18 +66,20 @@
         <dependency id="Microsoft.SqlServer.Server" version="$SqlServerVersionRange$" />
         <dependency id="System.Configuration.ConfigurationManager" version="8.0.1" exclude="Compile" />
         <dependency id="System.Security.Cryptography.Pkcs" version="8.0.1" />
+        <dependency id="System.Threading.RateLimiting" version="8.0.0" />
       </group>
       <group targetFramework="net9.0">
-        <dependency id="Microsoft.Bcl.Cryptography" version="9.0.13" />
+        <dependency id="Microsoft.Bcl.Cryptography" version="9.0.18" />
         <dependency id="Microsoft.Data.SqlClient.Extensions.Abstractions" version="$AbstractionsVersionRange$" />
         <dependency id="Microsoft.Data.SqlClient.Internal.Logging" version="$LoggingVersionRange$" />
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="$SniVersionRange$" exclude="Compile" />
-        <dependency id="Microsoft.Extensions.Caching.Memory" version="9.0.13" exclude="Compile" />
+        <dependency id="Microsoft.Extensions.Caching.Memory" version="9.0.18" exclude="Compile" />
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="8.16.0" />
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="8.16.0" />
         <dependency id="Microsoft.SqlServer.Server" version="$SqlServerVersionRange$" />
-        <dependency id="System.Configuration.ConfigurationManager" version="9.0.13" exclude="Compile" />
-        <dependency id="System.Security.Cryptography.Pkcs" version="9.0.13" />
+        <dependency id="System.Configuration.ConfigurationManager" version="9.0.18" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.Pkcs" version="9.0.18" />
+        <dependency id="System.Threading.RateLimiting" version="9.0.18" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="Microsoft.Bcl.Cryptography" version="8.0.0" />
@@ -92,6 +95,7 @@
         <dependency id="System.Security.Cryptography.Pkcs" version="8.0.1" />
         <dependency id="System.Text.Json" version="10.0.3" />
         <dependency id="System.Threading.Channels" version="10.0.3" />
+        <dependency id="System.Threading.RateLimiting" version="8.0.0" />
       </group>
     </dependencies>
 

--- a/src/Microsoft.Data.SqlClient/tests/Directory.Packages.props
+++ b/src/Microsoft.Data.SqlClient/tests/Directory.Packages.props
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.13" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.18" />
     <PackageVersion Include="Microsoft.SqlServer.SqlManagementObjects" Version="181.15.0" />
     <PackageVersion Include="Microsoft.SqlServer.Types" Version="170.1000.7" />
     <PackageVersion Include="System.Formats.Asn1" Version="10.0.3" />


### PR DESCRIPTION
## Description

This PR updates the centrally managed package versions in `Directory.Packages.props` for the .NET 9-compatible dependency set and aligns the generated package dependency metadata in `src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.nuspec` with those target-framework-specific versions.

The change keeps `Microsoft.Extensions.Caching.Memory`, `Microsoft.Bcl.Cryptography`, `System.Threading.RateLimiting`, `System.Configuration.ConfigurationManager`, and `System.Security.Cryptography.Pkcs` aligned on `9.0.18` for `net9.0`, while preserving the existing `8.0.0`/`8.0.1` pins for non-net9-compatible target frameworks. It also adds `System.Threading.RateLimiting` to the nuspec dependency groups so the packaged dependency metadata matches the project references.

## Issues

N/A

## Testing

- Built `Microsoft.Data.SqlClient` for `net8.0`
- Built the functional test project for `net8.0`
- Validated package restore/build against `nuget.org` for the updated dependency set

## Guidelines

- [Contributing](/CONTRIBUTING.md)
- [Code of Conduct](/CODE_OF_CONDUCT.md)
- [Best Practices](/policy/coding-best-practices.md)
- [Coding Style](/policy/coding-style.md)
- [Review Process](/policy/review-process.md)