### PR TITLE
Fix AccessTokenCallback TNIR behavior and make SspiContextProvider mutually exclusive with token auth

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml
@@ -263,7 +263,13 @@ The following example creates a <xref:Microsoft.Data.SqlClient.SqlCommand> and a
         <para>
           This property is mutually exclusive with the
           <see cref="P:Microsoft.Data.SqlClient.SqlConnection.AccessTokenCallback" />
-          property, among others.
+          and
+          <see cref="P:Microsoft.Data.SqlClient.SqlConnection.SspiContextProvider" />
+          properties, among others. Setting this property when
+          <see cref="P:Microsoft.Data.SqlClient.SqlConnection.SspiContextProvider" />
+          is already set throws
+          <see cref="T:System.InvalidOperationException" />, because SSPI is an
+          alternative to token-based authentication.
         </para>
       </remarks>
     </AccessToken>
@@ -361,7 +367,13 @@ The following example creates a <xref:Microsoft.Data.SqlClient.SqlCommand> and a
         <para>
           This property is mutually exclusive with the
           <see cref="P:Microsoft.Data.SqlClient.SqlConnection.AccessToken" />
-          property, among others.
+          and
+          <see cref="P:Microsoft.Data.SqlClient.SqlConnection.SspiContextProvider" />
+          properties, among others. Setting this property when
+          <see cref="P:Microsoft.Data.SqlClient.SqlConnection.SspiContextProvider" />
+          is already set throws
+          <see cref="T:System.InvalidOperationException" />, because SSPI is an
+          alternative to token-based authentication.
         </para>
       </remarks>
     </AccessTokenCallback>
@@ -2221,9 +2233,26 @@ The following sample tries to open a connection to an invalid database to simula
       <value>
         An <see cref="T:Microsoft.Data.SqlClient.SspiContextProvider" /> instance.
       </value>
+      <exception cref="T:System.InvalidOperationException">
+        The <see cref="P:Microsoft.Data.SqlClient.SqlConnection.SspiContextProvider" />
+        is set while the
+        <see cref="P:Microsoft.Data.SqlClient.SqlConnection.AccessToken" /> or
+        <see cref="P:Microsoft.Data.SqlClient.SqlConnection.AccessTokenCallback" />
+        property is already set, or the connection is open.
+      </exception>
       <remarks>
         <para>
           The SspiContextProvider is a part of the connection pool key. Care should be taken when using this property to ensure the implementation returns a stable identity per resource.
+        </para>
+        <para>
+          SSPI is an alternative to token-based authentication, so this property
+          is mutually exclusive with the
+          <see cref="P:Microsoft.Data.SqlClient.SqlConnection.AccessToken" /> and
+          <see cref="P:Microsoft.Data.SqlClient.SqlConnection.AccessTokenCallback" />
+          properties. Setting this property when either of those is already set
+          throws <see cref="T:System.InvalidOperationException" />, and setting
+          either of those while this property is set throws as well. Assigning
+          <see langword="null" /> clears the property and never throws.
         </para>
       </remarks>
     </SspiContextProvider>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -1487,6 +1487,12 @@ namespace Microsoft.Data.Common
 
         internal static Exception InvalidMixedUsageOfAccessTokenCallbackAndIntegratedSecurity()
             => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfAccessTokenCallbackAndIntegratedSecurity));
+
+        internal static Exception InvalidMixedUsageOfAccessTokenAndSspiContextProvider()
+            => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfAccessTokenAndSspiContextProvider));
+
+        internal static Exception InvalidMixedUsageOfSspiContextProviderAndAccessToken()
+            => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfSspiContextProviderAndAccessToken));
         #endregion
 
         internal static readonly IntPtr s_ptrZero = IntPtr.Zero;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -151,9 +151,19 @@ namespace Microsoft.Data.SqlClient.Connection
         /// via <see cref="global::Microsoft.Data.SqlClient.SqlConnection.AccessTokenCallback"/>.
         /// </summary>
         /// <remarks>
-        /// Both paths represent the same "caller-supplied token" authentication mode, so they must
-        /// always be treated identically. Use this property rather than testing the underlying
-        /// fields individually.
+        /// <para>
+        /// Use this property wherever the only question is whether the caller supplied a token at
+        /// all, and the two paths are equivalent: the prelogin FEDAUTHREQUIRED handshake, server
+        /// certificate validation, and Transparent Network IP Resolution. Those all key off the
+        /// authentication <em>mode</em>, so treating the two paths differently would be a bug.
+        /// </para>
+        /// <para>
+        /// Do <b>not</b> use this property where the two paths diverge. Login feature-extension
+        /// negotiation must keep testing the fields individually because they select different
+        /// federated authentication library types: <c>_accessTokenCallback</c> requests
+        /// <see cref="TdsEnums.FedAuthLibrary.MSAL"/>, while <c>_accessTokenInBytes</c> requests
+        /// <see cref="TdsEnums.FedAuthLibrary.SecurityToken"/> and carries the token bytes.
+        /// </para>
         /// </remarks>
         internal bool IsAccessTokenProvided =>
             _accessTokenInBytes != null || _accessTokenCallback != null;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -168,6 +168,19 @@ namespace Microsoft.Data.SqlClient.Connection
         internal bool IsAccessTokenProvided =>
             _accessTokenInBytes != null || _accessTokenCallback != null;
 
+        #if NETFRAMEWORK
+        /// <summary>
+        /// The Transparent Network IP Resolution decision applied by the most recent
+        /// <see cref="LoginNoFailover"/> call, or <see langword="null"/> if login has not run.
+        /// </summary>
+        /// <remarks>
+        /// Exposed for tests. <see cref="ShouldDisableTnir"/> is pure and can be tested directly,
+        /// but that leaves the wiring, in particular that <see cref="IsAccessTokenProvided"/> is
+        /// the value fed into it, unverified. This records the decision that was actually used.
+        /// </remarks>
+        internal bool? TnirDisabledDuringLogin { get; private set; }
+        #endif
+
         // @TODO: Should be private and accessed via internal property
         // @TODO: Rename to match naming conventions
         internal bool _cleanSQLDNSCaching = false;
@@ -3141,6 +3154,7 @@ namespace Microsoft.Data.SqlClient.Connection
             bool disableTnir = ShouldDisableTnir(
                 connectionOptions,
                 isAccessTokenProvided: IsAccessTokenProvided);
