### PR TITLE
Fix perf test build against pre-6.0 MDS baselines

### DIFF
--- a/eng/pipelines/perf/README.md
+++ b/eng/pipelines/perf/README.md
@@ -106,6 +106,27 @@ The VM's `NuGet.config` exposes only the governed feed, and CPM rejects multiple
 (`NU1507`). The baseline pass therefore restores through a **dedicated single-source config**
 (`perf-baseline-nuget.config`, generated at runtime) pointing only at `https://api.nuget.org/v3/index.json`.
 
+### Benchmarks must compile against the oldest baseline
+
+The baseline pass compiles the **same** `PerformanceTests` sources against the *released* MDS
+package, so a benchmark that calls an API introduced after `baselineVersion` fails that pass with
+`CS1061`. The project defines cumulative `MDS_GE_<major>` constants from `MdsPackageVersion` (see
+`Microsoft.Data.SqlClient.PerformanceTests.csproj`); guard such calls and provide an older
+fallback:
+
+```csharp
+#if MDS_GE_6
+    _ = reader.GetSqlJson(0).Value;   // GetSqlJson was added in MDS 6.0
+#else
+    _ = reader.GetString(0);
+#endif
+```
+
+Project mode, Package mode with no pinned version, and unparsable version strings define every
+constant, since those builds reference a current MDS. Note that a fallback makes the baseline
+measure a **different code path** than the current pass — the affected benchmark's delta is not
+meaningful, so the runner should say so loudly at setup (see `JsonVsVarcharReadRunner`).
+
 ## Comparison output
 
 `compare_perf.py` matches benchmarks by `(Type, Method, Parameters)` and reports, per benchmark, the
@@ -234,6 +255,7 @@ translated NDJSON as the `perf-kusto-payloads` artifact for manual/backfill inge
 | ------- | ------------------ |
 | `NU1507` during the baseline pass | Multiple NuGet sources under CPM. The baseline uses a single-source config; ensure `perf-baseline-nuget.config` is being passed via `-p:RestoreConfigFile`. |
 | Baseline restore fails to find MDS | `baselineVersion` isn't a published NuGet.org version, or the VM has no outbound access to `api.nuget.org`. |
