### PR TITLE
Fix AccessTokenCallback to match AccessToken behavior for TNIR and connection pool keys

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -145,6 +145,19 @@ namespace Microsoft.Data.SqlClient.Connection
         // @TODO: Probably a good idea to introduce a delegate type
         internal readonly Func<SqlAuthenticationParameters, CancellationToken, Task<SqlAuthenticationToken>> _accessTokenCallback;
 
+        /// <summary>
+        /// True when the caller supplied a federated authentication access token directly, either
+        /// as a literal token via <see cref="SqlConnection.AccessToken"/> or as a token provider
+        /// via <see cref="SqlConnection.AccessTokenCallback"/>.
+        /// </summary>
+        /// <remarks>
+        /// Both paths represent the same "caller-supplied token" authentication mode, so they must
+        /// always be treated identically. Use this property rather than testing the underlying
+        /// fields individually.
+        /// </remarks>
+        internal bool IsAccessTokenProvided =>
+            _accessTokenInBytes != null || _accessTokenCallback != null;
+
         // @TODO: Should be private and accessed via internal property
         // @TODO: Rename to match naming conventions
         internal bool _cleanSQLDNSCaching = false;
@@ -3115,7 +3128,9 @@ namespace Microsoft.Data.SqlClient.Connection
             #if NET
             bool isParallel = connectionOptions.MultiSubnetFailover;
             #else
-            bool disableTnir = ShouldDisableTnir(connectionOptions);
+            bool disableTnir = ShouldDisableTnir(
+                connectionOptions,
+                isAccessTokenProvided: IsAccessTokenProvided);
             bool isParallel = connectionOptions.MultiSubnetFailover ||
                               (connectionOptions.TransparentNetworkIPResolution && !disableTnir);
             #endif
@@ -3911,12 +3926,29 @@ namespace Microsoft.Data.SqlClient.Connection
         }
 
         #if NETFRAMEWORK
-        private bool ShouldDisableTnir(SqlConnectionOptions connectionOptions)
+        /// <summary>
+        /// Determines whether Transparent Network IP Resolution (TNIR) should be disabled for this
+        /// connection attempt.
+        /// </summary>
+        /// <param name="connectionOptions">The parsed connection options.</param>
+        /// <param name="isAccessTokenProvided">
+        /// True when the caller supplied a federated authentication access token directly, either
+        /// via <see cref="SqlConnection.AccessToken"/> or
+        /// <see cref="SqlConnection.AccessTokenCallback"/>.
+        /// </param>
+        /// <returns>
+        /// True when TNIR should be disabled. TNIR is disabled by default for Azure SQL endpoints
+        /// and for federated authentication, but an explicit
+        /// <c>TransparentNetworkIPResolution</c> keyword always takes precedence.
+        /// </returns>
+        internal static bool ShouldDisableTnir(
+            SqlConnectionOptions connectionOptions,
+            bool isAccessTokenProvided)
         {
             bool isAzureEndPoint = ADP.IsAzureSqlServerEndpoint(connectionOptions.DataSource);
 
             // @TODO: Turn into a HashSet and just check the list instead of this MESS.
-            bool isFedAuthEnabled = _accessTokenInBytes != null ||
+            bool isFedAuthEnabled = isAccessTokenProvided ||
                                     #pragma warning disable 0618 // Type or member is obsolete
                                     connectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryPassword ||
                                     #pragma warning restore 0618 // Type or member is obsolete

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -147,9 +147,8 @@ namespace Microsoft.Data.SqlClient.Connection
 
         /// <summary>
         /// True when the caller supplied a federated authentication access token directly, either
-        /// as a literal token via <see cref="SqlConnection.AccessToken"/> or as a token provider
-        /// via <see cref="SqlConnection.AccessTokenCallback"/>.
-        /// </summary>
+        /// as a literal token via <see cref="global::Microsoft.Data.SqlClient.SqlConnection.AccessToken"/> or as a token provider
+        /// via <see cref="global::Microsoft.Data.SqlClient.SqlConnection.AccessTokenCallback"/>.
         /// <remarks>
         /// Both paths represent the same "caller-supplied token" authentication mode, so they must
         /// always be treated identically. Use this property rather than testing the underlying

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -149,6 +149,7 @@ namespace Microsoft.Data.SqlClient.Connection
         /// True when the caller supplied a federated authentication access token directly, either
         /// as a literal token via <see cref="global::Microsoft.Data.SqlClient.SqlConnection.AccessToken"/> or as a token provider
         /// via <see cref="global::Microsoft.Data.SqlClient.SqlConnection.AccessTokenCallback"/>.
+        /// </summary>
         /// <remarks>
         /// Both paths represent the same "caller-supplied token" authentication mode, so they must
         /// always be treated identically. Use this property rather than testing the underlying

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -763,8 +763,15 @@ namespace Microsoft.Data.SqlClient
                     CheckAndThrowOnInvalidCombinationOfConnectionOptionAndAccessToken(ConnectionOptions);
                 }
 
