### PR TITLE
Pipelines | Add .NET 10 test coverage to the CI-SqlClient pipeline

### DIFF
--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -25,6 +25,26 @@ parameters:
     type: object
     default: [net8.0, net9.0, net10.0]
 
+  # The target frameworks to build and run tests for on Windows, for the
+  # primary test configurations (local SQL Server 2025 and Azure SQL).
+  #
+  # These configurations carry the broadest coverage, so newer runtimes are
+  # validated here first before being enabled across every configuration.
+  #
+  # Note: The driver does not ship a net10.0 target framework, so net10.0 test
+  # assemblies resolve the net9.0 driver build.  Including net10.0 here
+  # validates the driver running on the .NET 10 runtime.
+  #
+  - name: primaryTargetFrameworks
+    type: object
+    default: [net462, net8.0, net9.0, net10.0]
+
+  # The target frameworks to build and run tests for on Unix, for the primary
+  # test configurations (local SQL Server 2025 and Azure SQL).
+  - name: primaryTargetFrameworksUnix
+    type: object
+    default: [net8.0, net9.0, net10.0]
+
   # Netcore Version for Test Utilities
   - name: netcoreVersionTestUtils
     type: object
@@ -412,7 +432,7 @@ stages:
           pool: ${{parameters.defaultPoolName }}
           images:
             Win25_Sql25: ADO-MMS25-SQL25
-          TargetFrameworks: ${{parameters.targetFrameworks }}
+          TargetFrameworks: ${{parameters.primaryTargetFrameworks }}
           netcoreVersionTestUtils: ${{parameters.netcoreVersionTestUtils }}
           buildPlatforms: ${{parameters.buildPlatforms }}
           testSets: ${{parameters.testSets }}
@@ -485,7 +505,7 @@ stages:
           images:
             Win22_Azure_Sql: ADO-MMS22-SQL19
             Win11_Azure_Sql: ADO-CI-Win11
-          TargetFrameworks: ${{parameters.targetFrameworks }}
+          TargetFrameworks: ${{parameters.primaryTargetFrameworks }}
           netcoreVersionTestUtils: ${{parameters.netcoreVersionTestUtils }}
           buildPlatforms: ${{parameters.buildPlatforms }}
           testSets: ${{parameters.testSets }}
@@ -542,7 +562,7 @@ stages:
           pool: ${{parameters.defaultPoolName }}
           images:
             Ubuntu24_Sql25: ADO-UB24-SQL25
-          TargetFrameworks: ${{parameters.targetFrameworksUnix }}
+          TargetFrameworks: ${{parameters.primaryTargetFrameworksUnix }}
           netcoreVersionTestUtils: ${{parameters.netcoreVersionTestUtils }}
           buildPlatforms: [AnyCPU]
           testSets: ${{parameters.testSets }}
@@ -565,7 +585,7 @@ stages:
           pool: ${{parameters.defaultPoolName }}
           images:
             Ubuntu24_Azure_Sql: ADO-UB24-SQL25
-          TargetFrameworks: ${{parameters.targetFrameworksUnix }}
+          TargetFrameworks: ${{parameters.primaryTargetFrameworksUnix }}
           netcoreVersionTestUtils: ${{parameters.netcoreVersionTestUtils }}
           buildPlatforms: [AnyCPU]
           testSets: ${{parameters.testSets }}

--- a/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
@@ -175,6 +175,11 @@ extends:
     dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
     targetFrameworks: ${{ parameters.targetFrameworks }}
     targetFrameworksUnix: ${{ parameters.targetFrameworksUnix }}
+    # Keep the primary (SQL 2025 / Azure SQL) configurations on the same set of
+    # target frameworks as everything else.  Only the CI-SqlClient pipeline
+    # opts in to the broader .NET 10.0 coverage on those configurations.
+    primaryTargetFrameworks: ${{ parameters.targetFrameworks }}
+    primaryTargetFrameworksUnix: ${{ parameters.targetFrameworksUnix }}
     testJobTimeout: ${{ parameters.testJobTimeout }}
     testSets: ${{ parameters.testSets }}
     useManagedSNI: ${{ parameters.useManagedSNI }}

--- a/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
@@ -113,8 +113,9 @@ parameters:
   # These are _not_ the target frameworks to build the driver packages for.
   #
   # Note: We are excluding .NET 10.0 here to avoid consuming too many resources
-  # during PR pipeline runs, and until we update our 1ES images to include
-  # Visual Studio 2026 (18.0) whose MSBuild SDK supports .NET 10.
+  # across every SQL Server image.  .NET 10.0 coverage is provided by the
+  # primaryTargetFrameworks parameter below, which applies to the SQL Server
+  # 2025 and Azure SQL configurations.
   #
   - name: targetFrameworks
     displayName: Target Frameworks on Windows
@@ -126,13 +127,37 @@ parameters:
   # These are _not_ the target frameworks to build the driver packages for.
   #
   # Note: We are excluding .NET 10.0 here to avoid consuming too many resources
-  # during PR pipeline runs, and until we update our 1ES images to include
-  # Visual Studio 2026 (18.0) whose MSBuild SDK supports .NET 10.
+  # across every SQL Server image.  .NET 10.0 coverage is provided by the
+  # primaryTargetFrameworksUnix parameter below, which applies to the SQL
+  # Server 2025 and Azure SQL configurations.
   #
   - name: targetFrameworksUnix
     displayName: Target Frameworks on Unix
     type: object
     default: [net8.0, net9.0]