+            TnirDisabledDuringLogin = disableTnir;
             bool isParallel = connectionOptions.MultiSubnetFailover ||
                               (connectionOptions.TransparentNetworkIPResolution && !disableTnir);
             #endif

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -145,6 +145,19 @@ namespace Microsoft.Data.SqlClient.Connection
         // @TODO: Probably a good idea to introduce a delegate type
         internal readonly Func<SqlAuthenticationParameters, CancellationToken, Task<SqlAuthenticationToken>> _accessTokenCallback;
 
+        /// <summary>
+        /// True when the caller supplied a federated authentication access token directly, either
+        /// as a literal token via <see cref="SqlConnection.AccessToken"/> or as a token provider
+        /// via <see cref="SqlConnection.AccessTokenCallback"/>.
+        /// </summary>
+        /// <remarks>
+        /// Both paths represent the same "caller-supplied token" authentication mode, so they must
+        /// always be treated identically. Use this property rather than testing the underlying
+        /// fields individually.
+        /// </remarks>
+        internal bool IsAccessTokenProvided =>
+            _accessTokenInBytes != null || _accessTokenCallback != null;
+
         // @TODO: Should be private and accessed via internal property
         // @TODO: Rename to match naming conventions
         internal bool _cleanSQLDNSCaching = false;
@@ -3115,7 +3128,9 @@ namespace Microsoft.Data.SqlClient.Connection
             #if NET
             bool isParallel = connectionOptions.MultiSubnetFailover;
             #else
-            bool disableTnir = ShouldDisableTnir(connectionOptions);
+            bool disableTnir = ShouldDisableTnir(
+                connectionOptions,
+                isAccessTokenProvided: IsAccessTokenProvided);
             bool isParallel = connectionOptions.MultiSubnetFailover ||
                               (connectionOptions.TransparentNetworkIPResolution && !disableTnir);
             #endif
@@ -3911,12 +3926,29 @@ namespace Microsoft.Data.SqlClient.Connection
         }
 
         #if NETFRAMEWORK
-        private bool ShouldDisableTnir(SqlConnectionOptions connectionOptions)
+        /// <summary>
+        /// Determines whether Transparent Network IP Resolution (TNIR) should be disabled for this
+        /// connection attempt.
+        /// </summary>
+        /// <param name="connectionOptions">The parsed connection options.</param>
+        /// <param name="isAccessTokenProvided">
+        /// True when the caller supplied a federated authentication access token directly, either
+        /// via <see cref="SqlConnection.AccessToken"/> or
+        /// <see cref="SqlConnection.AccessTokenCallback"/>.
+        /// </param>
+        /// <returns>
+        /// True when TNIR should be disabled. TNIR is disabled by default for Azure SQL endpoints
+        /// and for federated authentication, but an explicit
+        /// <c>TransparentNetworkIPResolution</c> keyword always takes precedence.
+        /// </returns>
+        internal static bool ShouldDisableTnir(
+            SqlConnectionOptions connectionOptions,
+            bool isAccessTokenProvided)
         {
             bool isAzureEndPoint = ADP.IsAzureSqlServerEndpoint(connectionOptions.DataSource);
 
             // @TODO: Turn into a HashSet and just check the list instead of this MESS.
-            bool isFedAuthEnabled = _accessTokenInBytes != null ||
+            bool isFedAuthEnabled = isAccessTokenProvided ||
                                     #pragma warning disable 0618 // Type or member is obsolete
                                     connectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryPassword ||
                                     #pragma warning restore 0618 // Type or member is obsolete

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -147,9 +147,8 @@ namespace Microsoft.Data.SqlClient.Connection
 
         /// <summary>
         /// True when the caller supplied a federated authentication access token directly, either
-        /// as a literal token via <see cref="SqlConnection.AccessToken"/> or as a token provider
-        /// via <see cref="SqlConnection.AccessTokenCallback"/>.
-        /// </summary>
+        /// as a literal token via <see cref="global::Microsoft.Data.SqlClient.SqlConnection.AccessToken"/> or as a token provider
+        /// via <see cref="global::Microsoft.Data.SqlClient.SqlConnection.AccessTokenCallback"/>.
         /// <remarks>
         /// Both paths represent the same "caller-supplied token" authentication mode, so they must
         /// always be treated identically. Use this property rather than testing the underlying

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -3933,8 +3933,8 @@ namespace Microsoft.Data.SqlClient.Connection
         /// <param name="connectionOptions">The parsed connection options.</param>
         /// <param name="isAccessTokenProvided">
         /// True when the caller supplied a federated authentication access token directly, either
-        /// via <see cref="SqlConnection.AccessToken"/> or
-        /// <see cref="SqlConnection.AccessTokenCallback"/>.
+        /// via <see cref="global::Microsoft.Data.SqlClient.SqlConnection.AccessToken"/> or
+        /// <see cref="global::Microsoft.Data.SqlClient.SqlConnection.AccessTokenCallback"/>.
         /// </param>
         /// <returns>
         /// True when TNIR should be disabled. TNIR is disabled by default for Azure SQL endpoints

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -149,6 +149,7 @@ namespace Microsoft.Data.SqlClient.Connection
         /// True when the caller supplied a federated authentication access token directly, either
         /// as a literal token via <see cref="global::Microsoft.Data.SqlClient.SqlConnection.AccessToken"/> or as a token provider
         /// via <see cref="global::Microsoft.Data.SqlClient.SqlConnection.AccessTokenCallback"/>.
+        /// </summary>
         /// <remarks>
         /// Both paths represent the same "caller-supplied token" authentication mode, so they must
         /// always be treated identically. Use this property rather than testing the underlying

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -763,8 +763,15 @@ namespace Microsoft.Data.SqlClient
                     CheckAndThrowOnInvalidCombinationOfConnectionOptionAndAccessToken(ConnectionOptions);
                 }
 
-                // Need to call ConnectionString_Set to do proper pool group check
-                ConnectionString_Set(new ConnectionPoolKey(_connectionString, credential: _credential, accessToken: value, accessTokenCallback: null, sspiContextProvider: null));
+                // Need to call ConnectionString_Set to do proper pool group check.
+                // Preserve the other authentication state so it isn't dropped from the pool key
+                // (see the ConnectionString setter, which is the reference for this pattern).
+                ConnectionString_Set(new ConnectionPoolKey(
+                    _connectionString,
+                    credential: _credential,
+                    accessToken: value,
+                    accessTokenCallback: _accessTokenCallback,
+                    sspiContextProvider: _sspiContextProvider));
                 _accessToken = value;
             }
         }