-                // Need to call ConnectionString_Set to do proper pool group check
-                ConnectionString_Set(new ConnectionPoolKey(_connectionString, credential: _credential, accessToken: value, accessTokenCallback: null, sspiContextProvider: null));
+                // Need to call ConnectionString_Set to do proper pool group check.
+                // Preserve the other authentication state so it isn't dropped from the pool key
+                // (see the ConnectionString setter, which is the reference for this pattern).
+                ConnectionString_Set(new ConnectionPoolKey(
+                    _connectionString,
+                    credential: _credential,
+                    accessToken: value,
+                    accessTokenCallback: _accessTokenCallback,
+                    sspiContextProvider: _sspiContextProvider));
                 _accessToken = value;
             }
         }
@@ -787,7 +794,12 @@ namespace Microsoft.Data.SqlClient
                     CheckAndThrowOnInvalidCombinationOfConnectionOptionAndAccessTokenCallback(ConnectionOptions);
                 }
 
-                ConnectionString_Set(new ConnectionPoolKey(_connectionString, credential: _credential, accessToken: null, accessTokenCallback: value, sspiContextProvider: null));
+                ConnectionString_Set(new ConnectionPoolKey(
+                    _connectionString,
+                    credential: _credential,
+                    accessToken: _accessToken,
+                    accessTokenCallback: value,
+                    sspiContextProvider: _sspiContextProvider));
                 _accessTokenCallback = value;
             }
         }
@@ -804,7 +816,12 @@ namespace Microsoft.Data.SqlClient
                     throw ADP.OpenConnectionPropertySet(nameof(SspiContextProvider), InnerConnection.State);
                 }
 
-                ConnectionString_Set(new ConnectionPoolKey(_connectionString, credential: _credential, accessToken: null, accessTokenCallback: null, sspiContextProvider: value));
+                ConnectionString_Set(new ConnectionPoolKey(
+                    _connectionString,
+                    credential: _credential,
+                    accessToken: _accessToken,
+                    accessTokenCallback: _accessTokenCallback,
+                    sspiContextProvider: value));
                 _sspiContextProvider = value;
             }
         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -1179,7 +1179,7 @@ namespace Microsoft.Data.SqlClient
 
                         // We must NOT use the response for the FEDAUTHREQUIRED PreLogin option, if the connection string option
                         // was not using the new Authentication keyword or in other words, if Authentication=NotSpecified
-                        // Or AccessToken is not null, mean token based authentication is used.
+                        // Or an access token was supplied (AccessToken/AccessTokenCallback), which means token-based authentication is used.
                         if ((_connHandler.ConnectionOptions != null
                             && _connHandler.ConnectionOptions.Authentication != SqlAuthenticationMethod.NotSpecified)
                             || _connHandler.IsAccessTokenProvided)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -1182,7 +1182,7 @@ namespace Microsoft.Data.SqlClient
                         // Or AccessToken is not null, mean token based authentication is used.
                         if ((_connHandler.ConnectionOptions != null
                             && _connHandler.ConnectionOptions.Authentication != SqlAuthenticationMethod.NotSpecified)
-                            || _connHandler._accessTokenInBytes != null || _connHandler._accessTokenCallback != null)
+                            || _connHandler.IsAccessTokenProvided)
                         {
                             fedAuthRequired = payload[payloadOffset] == 0x01 ? true : false;
                         }
@@ -1219,7 +1219,7 @@ namespace Microsoft.Data.SqlClient
 
                 // Validate Certificate if Trust Server Certificate=false and Encryption forced (EncryptionOptions.ON) from Server.
                 bool shouldValidateServerCert = (_encryptionOption == EncryptionOptions.ON && !trustServerCert) ||
-                    ((_connHandler._accessTokenInBytes != null || _connHandler._accessTokenCallback != null) && !trustServerCert);
+                    (_connHandler.IsAccessTokenProvided && !trustServerCert);
 
                 uint info = (shouldValidateServerCert ? TdsEnums.SNI_SSL_VALIDATE_CERTIFICATE : 0)
                     | TdsEnums.SNI_SSL_USE_SCHANNEL_CACHE;

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionOptionsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionOptionsTest.cs
@@ -5,6 +5,9 @@
 using System;
 using Microsoft.Data.SqlClient.Tests.Common;
 using Xunit;