+
+  # The target frameworks used by the primary test configurations (local SQL
+  # Server 2025 and Azure SQL) on Windows.
+  #
+  # net10.0 is included here so that unit, functional, and manual tests get
+  # .NET 10 coverage without paying for it on every legacy SQL Server image.
+  #
+  # Note: The driver itself does not ship a net10.0 target framework, so the
+  # net10.0 test assemblies resolve the net9.0 driver build.  These jobs
+  # therefore validate the driver running on the .NET 10 runtime, rather than
+  # a net10.0 build of the driver.
+  #
+  - name: primaryTargetFrameworks
+    displayName: Target Frameworks on Windows (SQL 2025 and Azure SQL)
+    type: object
+    default: [net462, net8.0, net9.0, net10.0]
+
+  # The target frameworks used by the primary test configurations (local SQL
+  # Server 2025 and Azure SQL) on Unix.
+  - name: primaryTargetFrameworksUnix
+    displayName: Target Frameworks on Unix (SQL 2025 and Azure SQL)
+    type: object
+    default: [net8.0, net9.0, net10.0]
 
   # The timeout, in minutes, for each test job.
   - name: testJobTimeout
@@ -175,6 +200,8 @@ extends:
     dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
     targetFrameworks: ${{ parameters.targetFrameworks }}
     targetFrameworksUnix: ${{ parameters.targetFrameworksUnix }}
+    primaryTargetFrameworks: ${{ parameters.primaryTargetFrameworks }}
+    primaryTargetFrameworksUnix: ${{ parameters.primaryTargetFrameworksUnix }}
     testJobTimeout: ${{ parameters.testJobTimeout }}
     testSets: ${{ parameters.testSets }}
     useManagedSNI: ${{ parameters.useManagedSNI }}

--- a/eng/pipelines/sqlclient-pr-package-ref-pipeline.yml
+++ b/eng/pipelines/sqlclient-pr-package-ref-pipeline.yml
@@ -135,6 +135,11 @@ extends:
     debug: ${{ parameters.debug }}
     targetFrameworks: ${{ parameters.targetFrameworks }}
     targetFrameworksUnix: ${{ parameters.targetFrameworksUnix }}
+    # Keep the primary (SQL 2025 / Azure SQL) configurations on the same set of
+    # target frameworks as everything else.  Only the CI-SqlClient pipeline
+    # opts in to the broader .NET 10.0 coverage on those configurations.
+    primaryTargetFrameworks: ${{ parameters.targetFrameworks }}
+    primaryTargetFrameworksUnix: ${{ parameters.targetFrameworksUnix }}
     testJobTimeout: ${{ parameters.testJobTimeout }}
     testSets: ${{ parameters.testSets }}
     useManagedSNI: ${{ parameters.useManagedSNI }}

--- a/eng/pipelines/sqlclient-pr-project-ref-pipeline.yml
+++ b/eng/pipelines/sqlclient-pr-project-ref-pipeline.yml
@@ -135,6 +135,11 @@ extends:
     debug: ${{ parameters.debug }}
     targetFrameworks: ${{ parameters.targetFrameworks }}
     targetFrameworksUnix: ${{ parameters.targetFrameworksUnix }}
+    # Keep the primary (SQL 2025 / Azure SQL) configurations on the same set of
+    # target frameworks as everything else.  Only the CI-SqlClient pipeline
+    # opts in to the broader .NET 10.0 coverage on those configurations.
+    primaryTargetFrameworks: ${{ parameters.targetFrameworks }}
+    primaryTargetFrameworksUnix: ${{ parameters.targetFrameworksUnix }}
     testJobTimeout: ${{ parameters.testJobTimeout }}
     testSets: ${{ parameters.testSets }}
     useManagedSNI: ${{ parameters.useManagedSNI }}


### PR DESCRIPTION
**Stacked PR 2 of 3.** Targets `dev/automation/ci-sql2025-images` (#4513) - review that one first. Follow-up: (3) hosted-agent retirement.

## Summary

Adds .NET 10 test coverage to the CI-SqlClient pipeline.

Introduces `primaryTargetFrameworks` and `primaryTargetFrameworksUnix`, which apply only to the *primary* test configurations - local SQL Server 2025 and Azure SQL, on both Windows and Linux. Those four configurations now run `net10.0` in addition to their existing target frameworks. Each of those configurations runs the unit, functional, and manual test sets, so this covers all three for .NET 10.

Restricting .NET 10 to the primary configurations keeps the added agent cost bounded rather than multiplying it across every legacy SQL Server image. The other pipelines that extend the CI core (`ci-package-reference`, `pr-package-ref`, `pr-project-ref`) pin the new parameters to their existing target framework lists, so their behaviour is unchanged.

## Note on what this validates

The driver itself only targets `net462`, `net8.0`, and `net9.0`, so the `net10.0` test assemblies resolve the `net9.0` driver build. These jobs therefore validate the driver **on the .NET 10 runtime**, rather than validating a .NET 10 build of the driver. This is called out in a comment in the pipeline.

`global.json` already pins SDK `10.0.300`, so no SDK installation changes were needed.

## Checklist

- [x] Tests added or updated - n/a, pipeline-only change (this change *is* additional test coverage)
- [x] Public API changes documented - n/a
- [ ] Verified against customer repro - n/a
- [x] Ensure no breaking changes introduced - additive only; other pipelines pin the new parameters to preserve current behaviour

All modified YAML files parse cleanly. These changes have not yet been executed against Azure DevOps.