+| Baseline pass fails to compile: `CS1061 ... does not contain a definition for <member>` | A benchmark calls an MDS API newer than `baselineVersion`. Guard it with the `MDS_GE_<major>` constants and add an older fallback — see [Benchmarks must compile against the oldest baseline](#benchmarks-must-compile-against-the-oldest-baseline). |
 | No comparison / summary | The baseline pass was skipped (empty `baselineVersion`) or one pass produced no `*-report-full.json`. |
 | Ingestion step skipped | `enableKustoIngestion` is `false`, or `KustoClusterUri`, `KustoDatabase` or `KustoServiceConnection` (from `ADX Cluster Variables`) is empty (expected until the cluster is provisioned). |
 | Ingestion auth error | The service connection's SP lacks **Database Ingestor** on the target database. |

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/JsonVsVarcharReadRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/JsonVsVarcharReadRunner.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 
@@ -36,14 +37,30 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             // This build targets a pre-6.0 MDS baseline that has no GetSqlJson, so the JSON
             // benchmarks below read through the string accessor instead. Results for
             // ColumnType=JSON therefore measure a DIFFERENT code path than a current-MDS build
-            // and must not be compared against one.
-            Console.Error.WriteLine(
-                "WARNING: JsonVsVarcharReadRunner was built against a pre-6.0 Microsoft.Data.SqlClient " +
-                "baseline. The ColumnType=JSON benchmarks fall back to the string accessor and are " +
-                "NOT comparable with results from a current-MDS build.");
+            // and must not be compared against one. GlobalSetup runs once per parameter
+            // combination, so only the affected one warns.
+            if (ColumnType == "JSON")
+            {
+                Console.Error.WriteLine(
+                    "WARNING: JsonVsVarcharReadRunner was built against a pre-6.0 Microsoft.Data.SqlClient " +
+                    "baseline. The ColumnType=JSON benchmarks fall back to the string accessor and are " +
+                    "NOT comparable with results from a current-MDS build.");
+            }
 #endif
             _rowCount = s_config.Benchmarks.JsonVsVarcharReadRunnerConfig.RowCount;
+            if (_rowCount <= 0)
+            {
+                throw new InvalidOperationException(
+                    "JsonVsVarcharReadRunnerConfig.RowCount must be greater than zero; " +
+                    "the benchmarks would otherwise read from empty tables.");
+            }
+
             _connectionString = s_config.ConnectionString;
+            if (string.IsNullOrWhiteSpace(_connectionString))
+            {
+                throw new InvalidOperationException(
+                    "No connection string was configured; set ConnectionString in runnerconfig.jsonc.");
+            }
 
             string machineHash = ((uint)Environment.MachineName.GetHashCode()).ToString("x8");
             string suffix = $"{machineHash}_{Guid.NewGuid():N}";
@@ -55,69 +72,119 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             using var conn = new SqlConnection(_connectionString);
             conn.Open();
 
-            // Create JSON table. The native JSON column type requires SQL Server 2025+ or Azure
-            // SQL; on older servers this fails with a parse/type error, so surface why.
-            using (var cmd = new SqlCommand(
-                $"CREATE TABLE {_jsonTableName} (Id INT IDENTITY PRIMARY KEY, Data JSON)", conn))
+            try
             {
-                try
+                // Create JSON table. The native JSON column type requires SQL Server 2025+ or
+                // Azure SQL; on older servers this fails with a parse/type error, so surface why.
+                using (var cmd = new SqlCommand(
+                    $"CREATE TABLE {_jsonTableName} (Id INT IDENTITY PRIMARY KEY, Data JSON)", conn))
+                {
+                    try
+                    {
+                        cmd.ExecuteNonQuery();
+                    }
+                    catch (SqlException ex)
+                    {
+                        throw new InvalidOperationException(
+                            "JsonVsVarcharReadRunner requires a server with native JSON column support " +
+                            "(SQL Server 2025+ or Azure SQL). Disable this runner in runnerconfig.jsonc " +
+                            "when targeting an older server.", ex);
+                    }
+                }
+
+                // Create VARCHAR(MAX) table
+                using (var cmd = new SqlCommand(
+                    $"CREATE TABLE {_varcharTableName} (Id INT IDENTITY PRIMARY KEY, Data VARCHAR(MAX))", conn))
                 {
                     cmd.ExecuteNonQuery();
                 }
-                catch (SqlException ex)
+
+                // Bulk insert identical data into both tables
+                var dt = new System.Data.DataTable();
+                dt.Columns.Add("Data", typeof(string));
+                for (long i = 0; i < _rowCount; i++)
                 {
-                    throw new InvalidOperationException(
-                        "JsonVsVarcharReadRunner requires a server with native JSON column support " +
-                        "(SQL Server 2025+ or Azure SQL). Disable this runner in runnerconfig.jsonc " +
-                        "when targeting an older server.", ex);
+                    dt.Rows.Add(sampleJson);
+                }
+
+                using (var bulkCopy = new SqlBulkCopy(conn) { DestinationTableName = _jsonTableName, BatchSize = 10000 })
+                {
+                    bulkCopy.ColumnMappings.Add("Data", "Data");
+                    bulkCopy.WriteToServer(dt);
+                }
+
+                using (var bulkCopy = new SqlBulkCopy(conn) { DestinationTableName = _varcharTableName, BatchSize = 10000 })
+                {
+                    bulkCopy.ColumnMappings.Add("Data", "Data");
+                    bulkCopy.WriteToServer(dt);
                 }
             }
-
-            // Create VARCHAR(MAX) table
-            using (var cmd = new SqlCommand(
-                $"CREATE TABLE {_varcharTableName} (Id INT IDENTITY PRIMARY KEY, Data VARCHAR(MAX))", conn))
+            catch
             {
-                cmd.ExecuteNonQuery();
-            }
-
-            // Bulk insert identical data into both tables
-            var dt = new System.Data.DataTable();
-            dt.Columns.Add("Data", typeof(string));
-            for (long i = 0; i < _rowCount; i++)
-            {
-                dt.Rows.Add(sampleJson);
-            }
-
-            using (var bulkCopy = new SqlBulkCopy(conn) { DestinationTableName = _jsonTableName, BatchSize = 10000 })
-            {
-                bulkCopy.ColumnMappings.Add("Data", "Data");
-                bulkCopy.WriteToServer(dt);
-            }
-
-            using (var bulkCopy = new SqlBulkCopy(conn) { DestinationTableName = _varcharTableName, BatchSize = 10000 })
-            {
-                bulkCopy.ColumnMappings.Add("Data", "Data");
-                bulkCopy.WriteToServer(dt);
+                // GlobalCleanup is not guaranteed to run when GlobalSetup throws, so drop whatever
+                // was created here before surfacing the original failure. Table names are unique
+                // per run, so a leak would otherwise accumulate on the perf server.
+                DropTables(conn, bestEffort: true);
+                throw;
             }
         }
 
         [GlobalCleanup]
         public void Cleanup()
         {
+            // Setup can fail before it captures the connection string (e.g. a missing runner
+            // config), in which case there is nothing to clean up.
+            if (string.IsNullOrEmpty(_connectionString))
+            {
+                return;
+            }
+
             using var conn = new SqlConnection(_connectionString);
             conn.Open();
 
-            using (var cmd = new SqlCommand($"DROP TABLE IF EXISTS {_jsonTableName}", conn))
+            try
             {
-                cmd.ExecuteNonQuery();
+                DropTables(conn, bestEffort: false);
+            }
+            finally
+            {
+                SqlConnection.ClearAllPools();
+            }
+        }
+
+        /// <summary>
+        /// Drops both benchmark tables, skipping any that were never created. Each drop is
+        /// attempted even when an earlier one fails, so a single failure cannot leak the other
+        /// table. When <paramref name="bestEffort"/> is false, the collected failures are thrown.
+        /// </summary>
+        private void DropTables(SqlConnection conn, bool bestEffort)
+        {
+            List<Exception> failures = null;
+
+            foreach (string tableName in new[] { _jsonTableName, _varcharTableName })
+            {
+                if (string.IsNullOrEmpty(tableName))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    using var cmd = new SqlCommand($"DROP TABLE IF EXISTS {tableName}", conn);
+                    cmd.ExecuteNonQuery();
+                }
+                catch (Exception ex)
+                {
+                    (failures ??= new List<Exception>()).Add(
+                        new InvalidOperationException($"Failed to drop {tableName}.", ex));
+                }
             }
 