+#if NETFRAMEWORK
+using SqlConnectionInternal = global::Microsoft.Data.SqlClient.Connection.SqlConnectionInternal;
+#endif
 
 namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
 {
@@ -62,6 +65,41 @@ namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
 
             // Assert
             Assert.Equal(expectedValue, connectionString.TransparentNetworkIPResolution);
+        }
+
+        /// <summary>
+        /// TNIR is disabled by default whenever federated authentication is in play, including when
+        /// the token is supplied directly through <c>AccessToken</c> or <c>AccessTokenCallback</c>,
+        /// unless the user explicitly specified the TNIR keyword.
+        /// </summary>
+        [Theory]
+        // Non-Azure endpoint, no explicit TNIR keyword: access token (or callback) disables TNIR.
+        [InlineData("my.test.server", false, false, false)]
+        [InlineData("my.test.server", true, false, true)]
+        // Azure endpoint always disables TNIR when the keyword is absent.
+        [InlineData("test.database.windows.net", false, false, true)]
+        [InlineData("test.database.windows.net", true, false, true)]
+        // An explicit TNIR keyword always wins, regardless of access token or endpoint.
+        [InlineData("my.test.server", true, true, false)]
+        [InlineData("test.database.windows.net", true, true, false)]
+        [InlineData("test.database.windows.net", false, true, false)]
+        public void TestShouldDisableTnirWithAccessToken(
+            string dataSource,
+            bool isAccessTokenProvided,
+            bool tnirExplicitlySpecified,
+            bool expectedValue)
+        {
+            SqlConnectionStringBuilder builder = new() { DataSource = dataSource };
+            if (tnirExplicitlySpecified)
+            {
+                builder.TransparentNetworkIPResolution = true;
+            }
+
+            SqlConnectionOptions connectionOptions = new(builder.ConnectionString);
+
+            Assert.Equal(
+                expectedValue,
+                SqlConnectionInternal.ShouldDisableTnir(connectionOptions, isAccessTokenProvided));
         }
 #endif
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionTests.cs
@@ -764,6 +764,65 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             }
         }
 