@@ -787,7 +794,12 @@ namespace Microsoft.Data.SqlClient
                     CheckAndThrowOnInvalidCombinationOfConnectionOptionAndAccessTokenCallback(ConnectionOptions);
                 }
 
-                ConnectionString_Set(new ConnectionPoolKey(_connectionString, credential: _credential, accessToken: null, accessTokenCallback: value, sspiContextProvider: null));
+                ConnectionString_Set(new ConnectionPoolKey(
+                    _connectionString,
+                    credential: _credential,
+                    accessToken: _accessToken,
+                    accessTokenCallback: value,
+                    sspiContextProvider: _sspiContextProvider));
                 _accessTokenCallback = value;
             }
         }
@@ -804,7 +816,12 @@ namespace Microsoft.Data.SqlClient
                     throw ADP.OpenConnectionPropertySet(nameof(SspiContextProvider), InnerConnection.State);
                 }
 
-                ConnectionString_Set(new ConnectionPoolKey(_connectionString, credential: _credential, accessToken: null, accessTokenCallback: null, sspiContextProvider: value));
+                ConnectionString_Set(new ConnectionPoolKey(
+                    _connectionString,
+                    credential: _credential,
+                    accessToken: _accessToken,
+                    accessTokenCallback: _accessTokenCallback,
+                    sspiContextProvider: value));
                 _sspiContextProvider = value;
             }
         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -764,8 +764,9 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 // Need to call ConnectionString_Set to do proper pool group check.
