### PR TITLE
Address CodeQL findings: PKCS#1 padding (SM03799) and weak hash (SM02196)

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AlwaysEncrypted/ColumnMasterKeyMetadata.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AlwaysEncrypted/ColumnMasterKeyMetadata.cs
@@ -137,6 +137,7 @@ internal readonly ref struct ColumnMasterKeyMetadata : IDisposable
     /// </returns>
     /// <exception cref="CryptographicException">Thrown when the signing operation fails.</exception>
     public byte[] Sign() =>
+        // CodeQL [SM03799] Required for an external standard: Always Encrypted signs column master key metadata with RSA PKCS#1 v1.5 (https://learn.microsoft.com/en-us/sql/t-sql/statements/create-column-master-key-transact-sql?view=sql-server-ver16)
         _rsa.SignHash(_hash, s_hashAlgorithm, RSASignaturePadding.Pkcs1);
 
     /// <summary>
@@ -148,6 +149,7 @@ internal readonly ref struct ColumnMasterKeyMetadata : IDisposable
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="signature"/> is <see langword="null"/>.</exception>"
     public bool Verify(byte[] signature) =>
+        // CodeQL [SM03799] Required for an external standard: Always Encrypted signs column master key metadata with RSA PKCS#1 v1.5 (https://learn.microsoft.com/en-us/sql/t-sql/statements/create-column-master-key-transact-sql?view=sql-server-ver16)
         _rsa.VerifyHash(_hash, signature, s_hashAlgorithm, RSASignaturePadding.Pkcs1);
 
     /// <summary>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AlwaysEncrypted/ColumnMasterKeyMetadata.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AlwaysEncrypted/ColumnMasterKeyMetadata.cs
@@ -147,7 +147,7 @@ internal readonly ref struct ColumnMasterKeyMetadata : IDisposable
     /// <returns>
     /// <see langword="true"/> if the signature is valid and matches the computed hash; otherwise, <see langword="false"/>.
     /// </returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="signature"/> is <see langword="null"/>.</exception>"
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="signature"/> is <see langword="null"/>.</exception>
     public bool Verify(byte[] signature) =>
         // CodeQL [SM03799] Required for an external standard: Always Encrypted signs column master key metadata with RSA PKCS#1 v1.5 (https://learn.microsoft.com/en-us/sql/t-sql/statements/create-column-master-key-transact-sql?view=sql-server-ver16)
         _rsa.VerifyHash(_hash, signature, s_hashAlgorithm, RSASignaturePadding.Pkcs1);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AlwaysEncrypted/EncryptedColumnEncryptionKeyParameters.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AlwaysEncrypted/EncryptedColumnEncryptionKeyParameters.cs
@@ -151,7 +151,9 @@ internal readonly ref struct EncryptedColumnEncryptionKeyParameters : IDisposabl
         Debug.Assert(bytesWritten == HashSize, @"Hash size does not match the expected size.");
 
         bytesWritten = _keyType == SqlColumnEncryptionCertificateStoreProvider.MasterKeyType
+            // CodeQL [SM03799] Required for an external standard: Always Encrypted signs encrypted column encryption keys with RSA PKCS#1 v1.5 (https://learn.microsoft.com/en-us/sql/t-sql/statements/create-column-encryption-key-transact-sql?view=sql-server-ver16)
             ? _rsa.SignHash(hash, encryptedColumnEncryptionKey.AsSpan(signatureOffset), s_hashAlgorithm, RSASignaturePadding.Pkcs1)
+            // CodeQL [SM03799] Required for an external standard: Always Encrypted signs encrypted column encryption keys with RSA PKCS#1 v1.5 (https://learn.microsoft.com/en-us/sql/t-sql/statements/create-column-encryption-key-transact-sql?view=sql-server-ver16)
             : _rsa.SignData(hash, encryptedColumnEncryptionKey.AsSpan(signatureOffset), s_hashAlgorithm, RSASignaturePadding.Pkcs1);
         Debug.Assert(bytesWritten == _rsaKeySize, @"Signature length does not match the RSA key size.");
 
@@ -166,7 +168,9 @@ internal readonly ref struct EncryptedColumnEncryptionKeyParameters : IDisposabl
         Debug.Assert(bytesWritten == HashSize, @"Hash size does not match the expected size.");
 
         byte[] signedHash = _keyType == SqlColumnEncryptionCertificateStoreProvider.MasterKeyType
+            // CodeQL [SM03799] Required for an external standard: Always Encrypted signs encrypted column encryption keys with RSA PKCS#1 v1.5 (https://learn.microsoft.com/en-us/sql/t-sql/statements/create-column-encryption-key-transact-sql?view=sql-server-ver16)
             ? _rsa.SignHash(hash, s_hashAlgorithm, RSASignaturePadding.Pkcs1)