-            using (var cmd = new SqlCommand($"DROP TABLE IF EXISTS {_varcharTableName}", conn))
+            if (failures is not null && !bestEffort)
             {
-                cmd.ExecuteNonQuery();
+                throw new AggregateException(
+                    "JsonVsVarcharReadRunner could not drop one or more of its tables.", failures);
             }
-
-            SqlConnection.ClearAllPools();
         }
 
         [Benchmark]

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/JsonVsVarcharReadRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/JsonVsVarcharReadRunner.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
     /// </summary>
     public class JsonVsVarcharReadRunner : BaseRunner
     {
-        private static long s_rowCount;
+        private long _rowCount;
         private string _jsonTableName;
         private string _varcharTableName;
         private string _connectionString;
@@ -32,7 +32,17 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         [GlobalSetup]
         public void Setup()
         {
-            s_rowCount = s_config.Benchmarks.JsonVsVarcharReadRunnerConfig.RowCount;
+#if !MDS_GE_6
+            // This build targets a pre-6.0 MDS baseline that has no GetSqlJson, so the JSON
+            // benchmarks below read through the string accessor instead. Results for
+            // ColumnType=JSON therefore measure a DIFFERENT code path than a current-MDS build
+            // and must not be compared against one.
+            Console.Error.WriteLine(
+                "WARNING: JsonVsVarcharReadRunner was built against a pre-6.0 Microsoft.Data.SqlClient " +
+                "baseline. The ColumnType=JSON benchmarks fall back to the string accessor and are " +
+                "NOT comparable with results from a current-MDS build.");
+#endif
+            _rowCount = s_config.Benchmarks.JsonVsVarcharReadRunnerConfig.RowCount;
             _connectionString = s_config.ConnectionString;
 
             string machineHash = ((uint)Environment.MachineName.GetHashCode()).ToString("x8");
@@ -45,11 +55,22 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             using var conn = new SqlConnection(_connectionString);
             conn.Open();
 
-            // Create JSON table
+            // Create JSON table. The native JSON column type requires SQL Server 2025+ or Azure
+            // SQL; on older servers this fails with a parse/type error, so surface why.
             using (var cmd = new SqlCommand(
                 $"CREATE TABLE {_jsonTableName} (Id INT IDENTITY PRIMARY KEY, Data JSON)", conn))
             {
-                cmd.ExecuteNonQuery();
+                try
+                {
+                    cmd.ExecuteNonQuery();
+                }
+                catch (SqlException ex)
+                {
+                    throw new InvalidOperationException(
+                        "JsonVsVarcharReadRunner requires a server with native JSON column support " +
+                        "(SQL Server 2025+ or Azure SQL). Disable this runner in runnerconfig.jsonc " +
+                        "when targeting an older server.", ex);
+                }
             }
 
             // Create VARCHAR(MAX) table
@@ -62,7 +83,7 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             // Bulk insert identical data into both tables
             var dt = new System.Data.DataTable();
             dt.Columns.Add("Data", typeof(string));
-            for (int i = 0; i < s_rowCount; i++)
+            for (long i = 0; i < _rowCount; i++)
             {
                 dt.Rows.Add(sampleJson);
             }
@@ -90,12 +111,12 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             {
                 cmd.ExecuteNonQuery();
             }
-            
+
             using (var cmd = new SqlCommand($"DROP TABLE IF EXISTS {_varcharTableName}", conn))
             {
                 cmd.ExecuteNonQuery();
             }
-            
+
             SqlConnection.ClearAllPools();
         }
 
@@ -114,7 +135,7 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
                 // fall back to the string accessor.
                 while (reader.Read())
                 {
-#if MDS_SQLJSON_SUPPORTED
+#if MDS_GE_6
                     _ = reader.GetSqlJson(0).Value;
 #else
                     _ = reader.GetString(0);
@@ -141,7 +162,7 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             {
                 while (await reader.ReadAsync())
                 {
-#if MDS_SQLJSON_SUPPORTED
+#if MDS_GE_6
                     _ = reader.GetSqlJson(0).Value;
 #else
                     // Older baseline packages (pre-6.0) have no GetSqlJson, and

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/JsonVsVarcharReadRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/JsonVsVarcharReadRunner.cs
@@ -144,6 +144,11 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
 #if MDS_SQLJSON_SUPPORTED
                     _ = reader.GetSqlJson(0).Value;
 #else
+                    // Older baseline packages (pre-6.0) have no GetSqlJson, and
+                    // there is no async SqlJson accessor to fall back to. Use the
+                    // same GetFieldValueAsync<string> call the VARCHAR case uses so
+                    // the async benchmark keeps measuring an async read path rather
+                    // than a synchronous accessor over already-buffered data.
                     _ = await reader.GetFieldValueAsync<string>(0);
 #endif
                 }

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/JsonVsVarcharReadRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/JsonVsVarcharReadRunner.cs
@@ -110,9 +110,15 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             {
                 // Exercise the SqlJson accessor path so the JSON case captures
                 // JSON-type handling overhead rather than the shared string path.
+                // Older baseline packages (pre-6.0) have no GetSqlJson, so they
+                // fall back to the string accessor.
                 while (reader.Read())
                 {
+#if MDS_SQLJSON_SUPPORTED
                     _ = reader.GetSqlJson(0).Value;
+#else
+                    _ = reader.GetString(0);
+#endif
                 }
             }
             else
@@ -135,7 +141,11 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             {
                 while (await reader.ReadAsync())
                 {
+#if MDS_SQLJSON_SUPPORTED
                     _ = reader.GetSqlJson(0).Value;
+#else
+                    _ = await reader.GetFieldValueAsync<string>(0);
+#endif
                 }
             }
             else

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Microsoft.Data.SqlClient.PerformanceTests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Microsoft.Data.SqlClient.PerformanceTests.csproj
@@ -54,6 +54,17 @@
     <PackageReference Include="Microsoft.Data.SqlClient.Internal.Logging" VersionOverride="1.0.0" />
   </ItemGroup>
 
+  <!-- Baseline API availability =========================================== -->
+  <!-- In Package mode the perf pipeline can pin an older released MDS as the baseline.  APIs that   -->
+  <!-- were introduced after that baseline don't exist there, so benchmarks using them must fall     -->
+  <!-- back to an older equivalent.  MDS 6.0 introduced SqlJson / SqlDataReader.GetSqlJson, so       -->
+  <!-- MDS_SQLJSON_SUPPORTED is defined unless a pre-6.0 baseline package is pinned.  Project mode   -->
+  <!-- and Package mode without an explicit version always build against a current MDS.              -->
+  <PropertyGroup>
+    <MdsPackageMajorVersion Condition="'$(ReferenceType)' == 'Package' and '$(MdsPackageVersion)' != ''">$([System.Text.RegularExpressions.Regex]::Match('$(MdsPackageVersion)', '^[0-9]+').Value)</MdsPackageMajorVersion>
+    <DefineConstants Condition="'$(MdsPackageMajorVersion)' == '' or '$(MdsPackageMajorVersion)' &gt;= '6'">$(DefineConstants);MDS_SQLJSON_SUPPORTED</DefineConstants>
+  </PropertyGroup>
+
   <!-- Other references -->
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Microsoft.Data.SqlClient.PerformanceTests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Microsoft.Data.SqlClient.PerformanceTests.csproj
@@ -55,14 +55,19 @@
   </ItemGroup>
 
   <!-- Baseline API availability =========================================== -->
-  <!-- In Package mode the perf pipeline can pin an older released MDS as the baseline.  APIs that   -->
-  <!-- were introduced after that baseline don't exist there, so benchmarks using them must fall     -->
-  <!-- back to an older equivalent.  MDS 6.0 introduced SqlJson / SqlDataReader.GetSqlJson, so       -->
-  <!-- MDS_SQLJSON_SUPPORTED is defined unless a pre-6.0 baseline package is pinned.  Project mode   -->
-  <!-- and Package mode without an explicit version always build against a current MDS.              -->
+  <!-- In Package mode the perf pipeline can pin an older released MDS as the baseline, so this      -->
+  <!-- project must compile against the OLDEST baseline anyone may queue - a benchmark that calls an -->
+  <!-- API introduced after that baseline breaks the baseline pass with CS1061.  MdsBaselineMajor-   -->
+  <!-- Version is the major version of the pinned baseline; the cumulative MDS_GE_<n> constants let  -->
+  <!-- individual benchmarks guard a call and fall back to an older equivalent.  Project mode,       -->
+  <!-- Package mode without an explicit version, and any version string whose major cannot be parsed -->
+  <!-- all fail toward "current" (all constants defined), because those builds reference a current   -->
+  <!-- MDS.  Add a new MDS_GE_<n> line here as newer baselines start being used.                     -->
   <PropertyGroup>
-    <MdsPackageMajorVersion Condition="'$(ReferenceType)' == 'Package' and '$(MdsPackageVersion)' != ''">$([System.Text.RegularExpressions.Regex]::Match('$(MdsPackageVersion)', '^[0-9]+').Value)</MdsPackageMajorVersion>
-    <DefineConstants Condition="'$(MdsPackageMajorVersion)' == '' or '$(MdsPackageMajorVersion)' &gt;= '6'">$(DefineConstants);MDS_SQLJSON_SUPPORTED</DefineConstants>
+    <MdsBaselineMajorVersion Condition="'$(ReferenceType)' == 'Package' and '$(MdsPackageVersion)' != ''">$([System.Text.RegularExpressions.Regex]::Match('$(MdsPackageVersion)', '^[0-9]+').Value)</MdsBaselineMajorVersion>
+    <MdsBaselineMajorVersion Condition="'$(MdsBaselineMajorVersion)' == ''">99999</MdsBaselineMajorVersion>
+    <DefineConstants Condition="'$(MdsBaselineMajorVersion)' &gt;= '6'">$(DefineConstants);MDS_GE_6</DefineConstants>
+    <DefineConstants Condition="'$(MdsBaselineMajorVersion)' &gt;= '7'">$(DefineConstants);MDS_GE_7</DefineConstants>
   </PropertyGroup>
 
   <!-- Other references -->

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Microsoft.Data.SqlClient.PerformanceTests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Microsoft.Data.SqlClient.PerformanceTests.csproj
@@ -59,12 +59,13 @@
   <!-- project must compile against the OLDEST baseline anyone may queue - a benchmark that calls an -->
   <!-- API introduced after that baseline breaks the baseline pass with CS1061.  MdsBaselineMajor-   -->
   <!-- Version is the major version of the pinned baseline; the cumulative MDS_GE_<n> constants let  -->
-  <!-- individual benchmarks guard a call and fall back to an older equivalent.  Project mode,       -->
-  <!-- Package mode without an explicit version, and any version string whose major cannot be parsed -->
-  <!-- all fail toward "current" (all constants defined), because those builds reference a current   -->
-  <!-- MDS.  Add a new MDS_GE_<n> line here as newer baselines start being used.                     -->
+  <!-- individual benchmarks guard a call and fall back to an older equivalent.  Leading whitespace  -->
+  <!-- and a "v" prefix are tolerated.  Project mode, Package mode without an explicit version, and  -->
+  <!-- any version string whose major cannot be parsed all fail toward "current" (sentinel 99999, so -->
+  <!-- every constant is defined), because those builds reference a current MDS.  Add a new          -->
+  <!-- MDS_GE_<n> line here as newer baselines start being used.                                     -->
   <PropertyGroup>
-    <MdsBaselineMajorVersion Condition="'$(ReferenceType)' == 'Package' and '$(MdsPackageVersion)' != ''">$([System.Text.RegularExpressions.Regex]::Match('$(MdsPackageVersion)', '^[0-9]+').Value)</MdsBaselineMajorVersion>
+    <MdsBaselineMajorVersion Condition="'$(ReferenceType)' == 'Package' and '$(MdsPackageVersion)' != ''">$([System.Text.RegularExpressions.Regex]::Match('$(MdsPackageVersion)', '^\s*[vV]?([0-9]+)').Groups[1].Value)</MdsBaselineMajorVersion>
     <MdsBaselineMajorVersion Condition="'$(MdsBaselineMajorVersion)' == ''">99999</MdsBaselineMajorVersion>
     <DefineConstants Condition="'$(MdsBaselineMajorVersion)' &gt;= '6'">$(DefineConstants);MDS_GE_6</DefineConstants>
     <DefineConstants Condition="'$(MdsBaselineMajorVersion)' &gt;= '7'">$(DefineConstants);MDS_GE_7</DefineConstants>


### PR DESCRIPTION
## Summary

The perf pipeline's baseline pass compiles the `PerformanceTests` project against a **released** MDS package (`-p:ReferenceType=Package -p:MdsPackageVersion=<version>`). `JsonVsVarcharReadRunner` calls `SqlDataReader.GetSqlJson`, which was introduced in MDS 6.0, so any pre-6.0 baseline broke that pass:

```
JsonVsVarcharReadRunner.cs(115,32): error CS1061: 'SqlDataReader' does not contain a
definition for 'GetSqlJson' ... [::TargetFramework=net9.0]
```

Reproduced locally with `-p:MdsPackageVersion=5.2.3`; 6.0.2 / 7.0.2 / 7.1.0-preview build fine.

## Changes

**Baseline API gating (`Microsoft.Data.SqlClient.PerformanceTests.csproj`)**
- Derives `MdsBaselineMajorVersion` from `MdsPackageVersion` and defines cumulative `MDS_GE_6` / `MDS_GE_7` constants, so any future benchmark can guard a post-baseline API without new one-off plumbing.
- Tolerates whitespace and a `v` prefix. Project mode, unpinned Package mode, and unparsable versions all fail toward "current" (sentinel `99999`), since those builds reference a current MDS.

**`JsonVsVarcharReadRunner`**
- JSON reads are guarded with `#if MDS_GE_6`, falling back to `GetString` / `GetFieldValueAsync<string>`. The async fallback keeps an async read path so the async benchmark stays meaningful.
- Warns loudly from `GlobalSetup` when the fallback is compiled in — the baseline then measures a *different code path*, so that benchmark's delta is not comparable.
- Fails with an actionable message when the server lacks native JSON column support, instead of a raw `SqlException`.
- Validates `RowCount` and the configured connection string up front.
- Drops tables created by a partially-failed `GlobalSetup` (BenchmarkDotNet does not guarantee `GlobalCleanup` runs when setup throws, and table names are unique per run, so leaks accumulate on the perf server).
- `GlobalCleanup` attempts both drops even if one fails, skips tables never created, aggregates failures, and still clears pools via `finally`.
- Minor: non-static `_rowCount`, trailing whitespace.

**Docs (`eng/pipelines/perf/README.md`)**
- New "Benchmarks must compile against the oldest baseline" section with the guard pattern.
- Troubleshooting row mapping `CS1061` in the baseline pass to the fix.

## Validation

Emitted constants:

| `MdsPackageVersion` | constants |
| --- | --- |
| `5.2.3`, ` v5.2.3`, `V5.2.3`, `0.1.0` | *(none)* → fallback |
| `6.0.2` | `MDS_GE_6` |
| `7.0.2`, `7.1.0-preview1.26124.5` | `MDS_GE_6;MDS_GE_7` |
| `latest` (unparsable), unpinned, Project mode | all → current |

Builds clean in Package mode for 5.2.3 / 6.0.2 / 7.0.2 / 7.1.0-preview1.26124.5 and in Project mode across net8.0/net9.0/net10.0.

- [x] Tests added or updated (perf benchmark project only; no product code changed)
- [x] Public API changes documented (none — no API changes)
- [x] Verified against customer repro (build break reproduced and fixed locally)
- [x] Ensure no breaking changes introduced

No product code is touched, so no release note is needed.