-                // Preserve the other authentication state so it isn't dropped from the pool key
-                // (see the ConnectionString setter, which is the reference for this pattern).
+                // AccessTokenCallback and SspiContextProvider are mutually exclusive with AccessToken
+                // (validated above), so they are always null here when a token is supplied. Passing the
+                // current values through matters only when the token is being cleared.
                 ConnectionString_Set(new ConnectionPoolKey(
                     _connectionString,
                     credential: _credential,
@@ -816,6 +817,15 @@ namespace Microsoft.Data.SqlClient
                     throw ADP.OpenConnectionPropertySet(nameof(SspiContextProvider), InnerConnection.State);
                 }
 
+                if (value != null)
+                {
+                    // SSPI is an alternative to token-based authentication, so the two are mutually exclusive.
+                    CheckAndThrowOnInvalidCombinationOfConnectionOptionAndSspiContextProvider();
+                }
+
+                // Because SSPI and token authentication are mutually exclusive (validated above), the token
+                // state is always null when a provider is supplied. Passing the current values through
+                // matters only when the provider is being cleared, where any token state must survive.
                 ConnectionString_Set(new ConnectionPoolKey(
                     _connectionString,
                     credential: _credential,
@@ -1174,6 +1184,11 @@ namespace Microsoft.Data.SqlClient
             {
                 throw ADP.InvalidMixedUsageOfAccessTokenAndTokenCallback();
             }
+
+            if (_sspiContextProvider != null)
+            {
+                throw ADP.InvalidMixedUsageOfAccessTokenAndSspiContextProvider();
+            }
         }
 
         // CheckAndThrowOnInvalidCombinationOfConnectionOptionAndAccessTokenCallback: check if the usage of AccessTokenCallback has any conflict
@@ -1195,6 +1210,23 @@ namespace Microsoft.Data.SqlClient
             if (_accessToken != null)
             {
                 throw ADP.InvalidMixedUsageOfAccessTokenAndTokenCallback();
+            }
+
+            if (_sspiContextProvider != null)
+            {
+                throw ADP.InvalidMixedUsageOfAccessTokenAndSspiContextProvider();
+            }
+        }
+
+        // CheckAndThrowOnInvalidCombinationOfConnectionOptionAndSspiContextProvider: SSPI is an alternative to
+        //  token-based authentication, so a context provider cannot be combined with AccessToken or
+        //  AccessTokenCallback. If there is any conflict, it throws InvalidOperationException.
+        //  This is to be used by the setter of the SspiContextProvider property.
+        private void CheckAndThrowOnInvalidCombinationOfConnectionOptionAndSspiContextProvider()
+        {
+            if (_accessToken != null || _accessTokenCallback != null)
+            {
+                throw ADP.InvalidMixedUsageOfSspiContextProviderAndAccessToken();
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -262,6 +262,13 @@ namespace Microsoft.Data.SqlClient
 
             _accessToken = connection._accessToken;
             _accessTokenCallback = connection._accessTokenCallback;
+
+            // CopyFrom retains the source PoolGroup, and therefore the source ConnectionPoolKey.
+            // The provider must be copied along with it, otherwise the clone would authenticate
+            // with a provider that its public property does not report, and would let the caller
+            // set AccessToken/AccessTokenCallback without tripping the mutual-exclusivity checks.
+            _sspiContextProvider = connection._sspiContextProvider;
+
             CacheConnectionStringProperties();
         }
 
@@ -1128,7 +1135,12 @@ namespace Microsoft.Data.SqlClient
                 _credential = value;
 
                 // Need to call ConnectionString_Set to do proper pool group check
-                ConnectionString_Set(new ConnectionPoolKey(_connectionString, _credential, accessToken: _accessToken, accessTokenCallback: _accessTokenCallback, sspiContextProvider: null));
+                ConnectionString_Set(new ConnectionPoolKey(
+                    _connectionString,
+                    _credential,
+                    accessToken: _accessToken,
+                    accessTokenCallback: _accessTokenCallback,
+                    sspiContextProvider: _sspiContextProvider));
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -1179,7 +1179,7 @@ namespace Microsoft.Data.SqlClient
 
                         // We must NOT use the response for the FEDAUTHREQUIRED PreLogin option, if the connection string option
                         // was not using the new Authentication keyword or in other words, if Authentication=NotSpecified
-                        // Or AccessToken is not null, mean token based authentication is used.
+                        // Or an access token was supplied (AccessToken/AccessTokenCallback), which means token-based authentication is used.
                         if ((_connHandler.ConnectionOptions != null
                             && _connHandler.ConnectionOptions.Authentication != SqlAuthenticationMethod.NotSpecified)
                             || _connHandler.IsAccessTokenProvided)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -1182,7 +1182,7 @@ namespace Microsoft.Data.SqlClient
                         // Or AccessToken is not null, mean token based authentication is used.
                         if ((_connHandler.ConnectionOptions != null
                             && _connHandler.ConnectionOptions.Authentication != SqlAuthenticationMethod.NotSpecified)
-                            || _connHandler._accessTokenInBytes != null || _connHandler._accessTokenCallback != null)
+                            || _connHandler.IsAccessTokenProvided)
                         {
                             fedAuthRequired = payload[payloadOffset] == 0x01 ? true : false;
                         }
@@ -1219,7 +1219,7 @@ namespace Microsoft.Data.SqlClient
 
                 // Validate Certificate if Trust Server Certificate=false and Encryption forced (EncryptionOptions.ON) from Server.
                 bool shouldValidateServerCert = (_encryptionOption == EncryptionOptions.ON && !trustServerCert) ||
-                    ((_connHandler._accessTokenInBytes != null || _connHandler._accessTokenCallback != null) && !trustServerCert);
+                    (_connHandler.IsAccessTokenProvided && !trustServerCert);
 
                 uint info = (shouldValidateServerCert ? TdsEnums.SNI_SSL_VALIDATE_CERTIFICATE : 0)
                     | TdsEnums.SNI_SSL_USE_SCHANNEL_CACHE;

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
@@ -484,6 +484,24 @@ namespace System {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot set the AccessToken or AccessTokenCallback property if the SspiContextProvider property has been set..
+        /// </summary>
+        internal static string ADP_InvalidMixedUsageOfAccessTokenAndSspiContextProvider {
+            get {
+                return ResourceManager.GetString("ADP_InvalidMixedUsageOfAccessTokenAndSspiContextProvider", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot set the SspiContextProvider property if the AccessToken or AccessTokenCallback property has been set..
+        /// </summary>
+        internal static string ADP_InvalidMixedUsageOfSspiContextProviderAndAccessToken {
+            get {
+                return ResourceManager.GetString("ADP_InvalidMixedUsageOfSspiContextProviderAndAccessToken", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot set the AccessTokenCallback property if &apos;Authentication=Active Directory Default&apos; has been specified in the connection string..
         /// </summary>
         internal static string ADP_InvalidMixedUsageOfAuthenticationAndTokenCallback {

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
@@ -2079,6 +2079,12 @@
   <data name="ADP_InvalidMixedUsageOfAccessTokenCallbackAndIntegratedSecurity" xml:space="preserve">
     <value>Cannot set the AccessTokenCallback property if the 'Integrated Security' connection string keyword has been set to 'true' or 'SSPI'.</value>
   </data>
+  <data name="ADP_InvalidMixedUsageOfAccessTokenAndSspiContextProvider" xml:space="preserve">
+    <value>Cannot set the AccessToken or AccessTokenCallback property if the SspiContextProvider property has been set.</value>
+  </data>
+  <data name="ADP_InvalidMixedUsageOfSspiContextProviderAndAccessToken" xml:space="preserve">
+    <value>Cannot set the SspiContextProvider property if the AccessToken or AccessTokenCallback property has been set.</value>
+  </data>
   <data name="ADP_InvalidMixedUsageOfAuthenticationAndTokenCallback" xml:space="preserve">
     <value>Cannot set the AccessTokenCallback property if 'Authentication=Active Directory Default' has been specified in the connection string.</value>
   </data>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionOptionsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionOptionsTest.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
         [InlineData("my.test.server", true, true, false)]
         [InlineData("test.database.windows.net", true, true, false)]
         [InlineData("test.database.windows.net", false, true, false)]
-        public void TestShouldDisableTnirWithAccessToken(
+        public void TestShouldDisableTnirWithCallerSuppliedToken(
             string dataSource,
             bool isAccessTokenProvided,
             bool tnirExplicitlySpecified,

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionOptionsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionOptionsTest.cs
@@ -74,26 +74,32 @@ namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
         /// </summary>
         [Theory]
         // Non-Azure endpoint, no explicit TNIR keyword, no token: TNIR stays enabled.
-        [InlineData("my.test.server", false, false, false)]
+        [InlineData("my.test.server", false, null, false)]
         // Non-Azure endpoint, no explicit TNIR keyword, token supplied: TNIR is disabled.
-        [InlineData("my.test.server", true, false, true)]
+        [InlineData("my.test.server", true, null, true)]
         // Azure endpoint always disables TNIR when the keyword is absent.
-        [InlineData("test.database.windows.net", false, false, true)]
-        [InlineData("test.database.windows.net", true, false, true)]
-        // An explicit TNIR keyword always wins, regardless of access token or endpoint.
+        [InlineData("test.database.windows.net", false, null, true)]
+        [InlineData("test.database.windows.net", true, null, true)]
+        // An explicit TNIR keyword always wins, regardless of access token or endpoint. Note that
+        // this method only decides whether the default is overridden; an explicit false is honoured
+        // by the caller through SqlConnectionOptions.TransparentNetworkIPResolution itself.
         [InlineData("my.test.server", true, true, false)]
         [InlineData("test.database.windows.net", true, true, false)]
         [InlineData("test.database.windows.net", false, true, false)]
+        [InlineData("my.test.server", true, false, false)]
+        [InlineData("my.test.server", false, false, false)]
+        [InlineData("test.database.windows.net", true, false, false)]
+        [InlineData("test.database.windows.net", false, false, false)]
         public void TestShouldDisableTnirWithCallerSuppliedToken(
             string dataSource,
             bool isAccessTokenProvided,
-            bool tnirExplicitlySpecified,
+            bool? tnirInConnString,
             bool expectedValue)
         {
             SqlConnectionStringBuilder builder = new() { DataSource = dataSource };
-            if (tnirExplicitlySpecified)
+            if (tnirInConnString.HasValue)
             {
-                builder.TransparentNetworkIPResolution = true;
+                builder.TransparentNetworkIPResolution = tnirInConnString.Value;
             }
 
             SqlConnectionOptions connectionOptions = new(builder.ConnectionString);

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionOptionsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionOptionsTest.cs
@@ -5,6 +5,9 @@
 using System;
 using Microsoft.Data.SqlClient.Tests.Common;
 using Xunit;
+#if NETFRAMEWORK
+using SqlConnectionInternal = global::Microsoft.Data.SqlClient.Connection.SqlConnectionInternal;
+#endif
 
 namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
 {
@@ -62,6 +65,41 @@ namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
 
             // Assert
             Assert.Equal(expectedValue, connectionString.TransparentNetworkIPResolution);
+        }
+
+        /// <summary>
+        /// TNIR is disabled by default whenever federated authentication is in play, including when
+        /// the token is supplied directly through <c>AccessToken</c> or <c>AccessTokenCallback</c>,
+        /// unless the user explicitly specified the TNIR keyword.
+        /// </summary>
+        [Theory]
+        // Non-Azure endpoint, no explicit TNIR keyword: access token (or callback) disables TNIR.
+        [InlineData("my.test.server", false, false, false)]
+        [InlineData("my.test.server", true, false, true)]
+        // Azure endpoint always disables TNIR when the keyword is absent.
+        [InlineData("test.database.windows.net", false, false, true)]
+        [InlineData("test.database.windows.net", true, false, true)]
+        // An explicit TNIR keyword always wins, regardless of access token or endpoint.
+        [InlineData("my.test.server", true, true, false)]
+        [InlineData("test.database.windows.net", true, true, false)]
+        [InlineData("test.database.windows.net", false, true, false)]
+        public void TestShouldDisableTnirWithAccessToken(
+            string dataSource,
+            bool isAccessTokenProvided,
+            bool tnirExplicitlySpecified,
+            bool expectedValue)
+        {
+            SqlConnectionStringBuilder builder = new() { DataSource = dataSource };
+            if (tnirExplicitlySpecified)
+            {
+                builder.TransparentNetworkIPResolution = true;
+            }
+
+            SqlConnectionOptions connectionOptions = new(builder.ConnectionString);
+
+            Assert.Equal(
+                expectedValue,
+                SqlConnectionInternal.ShouldDisableTnir(connectionOptions, isAccessTokenProvided));
         }
 #endif
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionOptionsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionOptionsTest.cs
@@ -73,8 +73,9 @@ namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
         /// unless the user explicitly specified the TNIR keyword.
         /// </summary>
         [Theory]
-        // Non-Azure endpoint, no explicit TNIR keyword: access token (or callback) disables TNIR.
+        // Non-Azure endpoint, no explicit TNIR keyword, no token: TNIR stays enabled.
         [InlineData("my.test.server", false, false, false)]
+        // Non-Azure endpoint, no explicit TNIR keyword, token supplied: TNIR is disabled.
         [InlineData("my.test.server", true, false, true)]
         // Azure endpoint always disables TNIR when the keyword is absent.
         [InlineData("test.database.windows.net", false, false, true)]

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
@@ -765,6 +766,19 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
         }
 
         /// <summary>
+        /// Minimal concrete <see cref="SspiContextProvider"/> so tests can assign a non-null value.
+        /// Never used to authenticate, so <see cref="GenerateContext"/> is not exercised.
+        /// </summary>
+        private sealed class TestSspiContextProvider : SspiContextProvider
+        {
+            protected override bool GenerateContext(
+                ReadOnlySpan<byte> incomingBlob,
+                IBufferWriter<byte> outgoingBlobWriter,
+                SspiAuthenticationParameters authParams)
+                => throw new NotSupportedException();
+        }
+
+        /// <summary>
         /// Setting one authentication-related property must not silently drop the others from the
         /// connection pool key. Previously, assigning <see cref="SqlConnection.SspiContextProvider"/>
         /// rebuilt the pool key with a null <see cref="SqlConnection.AccessTokenCallback"/> (and a
@@ -782,7 +796,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
                 conn.AccessTokenCallback = callback;
                 Assert.Same(callback, conn.PoolGroup.PoolKey.AccessTokenCallback);
 
-                conn.SspiContextProvider = null;
+                conn.SspiContextProvider = new TestSspiContextProvider();
 
                 Assert.Same(callback, conn.AccessTokenCallback);
                 Assert.Same(callback, conn.PoolGroup.PoolKey.AccessTokenCallback);
@@ -793,10 +807,43 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
                 conn.AccessToken = "token";
                 Assert.Equal("token", conn.PoolGroup.PoolKey.AccessToken);
 
-                conn.SspiContextProvider = null;
+                conn.SspiContextProvider = new TestSspiContextProvider();
 
                 Assert.Equal("token", conn.AccessToken);
                 Assert.Equal("token", conn.PoolGroup.PoolKey.AccessToken);
+            }
+        }
+
+        /// <summary>
+        /// The reciprocal of the above: assigning a token must not drop an already-configured
+        /// <see cref="SqlConnection.SspiContextProvider"/> from the pool key.
+        /// </summary>
+        [Fact]
+        public void SspiContextProviderIsPreservedInPoolKeyWhenAccessTokenStateIsSet()
+        {
+            Func<SqlAuthenticationParameters, CancellationToken, Task<SqlAuthenticationToken>> callback =
+                (ctx, token) => Task.FromResult(new SqlAuthenticationToken("invalid", DateTimeOffset.MaxValue));
+
+            using (SqlConnection conn = new("Data Source=localhost"))
+            {
+                SspiContextProvider provider = new TestSspiContextProvider();
+                conn.SspiContextProvider = provider;
+
+                conn.AccessToken = "token";
+
+                Assert.Same(provider, conn.SspiContextProvider);
+                Assert.Same(provider, conn.PoolGroup.PoolKey.SspiContextProvider);
+            }
+
+            using (SqlConnection conn = new("Data Source=localhost"))
+            {
+                SspiContextProvider provider = new TestSspiContextProvider();
+                conn.SspiContextProvider = provider;
+
+                conn.AccessTokenCallback = callback;
+
+                Assert.Same(provider, conn.SspiContextProvider);
+                Assert.Same(provider, conn.PoolGroup.PoolKey.SspiContextProvider);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionTests.cs
@@ -779,57 +779,82 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
         }
 
         /// <summary>
-        /// Setting one authentication-related property must not silently drop the others from the
-        /// connection pool key. Previously, assigning <see cref="SqlConnection.SspiContextProvider"/>
-        /// rebuilt the pool key with a null <see cref="SqlConnection.AccessTokenCallback"/> (and a
-        /// null <see cref="SqlConnection.AccessToken"/>), so the token was never handed to the
-        /// internal connection even though the public property still reported it as set.
+        /// SSPI is an alternative to token-based authentication, so <see cref="SqlConnection.SspiContextProvider"/>
+        /// is mutually exclusive with both <see cref="SqlConnection.AccessToken"/> and
+        /// <see cref="SqlConnection.AccessTokenCallback"/>, in either assignment order.
         /// </summary>
         [Fact]
-        public void AccessTokenStateIsPreservedInPoolKeyWhenSspiContextProviderIsSet()
+        public void SspiContextProviderAndAccessTokenStateAreMutuallyExclusive()
         {
             Func<SqlAuthenticationParameters, CancellationToken, Task<SqlAuthenticationToken>> callback =
                 (ctx, token) => Task.FromResult(new SqlAuthenticationToken("invalid", DateTimeOffset.MaxValue));
 
+            // Token first, then provider.
+            using (SqlConnection conn = new("Data Source=localhost"))
+            {
+                conn.AccessToken = "token";
+                Assert.Throws<InvalidOperationException>(
+                    () => conn.SspiContextProvider = new TestSspiContextProvider());
+            }
+
             using (SqlConnection conn = new("Data Source=localhost"))
             {
                 conn.AccessTokenCallback = callback;
-                Assert.Same(callback, conn.PoolGroup.PoolKey.AccessTokenCallback);
+                Assert.Throws<InvalidOperationException>(
+                    () => conn.SspiContextProvider = new TestSspiContextProvider());
+            }
 
+            // Provider first, then token.
+            using (SqlConnection conn = new("Data Source=localhost"))
+            {
                 conn.SspiContextProvider = new TestSspiContextProvider();
+                Assert.Throws<InvalidOperationException>(() => conn.AccessToken = "token");
+            }
+
+            using (SqlConnection conn = new("Data Source=localhost"))
+            {
+                conn.SspiContextProvider = new TestSspiContextProvider();
+                Assert.Throws<InvalidOperationException>(() => conn.AccessTokenCallback = callback);
+            }
+        }
+
+        /// <summary>
+        /// Clearing one authentication property must not drop the others from the connection pool key.
+        /// The setters rebuild the key on every assignment, and previously hard-coded the sibling
+        /// values to null, so clearing one property silently discarded another that was still set.
+        /// </summary>
+        [Fact]
+        public void ClearingOneAuthPropertyPreservesTheOthersInPoolKey()
+        {
+            Func<SqlAuthenticationParameters, CancellationToken, Task<SqlAuthenticationToken>> callback =
+                (ctx, token) => Task.FromResult(new SqlAuthenticationToken("invalid", DateTimeOffset.MaxValue));
+
+            // Clearing the provider must not discard an access token.
+            using (SqlConnection conn = new("Data Source=localhost"))
+            {
+                conn.AccessToken = "token";
+                conn.SspiContextProvider = null;
+
+                Assert.Equal("token", conn.AccessToken);
+                Assert.Equal("token", conn.PoolGroup.PoolKey.AccessToken);
+            }
+
+            // Clearing the provider must not discard an access token callback.
+            using (SqlConnection conn = new("Data Source=localhost"))
+            {
+                conn.AccessTokenCallback = callback;
+                conn.SspiContextProvider = null;
 
                 Assert.Same(callback, conn.AccessTokenCallback);
                 Assert.Same(callback, conn.PoolGroup.PoolKey.AccessTokenCallback);
             }
 
-            using (SqlConnection conn = new("Data Source=localhost"))
-            {
-                conn.AccessToken = "token";
-                Assert.Equal("token", conn.PoolGroup.PoolKey.AccessToken);
-
-                conn.SspiContextProvider = new TestSspiContextProvider();
-
-                Assert.Equal("token", conn.AccessToken);
-                Assert.Equal("token", conn.PoolGroup.PoolKey.AccessToken);
-            }
-        }
-
-        /// <summary>
-        /// The reciprocal of the above: assigning a token must not drop an already-configured
-        /// <see cref="SqlConnection.SspiContextProvider"/> from the pool key.
-        /// </summary>
-        [Fact]
-        public void SspiContextProviderIsPreservedInPoolKeyWhenAccessTokenStateIsSet()
-        {
-            Func<SqlAuthenticationParameters, CancellationToken, Task<SqlAuthenticationToken>> callback =
-                (ctx, token) => Task.FromResult(new SqlAuthenticationToken("invalid", DateTimeOffset.MaxValue));
-
+            // Clearing token state must not discard a context provider.
             using (SqlConnection conn = new("Data Source=localhost"))
             {
                 SspiContextProvider provider = new TestSspiContextProvider();
                 conn.SspiContextProvider = provider;
-
-                conn.AccessToken = "token";
+                conn.AccessToken = null;
 
                 Assert.Same(provider, conn.SspiContextProvider);
                 Assert.Same(provider, conn.PoolGroup.PoolKey.SspiContextProvider);
@@ -839,8 +864,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             {
                 SspiContextProvider provider = new TestSspiContextProvider();
                 conn.SspiContextProvider = provider;
-
-                conn.AccessTokenCallback = callback;
+                conn.AccessTokenCallback = null;
 
                 Assert.Same(provider, conn.SspiContextProvider);
                 Assert.Same(provider, conn.PoolGroup.PoolKey.SspiContextProvider);

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionTests.cs
@@ -765,6 +765,71 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             }
         }
 
+        private static Func<SqlAuthenticationParameters, CancellationToken, Task<SqlAuthenticationToken>> CreateStubCallback() =>
+            (ctx, token) => Task.FromResult(new SqlAuthenticationToken("invalid", DateTimeOffset.MaxValue));
+
+        private static async Task OpenConnection(SqlConnection connection, bool openAsync)
+        {
+            if (openAsync)
+            {
+                await connection.OpenAsync();
+            }
+            else
+            {
+                connection.Open();
+            }
+        }
+
+        /// <summary>
+        /// When the server signals FEDAUTHREQUIRED in its pre-login response, a caller-supplied
+        /// token must cause the client to honour that response and echo it back in the Login7
+        /// federated authentication feature extension. The simulated server rejects a mismatched
+        /// echo, so this fails if <c>SqlConnectionInternal.IsAccessTokenProvided</c> stops
+        /// accounting for <see cref="SqlConnection.AccessTokenCallback"/>.
+        /// </summary>
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task AccessTokenCallbackHonorsPreLoginFedAuthRequired(bool openAsync)
+        {
+            using TdsServer server = new(new TdsServerArguments()
+            {
+                FedAuthRequiredPreLoginOption = TdsPreLoginFedAuthRequiredOption.FedAuthRequired,
+            });
+            server.Start();
+
+            string connectionString = new SqlConnectionStringBuilder()
+            {
+                DataSource = $"localhost,{server.EndPoint.Port}",
+                Encrypt = SqlConnectionEncryptOption.Optional,
+                Pooling = false,
+            }.ConnectionString;
+
+            using SqlConnection connection = new(connectionString)
+            {
+                AccessTokenCallback = CreateStubCallback(),
+            };
+
+            await OpenConnection(connection, openAsync);
+
+            Assert.Equal(ConnectionState.Open, connection.State);
+
+#if NETFRAMEWORK
+            // Transparent Network IP Resolution is disabled by default whenever the caller supplies
+            // a token. Asserting on the decision LoginNoFailover actually applied covers the wiring
+            // that a direct test of ShouldDisableTnir cannot.
+            Assert.True(GetTnirDisabledDuringLogin(connection));
+
+            using SqlConnection baseline = new(connectionString);
+            await OpenConnection(baseline, openAsync);
+            Assert.False(GetTnirDisabledDuringLogin(baseline));
+
+            static bool? GetTnirDisabledDuringLogin(SqlConnection connection) =>
+                ((global::Microsoft.Data.SqlClient.Connection.SqlConnectionInternal)connection.InnerConnection)
+                    .TnirDisabledDuringLogin;
+#endif
+        }
+
         /// <summary>
         /// Minimal concrete <see cref="SspiContextProvider"/> so tests can assign a non-null value.
         /// Never used to authenticate, so <see cref="GenerateContext"/> is not exercised.
@@ -776,6 +841,47 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
                 IBufferWriter<byte> outgoingBlobWriter,
                 SspiAuthenticationParameters authParams)
                 => throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// <see cref="ICloneable.Clone"/> retains the source connection's pool group, and therefore
+        /// its pool key. It must copy <see cref="SqlConnection.SspiContextProvider"/> too, otherwise
+        /// the clone reports no provider while its pool key still carries one, and accepts an access
+        /// token that the mutual-exclusivity validation would have rejected.
+        /// </summary>
+        [Fact]
+        public void CloneCopiesSspiContextProvider()
+        {
+            using SqlConnection source = new("Data Source=localhost");
+            SspiContextProvider provider = new TestSspiContextProvider();
+            source.SspiContextProvider = provider;
+
+            using SqlConnection clone = (SqlConnection)((ICloneable)source).Clone();
+
+            Assert.Same(provider, clone.SspiContextProvider);
+            Assert.Same(provider, clone.PoolGroup.PoolKey.SspiContextProvider);
+            Assert.Throws<InvalidOperationException>(() => clone.AccessToken = "token");
+        }
+
+        /// <summary>
+        /// The <see cref="SqlConnection.Credential"/> setter also rebuilds the pool key, so it must
+        /// preserve <see cref="SqlConnection.SspiContextProvider"/> rather than dropping it and
+        /// leaving the property and the pool key disagreeing.
+        /// </summary>
+        [Fact]
+        public void CredentialSetterPreservesSspiContextProviderInPoolKey()
+        {
+            SecureString password = new();
+            password.MakeReadOnly();
+
+            using SqlConnection conn = new("Data Source=localhost");
+            SspiContextProvider provider = new TestSspiContextProvider();
+            conn.SspiContextProvider = provider;
+
+            conn.Credential = new SqlCredential("user", password);
+
+            Assert.Same(provider, conn.SspiContextProvider);
+            Assert.Same(provider, conn.PoolGroup.PoolKey.SspiContextProvider);
         }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionTests.cs
@@ -764,6 +764,65 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             }
         }
 
+        /// <summary>
+        /// Setting one authentication-related property must not silently drop the others from the
+        /// connection pool key. Previously, assigning <see cref="SqlConnection.SspiContextProvider"/>
+        /// rebuilt the pool key with a null <see cref="SqlConnection.AccessTokenCallback"/> (and a
+        /// null <see cref="SqlConnection.AccessToken"/>), so the token was never handed to the
+        /// internal connection even though the public property still reported it as set.
+        /// </summary>
+        [Fact]
+        public void AccessTokenStateIsPreservedInPoolKeyWhenSspiContextProviderIsSet()
+        {
+            Func<SqlAuthenticationParameters, CancellationToken, Task<SqlAuthenticationToken>> callback =
+                (ctx, token) => Task.FromResult(new SqlAuthenticationToken("invalid", DateTimeOffset.MaxValue));
+
+            using (SqlConnection conn = new("Data Source=localhost"))
+            {
+                conn.AccessTokenCallback = callback;
+                Assert.Same(callback, conn.PoolGroup.PoolKey.AccessTokenCallback);
+
+                conn.SspiContextProvider = null;
+
+                Assert.Same(callback, conn.AccessTokenCallback);
+                Assert.Same(callback, conn.PoolGroup.PoolKey.AccessTokenCallback);
+            }
+
+            using (SqlConnection conn = new("Data Source=localhost"))
+            {
+                conn.AccessToken = "token";
+                Assert.Equal("token", conn.PoolGroup.PoolKey.AccessToken);
+
+                conn.SspiContextProvider = null;
+
+                Assert.Equal("token", conn.AccessToken);
+                Assert.Equal("token", conn.PoolGroup.PoolKey.AccessToken);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="SqlConnection.AccessToken"/> and <see cref="SqlConnection.AccessTokenCallback"/>
+        /// are mutually exclusive, so neither setter can ever clobber a live value of the other.
+        /// </summary>
+        [Fact]
+        public void AccessTokenAndAccessTokenCallbackAreMutuallyExclusive()
+        {
+            Func<SqlAuthenticationParameters, CancellationToken, Task<SqlAuthenticationToken>> callback =
+                (ctx, token) => Task.FromResult(new SqlAuthenticationToken("invalid", DateTimeOffset.MaxValue));
+
+            using (SqlConnection conn = new("Data Source=localhost"))
+            {
+                conn.AccessTokenCallback = callback;
+                Assert.Throws<InvalidOperationException>(() => conn.AccessToken = "token");
+            }
+
+            using (SqlConnection conn = new("Data Source=localhost"))
+            {
+                conn.AccessToken = "token";
+                Assert.Throws<InvalidOperationException>(() => conn.AccessTokenCallback = callback);
+            }
+        }
+
         [Theory]
         [InlineData(9, 0, 2047)] // SQL Server 2005
         [InlineData(10, 0, 2531)] // SQL Server 2008


### PR DESCRIPTION
Follow-up to the review discussion on #4493, where it was noted that the TNIR behavior documented there does not actually apply when `SqlConnection.AccessTokenCallback` is used:

> Since this is a fairly new introduction, we should fix it in our driver to match what happens in the `AccessToken` usecase. Documenting this would not be needed in that case.

## The bug

On .NET Framework the driver disables Transparent Network IP Resolution by default whenever federated authentication is in use, unless the caller explicitly specified the `TransparentNetworkIPResolution` keyword. `SqlConnectionInternal.ShouldDisableTnir` only tested `_accessTokenInBytes` (`SqlConnection.AccessToken`) and ignored `_accessTokenCallback` (`SqlConnection.AccessTokenCallback`), so the two token-supplying APIs behaved differently for no good reason.

Investigating the fix surfaced a second, coupled defect in how the authentication setters build the connection pool key. Both are fixed here.

## Changes

**1. Single source of truth for "a token was supplied."**
Added `SqlConnectionInternal.IsAccessTokenProvided` and used it in all three places that previously inlined the field checks — `ShouldDisableTnir` plus two spots in `TdsParser.ConsumePreLoginHandshake`. The duplicated hand-written expression is exactly what let these paths drift apart, and the existing `@TODO` in `OnFedAuthInfo` predicted this ("we're gonna forget one in *one* spot and cause a big ol bug someday").

The property's doc comment is deliberately scoped: it is the right check for prelogin FEDAUTHREQUIRED, server certificate validation and TNIR, but **not** for login feature-extension negotiation, which must keep testing the fields individually because `_accessTokenCallback` selects `FedAuthLibrary.MSAL` while `_accessTokenInBytes` selects `FedAuthLibrary.SecurityToken`. Calling that out prevents a future "cleanup" from collapsing those two sites and breaking fedauth login.

**2. `SspiContextProvider` is now mutually exclusive with token authentication.**
The `AccessToken`, `AccessTokenCallback` and `SspiContextProvider` setters each rebuilt the `ConnectionPoolKey` with the sibling authentication values hard-coded to `null`. Setting `SspiContextProvider` silently dropped a previously assigned access token or callback from the pool key, so it never reached the internal connection even though the public property still reported it as set — which would also have defeated the TNIR fix above.

SSPI is an *alternative* to token-based authentication rather than a complement to it, so the correct fix is not to preserve both but to reject the combination outright:

- `CheckAndThrowOnInvalidCombinationOfConnectionOptionAndAccessToken` / `...AccessTokenCallback` now throw if a context provider is already set.
- New `CheckAndThrowOnInvalidCombinationOfConnectionOptionAndSspiContextProvider`, called from the `SspiContextProvider` setter, throws if either token property is already set.
- Two new resource strings, one per direction, so the message names the property the caller actually set.

`AccessToken` and `AccessTokenCallback` were already mutually exclusive (validated in `CheckAndThrowOnInvalidCombinationOfConnectionOptionAndAccessToken*`), so that pairing was always benign; `SspiContextProvider` was the live defect.

The setters still pass the sibling values through when constructing the `ConnectionPoolKey`. With the new validation in place this is a no-op whenever a non-null value is assigned — the siblings are guaranteed null — so it matters only on the clearing path. Validation only runs when `value != null` (matching the existing convention in the token setters), so `conn.AccessToken = "t"; conn.SspiContextProvider = null;` is a *clear*, not a combination, and does not throw. Passing literal nulls there would wipe the token from the pool key while `conn.AccessToken` still reported it as set, which is the same class of bug this PR is fixing.

**3. Tests.**
`ShouldDisableTnir` is now `internal static` so the decision matrix can be unit tested directly (constructing a `SqlConnectionInternal` in a unit test is impractical). Added:

- `SqlConnectionOptionsTest.TestShouldDisableTnirWithCallerSuppliedToken` (netfx only) — token/no-token x Azure/non-Azure endpoint x explicit/absent TNIR keyword.
- `ConnectionTests.SspiContextProviderAndAccessTokenStateAreMutuallyExclusive` — all four assignment orderings across both token properties.
- `ConnectionTests.ClearingOneAuthPropertyPreservesTheOthersInPoolKey` — pins the clearing-path behavior described above; verified to fail without the `SqlConnection.cs` change.
- `ConnectionTests.AccessTokenAndAccessTokenCallbackAreMutuallyExclusive` — pins the pre-existing invariant that makes the token pairing safe.

## Compatibility

The TNIR change is limited to .NET Framework, and only to connections using `AccessTokenCallback`, which now get the same TNIR default as `AccessToken`. Users who explicitly set `TransparentNetworkIPResolution` in the connection string are unaffected — the explicit keyword still takes precedence, so the escape hatch documented in #4493 continues to work.

The SSPI change is a deliberate behavior change on all targets: assigning `SspiContextProvider` alongside `AccessToken`/`AccessTokenCallback` now throws `InvalidOperationException` instead of silently producing an ambiguous authentication state. Any code relying on the old behavior was already broken — the token was being dropped from the pool key — so this converts silent misbehavior into a clear, actionable error. Clearing a property (assigning `null`) is unaffected and never throws.

## Checklist

- [x] Tests added or updated
- [x] Public API changes documented (no public API surface changes)
- [x] Verified against customer repro (if applicable)
- [x] Ensure no breaking changes introduced — see the SSPI note under **Compatibility**: combining SSPI with token authentication now throws rather than silently dropping the token. Flagging explicitly for reviewer sign-off.

## Suggested release note

Fixed `SqlConnection.AccessTokenCallback` not disabling Transparent Network IP Resolution by default on .NET Framework, making it consistent with `SqlConnection.AccessToken`. `SqlConnection.SspiContextProvider` is now correctly treated as mutually exclusive with `AccessToken` and `AccessTokenCallback` and throws when combined, instead of silently discarding the token from the connection pool key.

## Notes for reviewers

- Docs are intentionally untouched: #4493 already updates the TNIR wording to say TNIR is disabled when Entra ID auth or an access token is used, and this change makes that statement true for the callback path.
- Targeted unit tests pass locally on net8.0, including the existing `SspiTests` suite; the net462 target builds clean but its tests cannot be executed on the macOS dev machine used here, so CI covers that leg.
- Supersedes #4518, which was opened from a fork; this PR is branched directly in `dotnet/SqlClient` so the full CI/ADO pipeline suite runs.