+        /// <summary>
+        /// Setting one authentication-related property must not silently drop the others from the
+        /// connection pool key. Previously, assigning <see cref="SqlConnection.SspiContextProvider"/>
+        /// rebuilt the pool key with a null <see cref="SqlConnection.AccessTokenCallback"/> (and a
+        /// null <see cref="SqlConnection.AccessToken"/>), so the token was never handed to the
+        /// internal connection even though the public property still reported it as set.
+        /// </summary>
+        [Fact]
+        public void AccessTokenStateIsPreservedInPoolKeyWhenSspiContextProviderIsSet()
+        {
+            Func<SqlAuthenticationParameters, CancellationToken, Task<SqlAuthenticationToken>> callback =
+                (ctx, token) => Task.FromResult(new SqlAuthenticationToken("invalid", DateTimeOffset.MaxValue));
+
+            using (SqlConnection conn = new("Data Source=localhost"))
+            {
+                conn.AccessTokenCallback = callback;
+                Assert.Same(callback, conn.PoolGroup.PoolKey.AccessTokenCallback);
+
+                conn.SspiContextProvider = null;
+
+                Assert.Same(callback, conn.AccessTokenCallback);
+                Assert.Same(callback, conn.PoolGroup.PoolKey.AccessTokenCallback);
+            }
+
+            using (SqlConnection conn = new("Data Source=localhost"))
+            {
+                conn.AccessToken = "token";
+                Assert.Equal("token", conn.PoolGroup.PoolKey.AccessToken);
+
+                conn.SspiContextProvider = null;
+
+                Assert.Equal("token", conn.AccessToken);
+                Assert.Equal("token", conn.PoolGroup.PoolKey.AccessToken);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="SqlConnection.AccessToken"/> and <see cref="SqlConnection.AccessTokenCallback"/>
+        /// are mutually exclusive, so neither setter can ever clobber a live value of the other.
+        /// </summary>
+        [Fact]
+        public void AccessTokenAndAccessTokenCallbackAreMutuallyExclusive()
+        {
+            Func<SqlAuthenticationParameters, CancellationToken, Task<SqlAuthenticationToken>> callback =
+                (ctx, token) => Task.FromResult(new SqlAuthenticationToken("invalid", DateTimeOffset.MaxValue));
+
+            using (SqlConnection conn = new("Data Source=localhost"))
+            {
+                conn.AccessTokenCallback = callback;
+                Assert.Throws<InvalidOperationException>(() => conn.AccessToken = "token");
+            }
+
+            using (SqlConnection conn = new("Data Source=localhost"))
+            {
+                conn.AccessToken = "token";
+                Assert.Throws<InvalidOperationException>(() => conn.AccessTokenCallback = callback);
+            }
+        }
+
         [Theory]
         [InlineData(9, 0, 2047)] // SQL Server 2005
         [InlineData(10, 0, 2531)] // SQL Server 2008


### PR DESCRIPTION
Follow-up to the review discussion on #4493, where it was noted that the TNIR behavior documented there does not actually apply when `SqlConnection.AccessTokenCallback` is used:

> Since this is a fairly new introduction, we should fix it in our driver to match what happens in the `AccessToken` usecase. Documenting this would not be needed in that case.

## The bug

On .NET Framework the driver disables Transparent Network IP Resolution by default whenever federated authentication is in use, unless the caller explicitly specified the `TransparentNetworkIPResolution` keyword. `SqlConnectionInternal.ShouldDisableTnir` only tested `_accessTokenInBytes` (`SqlConnection.AccessToken`) and ignored `_accessTokenCallback` (`SqlConnection.AccessTokenCallback`), so the two token-supplying APIs behaved differently for no good reason.

## Changes

**1. Single source of truth for "a token was supplied."**
Added `SqlConnectionInternal.IsAccessTokenProvided` and used it in all three places that previously inlined the field checks — `ShouldDisableTnir` plus two spots in `TdsParser.ConsumePreLoginHandshake`. The duplicated hand-written expression is exactly what let these paths drift apart, and the existing `@TODO` in `OnFedAuthInfo` predicted this ("we're gonna forget one in *one* spot and cause a big ol bug someday").

**2. Pool key no longer drops sibling authentication state.**
The `AccessToken`, `AccessTokenCallback` and `SspiContextProvider` setters each rebuilt the `ConnectionPoolKey` with the sibling authentication values hard-coded to `null`. Setting `SspiContextProvider` silently dropped a previously assigned access token or callback from the pool key, so it never reached the internal connection even though the public property still reported it as set — which would also have defeated the TNIR fix above. These now preserve sibling state, matching the `ConnectionString` setter, which already did this correctly.

`AccessToken` and `AccessTokenCallback` are already mutually exclusive (validated in `CheckAndThrowOnInvalidCombinationOfConnectionOptionAndAccessToken*`), so that pairing was benign; `SspiContextProvider` is not mutually exclusive with either, so that one was a live defect.

**3. Tests.**
`ShouldDisableTnir` is now `internal static` so the decision matrix can be unit tested directly (constructing a `SqlConnectionInternal` in a unit test is impractical). Added:
- `SqlConnectionOptionsTest.TestShouldDisableTnirWithAccessToken` (netfx only) — token/no-token x Azure/non-Azure endpoint x explicit/absent TNIR keyword.
- `ConnectionTests.AccessTokenStateIsPreservedInPoolKeyWhenSspiContextProviderIsSet` — verified to fail without the `SqlConnection.cs` change.
- `ConnectionTests.AccessTokenAndAccessTokenCallbackAreMutuallyExclusive` — pins the invariant that makes the token pairing safe.

## Compatibility

Behavior change is limited to .NET Framework, and only for connections using `AccessTokenCallback`, which now get the same TNIR default as `AccessToken`. Users who explicitly set `TransparentNetworkIPResolution` in the connection string are unaffected — the explicit keyword still takes precedence, so the escape hatch documented in #4493 continues to work.

## Checklist

- [x] Tests added or updated
- [x] Public API changes documented (no public API changes)
- [x] Verified against customer repro (if applicable)
- [x] Ensure no breaking changes introduced

## Suggested release note

Fixed `SqlConnection.AccessTokenCallback` not disabling Transparent Network IP Resolution by default on .NET Framework, making it consistent with `SqlConnection.AccessToken`. Also fixed the `AccessToken`, `AccessTokenCallback` and `SspiContextProvider` setters discarding each other's values from the connection pool key.

## Notes for reviewers

- Docs are intentionally untouched: #4493 already updates the TNIR wording to say TNIR is disabled when Entra ID auth or an access token is used, and this change makes that statement true for the callback path.
- Full net8.0 unit test suite was still running locally when this was opened; CI will cover it. net462 tests cannot be executed on the macOS dev machine used here, though the net462 target builds clean.