+            // CodeQL [SM03799] Required for an external standard: Always Encrypted signs encrypted column encryption keys with RSA PKCS#1 v1.5 (https://learn.microsoft.com/en-us/sql/t-sql/statements/create-column-encryption-key-transact-sql?view=sql-server-ver16)
             : _rsa.SignData(hash, s_hashAlgorithm, RSASignaturePadding.Pkcs1);
         bytesWritten = signedHash.Length;
         Debug.Assert(bytesWritten == _rsaKeySize, @"Signature length does not match the RSA key size.");
@@ -246,7 +250,9 @@ internal readonly ref struct EncryptedColumnEncryptionKeyParameters : IDisposabl
 #endif
 
         bool dataVerified = _keyType == SqlColumnEncryptionCertificateStoreProvider.MasterKeyType
+            // CodeQL [SM03799] Required for an external standard: Always Encrypted signs encrypted column encryption keys with RSA PKCS#1 v1.5 (https://learn.microsoft.com/en-us/sql/t-sql/statements/create-column-encryption-key-transact-sql?view=sql-server-ver16)
             ? _rsa.VerifyHash(hash, signature, s_hashAlgorithm, RSASignaturePadding.Pkcs1)
+            // CodeQL [SM03799] Required for an external standard: Always Encrypted signs encrypted column encryption keys with RSA PKCS#1 v1.5 (https://learn.microsoft.com/en-us/sql/t-sql/statements/create-column-encryption-key-transact-sql?view=sql-server-ver16)
             : _rsa.VerifyData(hash, signature, s_hashAlgorithm, RSASignaturePadding.Pkcs1);
 
         // Validate the signature

--- a/tools/PackageValidator/src/AssemblyInspector.cs
+++ b/tools/PackageValidator/src/AssemblyInspector.cs
@@ -232,6 +232,7 @@ internal static class AssemblyInspector
 
         // The token is defined by the CLI spec as the low 8 bytes of the SHA-1 hash of the public
         // key, emitted in reverse (little-endian) order.
+        // CodeQL [SM02196] Required for an external standard: ECMA-335 defines the strong-name public key token as a SHA-1 hash; this is an identity computation, not a security boundary.
         byte[] hash = SHA1.HashData(publicKey);
         var token = new byte[8];
         for (int i = 0; i < 8; i++)

--- a/tools/PackageValidator/src/PortablePdb.cs
+++ b/tools/PackageValidator/src/PortablePdb.cs
@@ -191,6 +191,10 @@ internal static class PortablePdb
     /// <summary>
     /// Creates a <see cref="HashAlgorithm"/> for a PDB checksum algorithm name.
     /// </summary>
+    /// <remarks>
+    /// Only SHA-2 family algorithms are supported; weak hashes such as SHA-1 are deliberately not
+    /// recognized, so a PDB recording one is reported as inconclusive rather than verified.
+    /// </remarks>
     /// <param name="algorithm">The algorithm name as recorded in the debug directory (for example <c>"SHA256"</c>).</param>
     /// <returns>A new hash algorithm instance, or <see langword="null"/> if the name is not recognized.</returns>
     private static HashAlgorithm? CreateHashAlgorithm(string algorithm) =>
@@ -199,7 +203,6 @@ internal static class PortablePdb
             "SHA256" => SHA256.Create(),
             "SHA384" => SHA384.Create(),
             "SHA512" => SHA512.Create(),
-            "SHA1" => SHA1.Create(),
             _ => null,
         };
 }


### PR DESCRIPTION
## Summary

Addresses two CodeQL/SDL findings.

### SM03799 — RSA PKCS#1 v1.5 signature padding (Always Encrypted)

CodeQL flags `RSASignaturePadding.Pkcs1` in the Always Encrypted signing/verification paths, recommending PSS instead.

These are false positives. The encrypted CEK blob and column master key metadata signatures are defined by an external standard — they are produced and verified by SQL Server tooling and other client drivers. Switching to PSS would produce blobs no other client could verify. Suppression comments are added, matching the existing `SM03796` suppressions already present for RSA-OAEP(SHA1) in the same file.

- `EncryptedColumnEncryptionKeyParameters.cs` — `SignHash`/`SignData` (both `NET` and `NETFRAMEWORK` paths) and `VerifyHash`/`VerifyData`
- `ColumnMasterKeyMetadata.cs` — `Sign()` and `Verify()`

### SM02196 — weak hash algorithm (PackageValidator)

- `PortablePdb.CreateHashAlgorithm` — **SHA1 removed** from the PDB checksum algorithm map. Modern compilers record SHA-2 checksums, and an unrecognized algorithm already degrades to an inconclusive result rather than a failure, so this is a no-op in practice while removing an SDL-banned hash.
- `AssemblyInspector.ComputePublicKeyToken` — suppressed. SHA-1 is mandated by ECMA-335 for strong-name public key tokens and is used purely as an identity computation, not a security boundary.

## Validation

- `Microsoft.Data.SqlClient.csproj` (net9.0) builds clean — 0 warnings, 0 errors
- PackageValidator tests: 61/61 passing

## Checklist

- [x] Tests added or updated — N/A, no behavioral change requiring new tests
- [x] Public API changes documented — N/A, no API changes
- [x] Verified against customer repro (if applicable) — N/A
- [x] Ensure no breaking changes introduced
