### PR TITLE
Fix Entra ID tenant parsing for multi-segment STSURL authorities

### DIFF
--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.cs
@@ -249,10 +249,13 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
             // More information:
             //
             //   https://docs.microsoft.com/azure/active-directory/develop/msal-client-application-configuration
+            //
+            // The authority URL provided by the server may be a bare tenant endpoint
+            // ("https://login.microsoftonline.com/{tenantId}") or an ADAL v1 style endpoint
+            // ("https://login.microsoftonline.com/{tenantId}/oauth2/authorize"), so the tenant is
+            // taken from the first path segment rather than the last.
 
-            int separatorIndex = parameters.Authority.LastIndexOf('/');
-            string authority = parameters.Authority.Remove(separatorIndex + 1);
-            string audience = parameters.Authority.Substring(separatorIndex + 1);
+            ParseAuthority(parameters.Authority, out string authority, out string audience, out string msalAuthority);
             string? clientId = string.IsNullOrWhiteSpace(parameters.UserId) ? null : parameters.UserId;
 
             if (parameters.AuthenticationMethod == SqlAuthenticationMethod.ActiveDirectoryDefault)
@@ -316,9 +319,9 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
 
             PublicClientAppKey pcaKey =
             #if NETFRAMEWORK
-                new(parameters.Authority, redirectUri, _applicationClientId, _iWin32WindowFunc);
+                new(msalAuthority, redirectUri, _applicationClientId, _iWin32WindowFunc);
             #else
-                new(parameters.Authority, redirectUri, _applicationClientId);
+                new(msalAuthority, redirectUri, _applicationClientId);
             #endif
 
             AuthenticationResult? result = null;
@@ -531,6 +534,58 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
                 $"Unexpected error: {ex.Message}",
                 ex);
         }
+    }
+
+    /// <summary>
+    /// Splits an Entra ID authority URL (the STSURL provided by the server in the FEDAUTHINFO TDS
+    /// token) into the authority host and the tenant.
+    /// </summary>
+    /// <param name="authorityUrl">
+    /// The authority URL, e.g. <c>https://login.microsoftonline.com/{tenantId}</c>. Some services
+    /// (for example the Dataverse/Dynamics 365 TDS endpoint) return an ADAL v1 style URL such as
+    /// <c>https://login.microsoftonline.com/{tenantId}/oauth2/authorize</c>.
+    /// </param>
+    /// <param name="authorityHost">
+    /// Receives the authority host with a trailing slash, e.g. <c>https://login.microsoftonline.com/</c>.
+    /// </param>
+    /// <param name="tenant">
+    /// Receives the tenant (the first path segment of the authority URL), which may be a tenant id,
+    /// a domain name, or one of the <c>common</c>/<c>organizations</c>/<c>consumers</c> placeholders.
+    /// </param>
+    /// <param name="msalAuthority">
+    /// Receives the normalized authority (host + tenant) suitable for MSAL's <c>WithAuthority</c>.
+    /// </param>
+    /// <remarks>
+    /// The tenant is taken from the first path segment rather than the last so that trailing
+    /// endpoint suffixes (<c>/oauth2/authorize</c>, <c>/oauth2/v2.0/token</c>, etc.) are ignored.
+    /// </remarks>
+    internal static void ParseAuthority(
+        string authorityUrl,
+        out string authorityHost,
+        out string tenant,
+        out string msalAuthority)
+    {
+        if (Uri.TryCreate(authorityUrl, UriKind.Absolute, out Uri? uri) &&
+            (uri.Scheme == Uri.UriSchemeHttps || uri.Scheme == Uri.UriSchemeHttp))
+        {
+            string path = uri.AbsolutePath.Trim('/');
+            int slashIndex = path.IndexOf('/');
+            tenant = slashIndex < 0 ? path : path.Substring(0, slashIndex);
+
+            if (tenant.Length > 0)
+            {
+                authorityHost = uri.GetLeftPart(UriPartial.Authority) + "/";
+                msalAuthority = authorityHost + tenant;
+                return;
+            }
+        }
+
+        // Fall back to the legacy behavior of splitting at the last separator when the authority
+        // isn't an absolute HTTP(S) URL, or when it carries no tenant segment.
+        int separatorIndex = authorityUrl.LastIndexOf('/');
+        authorityHost = authorityUrl.Remove(separatorIndex + 1);
+        tenant = authorityUrl.Substring(separatorIndex + 1);
+        msalAuthority = authorityUrl;
     }
 
     private static async Task<AuthenticationResult?> TryAcquireTokenSilent(IPublicClientApplication app, SqlAuthenticationParameters parameters,

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.cs
@@ -265,7 +265,7 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
 
             if (parameters.AuthenticationMethod == SqlAuthenticationMethod.ActiveDirectoryDefault)
             {
-                // Cache DefaultAzureCredenial based on scope, authority host, tenant, and clientId
+                // Cache DefaultAzureCredential based on scope, authority host, tenant, and clientId
                 TokenCredentialKey tokenCredentialKey = new(typeof(DefaultAzureCredential), authorityHost, scope, tenant, clientId);
                 AccessToken accessToken = await GetTokenAsync(tokenCredentialKey, string.Empty, tokenRequestContext, cts.Token).ConfigureAwait(false);
                 SqlClientEventSource.Log.TryTraceEvent("AcquireTokenAsync | Acquired access token for Default auth mode. Expiry Time: {0}", accessToken.ExpiresOn);
@@ -588,11 +588,13 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
         out string msalAuthority)
     {
         if (Uri.TryCreate(authorityUrl, UriKind.Absolute, out Uri? uri) &&
-            uri.Scheme == Uri.UriSchemeHttps)
+            uri.Scheme == Uri.UriSchemeHttps &&
+            uri.Segments.Length > 1)
         {
-            string path = uri.AbsolutePath.Trim('/');
-            int slashIndex = path.IndexOf('/');
-            tenant = slashIndex < 0 ? path : path.Substring(0, slashIndex);
+            // Segments[0] is always the leading "/", so the tenant is Segments[1]. Each segment
+            // keeps its trailing separator when further segments follow, e.g. the segments of
+            // "/{tenant}/oauth2/authorize" are [ "/", "{tenant}/", "oauth2/", "authorize" ].
+            tenant = uri.Segments[1].TrimEnd('/');
 
             if (tenant.Length > 0)
             {

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.cs
@@ -364,7 +364,7 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
             else if (parameters.AuthenticationMethod == SqlAuthenticationMethod.ActiveDirectoryPassword)
             #pragma warning restore CS0618 // Type or member is obsolete
             {
-                string pwCacheKey = GetAccountPwCacheKey(parameters);
+                string pwCacheKey = GetAccountPwCacheKey(msalAuthority, parameters.UserId);
                 object? previousPw = s_accountPwCache.Get(pwCacheKey);
                 string password = parameters.Password is null ? string.Empty : parameters.Password;
                 byte[] currPwHash = GetHash(password);
@@ -837,9 +837,18 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
         return await tokenCredentialInstance._tokenCredential.GetTokenAsync(tokenRequestContext, cancellationToken);
     }
 
-    private static string GetAccountPwCacheKey(SqlAuthenticationParameters parameters)
+    /// <summary>
+    /// Builds the cache key used to remember which password was last validated for an account.
+    /// </summary>
+    /// <param name="msalAuthority">
+    /// The normalized authority (host + tenant) from <see cref="TryParseAuthority"/>. The
+    /// normalized form is used so that two spellings of the same tenant (for example a bare
+    /// tenant endpoint and an OAuth v1 <c>/oauth2/authorize</c> endpoint) share a single entry.
+    /// </param>
+    /// <param name="userId">The user id being authenticated, which may be null.</param>
+    private static string GetAccountPwCacheKey(string msalAuthority, string? userId)
     {
-        return parameters.Authority + "+" + parameters.UserId;
+        return msalAuthority + "+" + userId;
     }
 
     private static byte[] GetHash(string input)

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.cs
@@ -222,29 +222,26 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
             string[] scopes = [scope];
             TokenRequestContext tokenRequestContext = new(scopes);
 
-            // We split audience from Authority URL here. Audience can be one of
+            // We split the tenant from the Authority URL here. The tenant can be one of
             // the following:
             //
-            //   - The Entra ID authority audience enumeration
             //   - The tenant ID, which can be:
             //     - A GUID (the ID of your Entra ID instance), for
             //       single-tenant applications
             //     - A domain name associated with your Entra ID instance (also
             //       for single-tenant applications)
-            //   - One of these placeholders as a tenant ID in place of the
-            //     Entra ID authority audience enumeration:
+            //   - One of these placeholders, which select an Entra ID authority
+            //     audience instead of a specific tenant:
             //     - `organizations` for a multitenant application
             //     - `consumers` to sign in users only with their personal
             //       accounts
             //     - `common` to sign in users with their work and school
             //       accounts or their personal Microsoft accounts
             //
-            // MSAL will throw a meaningful exception if you specify both the
-            // Entra ID authority audience and the tenant ID.
-            //
-            // If you don't specify an audience, your app will target Entra ID
-            // and personal Microsoft accounts as an audience.  (That is, it
-            // will behave as though `common` were specified.)
+            // If no tenant is specified, the app targets Entra ID and personal
+            // Microsoft accounts as an audience.  (That is, it behaves as though
+            // `common` were specified.)  We always have a tenant here, because the
+            // server supplies one in the STSURL.
             //
             // More information:
             //
@@ -255,7 +252,7 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
             // ("https://login.microsoftonline.com/{tenantId}/oauth2/authorize"), so the tenant is
             // taken from the first path segment rather than the last.
 
-            if (!TryParseAuthority(parameters.Authority, out string authority, out string audience, out string msalAuthority))
+            if (!TryParseAuthority(parameters.Authority, out string authorityHost, out string tenant, out string msalAuthority))
             {
                 throw new Extensions.Azure.AuthenticationException(
                     parameters.AuthenticationMethod,
@@ -268,8 +265,8 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
 
             if (parameters.AuthenticationMethod == SqlAuthenticationMethod.ActiveDirectoryDefault)
             {
-                // Cache DefaultAzureCredenial based on scope, authority, audience, and clientId
-                TokenCredentialKey tokenCredentialKey = new(typeof(DefaultAzureCredential), authority, scope, audience, clientId);
+                // Cache DefaultAzureCredenial based on scope, authority host, tenant, and clientId
+                TokenCredentialKey tokenCredentialKey = new(typeof(DefaultAzureCredential), authorityHost, scope, tenant, clientId);
                 AccessToken accessToken = await GetTokenAsync(tokenCredentialKey, string.Empty, tokenRequestContext, cts.Token).ConfigureAwait(false);
                 SqlClientEventSource.Log.TryTraceEvent("AcquireTokenAsync | Acquired access token for Default auth mode. Expiry Time: {0}", accessToken.ExpiresOn);
                 return new SqlAuthenticationToken(accessToken.Token, accessToken.ExpiresOn);
@@ -277,8 +274,8 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
 
             if (parameters.AuthenticationMethod == SqlAuthenticationMethod.ActiveDirectoryManagedIdentity || parameters.AuthenticationMethod == SqlAuthenticationMethod.ActiveDirectoryMSI)
             {
-                // Cache ManagedIdentityCredential based on scope, authority, and clientId
-                TokenCredentialKey tokenCredentialKey = new(typeof(ManagedIdentityCredential), authority, scope, string.Empty, clientId);
+                // Cache ManagedIdentityCredential based on scope, authority host, and clientId
+                TokenCredentialKey tokenCredentialKey = new(typeof(ManagedIdentityCredential), authorityHost, scope, string.Empty, clientId);
                 AccessToken accessToken = await GetTokenAsync(tokenCredentialKey, string.Empty, tokenRequestContext, cts.Token).ConfigureAwait(false);
                 SqlClientEventSource.Log.TryTraceEvent("AcquireTokenAsync | Acquired access token for Managed Identity auth mode. Expiry Time: {0}", accessToken.ExpiresOn);
                 return new SqlAuthenticationToken(accessToken.Token, accessToken.ExpiresOn);
@@ -286,8 +283,8 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
 
             if (parameters.AuthenticationMethod == SqlAuthenticationMethod.ActiveDirectoryServicePrincipal)
             {
-                // Cache ClientSecretCredential based on scope, authority, audience, and clientId
-                TokenCredentialKey tokenCredentialKey = new(typeof(ClientSecretCredential), authority, scope, audience, clientId);
+                // Cache ClientSecretCredential based on scope, authority host, tenant, and clientId
+                TokenCredentialKey tokenCredentialKey = new(typeof(ClientSecretCredential), authorityHost, scope, tenant, clientId);
                 string password = parameters.Password is null ? string.Empty : parameters.Password;
                 AccessToken accessToken = await GetTokenAsync(tokenCredentialKey, password, tokenRequestContext, cts.Token).ConfigureAwait(false);
                 SqlClientEventSource.Log.TryTraceEvent("AcquireTokenAsync | Acquired access token for Active Directory Service Principal auth mode. Expiry Time: {0}", accessToken.ExpiresOn);
@@ -296,8 +293,8 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
 
             if (parameters.AuthenticationMethod == SqlAuthenticationMethod.ActiveDirectoryWorkloadIdentity)
             {
-                // Cache WorkloadIdentityCredential based on authority and clientId
-                TokenCredentialKey tokenCredentialKey = new(typeof(WorkloadIdentityCredential), authority, string.Empty, string.Empty, clientId);
+                // Cache WorkloadIdentityCredential based on authority host and clientId
+                TokenCredentialKey tokenCredentialKey = new(typeof(WorkloadIdentityCredential), authorityHost, string.Empty, string.Empty, clientId);
                 // If either tenant id, client id, or the token file path are not specified when fetching the token,
                 // a CredentialUnavailableException will be thrown instead
                 AccessToken accessToken = await GetTokenAsync(tokenCredentialKey, string.Empty, tokenRequestContext, cts.Token).ConfigureAwait(false);
@@ -942,8 +939,8 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
         {
             DefaultAzureCredentialOptions defaultAzureCredentialOptions = new()
             {
-                AuthorityHost = new Uri(tokenCredentialKey._authority),
-                TenantId = tokenCredentialKey._audience,
+                AuthorityHost = new Uri(tokenCredentialKey._authorityHost),
+                TenantId = tokenCredentialKey._tenant,
                 ExcludeInteractiveBrowserCredential = true // Force disabled, even though it's disabled by default to respect driver specifications.
             };
 
@@ -987,23 +984,23 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
                 : ManagedIdentityId.FromUserAssignedClientId(tokenCredentialKey._clientId);
             ManagedIdentityCredentialOptions managedIdentityCredentialOptions = new(managedIdentityId)
             {
-                AuthorityHost = new Uri(tokenCredentialKey._authority)
+                AuthorityHost = new Uri(tokenCredentialKey._authorityHost)
             };
 
             return new TokenCredentialData(new ManagedIdentityCredential(managedIdentityCredentialOptions), GetHash(secret));
         }
         else if (tokenCredentialKey._tokenCredentialType == typeof(ClientSecretCredential))
         {
-            TokenCredentialOptions tokenCredentialOptions = new() { AuthorityHost = new Uri(tokenCredentialKey._authority) };
+            TokenCredentialOptions tokenCredentialOptions = new() { AuthorityHost = new Uri(tokenCredentialKey._authorityHost) };
 
-            return new TokenCredentialData(new ClientSecretCredential(tokenCredentialKey._audience, tokenCredentialKey._clientId, secret, tokenCredentialOptions), GetHash(secret));
+            return new TokenCredentialData(new ClientSecretCredential(tokenCredentialKey._tenant, tokenCredentialKey._clientId, secret, tokenCredentialOptions), GetHash(secret));
         }
         else if (tokenCredentialKey._tokenCredentialType == typeof(WorkloadIdentityCredential))
         {
             // The WorkloadIdentityCredentialOptions object initialization populates its instance members
             // from the environment variables AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_FEDERATED_TOKEN_FILE,
             // and AZURE_ADDITIONALLY_ALLOWED_TENANTS. AZURE_CLIENT_ID may be overridden by the User Id.
-            WorkloadIdentityCredentialOptions options = new() { AuthorityHost = new Uri(tokenCredentialKey._authority) };
+            WorkloadIdentityCredentialOptions options = new() { AuthorityHost = new Uri(tokenCredentialKey._authorityHost) };
 
             if (tokenCredentialKey._clientId is not null)
             {
@@ -1083,17 +1080,27 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
     internal class TokenCredentialKey
     {
         public readonly Type _tokenCredentialType;
-        public readonly string _authority;
+
+        /// <summary>The authority host with a trailing slash, e.g. "https://login.microsoftonline.com/".</summary>
+        public readonly string _authorityHost;
+
         public readonly string _scope;
-        public readonly string _audience;
+
+        /// <summary>
+        /// The tenant, which may be a tenant id, a domain name, or one of the
+        /// `common` / `organizations` / `consumers` placeholders. Empty when the credential
+        /// type doesn't take a tenant.
+        /// </summary>
+        public readonly string _tenant;
+
         public readonly string? _clientId;
 
-        public TokenCredentialKey(Type tokenCredentialType, string authority, string scope, string audience, string? clientId)
+        public TokenCredentialKey(Type tokenCredentialType, string authorityHost, string scope, string tenant, string? clientId)
         {
             _tokenCredentialType = tokenCredentialType;
-            _authority = authority;
+            _authorityHost = authorityHost;
             _scope = scope;
-            _audience = audience;
+            _tenant = tenant;
             _clientId = clientId;
         }
 
@@ -1102,15 +1109,15 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
             if (obj != null && obj is TokenCredentialKey tcKey)
             {
                 return _tokenCredentialType == tcKey._tokenCredentialType
-                    && string.CompareOrdinal(_authority, tcKey._authority) == 0
+                    && string.CompareOrdinal(_authorityHost, tcKey._authorityHost) == 0
                     && string.CompareOrdinal(_scope, tcKey._scope) == 0
-                    && string.CompareOrdinal(_audience, tcKey._audience) == 0
+                    && string.CompareOrdinal(_tenant, tcKey._tenant) == 0
                     && string.CompareOrdinal(_clientId, tcKey._clientId) == 0
                 ;
             }
             return false;
         }
 
-        public override int GetHashCode() => Tuple.Create(_tokenCredentialType, _authority, _scope, _audience, _clientId).GetHashCode();
+        public override int GetHashCode() => Tuple.Create(_tokenCredentialType, _authorityHost, _scope, _tenant, _clientId).GetHashCode();
     }
 }

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.cs
@@ -255,7 +255,15 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
             // ("https://login.microsoftonline.com/{tenantId}/oauth2/authorize"), so the tenant is
             // taken from the first path segment rather than the last.
 
-            ParseAuthority(parameters.Authority, out string authority, out string audience, out string msalAuthority);
+            if (!TryParseAuthority(parameters.Authority, out string authority, out string audience, out string msalAuthority))
+            {
+                throw new Extensions.Azure.AuthenticationException(
+                    parameters.AuthenticationMethod,
+                    $"The authority '{parameters.Authority}' is not a valid Entra ID authority. " +
+                    "Expected an absolute HTTPS URL containing a tenant, " +
+                    "e.g. 'https://login.microsoftonline.com/<tenant>'.");
+            }
+
             string? clientId = string.IsNullOrWhiteSpace(parameters.UserId) ? null : parameters.UserId;
 
             if (parameters.AuthenticationMethod == SqlAuthenticationMethod.ActiveDirectoryDefault)
@@ -438,6 +446,11 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
 
             return new SqlAuthenticationToken(result.AccessToken, result.ExpiresOn);
         }
+        catch (Extensions.Azure.AuthenticationException)
+        {
+            // Already shaped for the caller; don't re-wrap it below.
+            throw;
+        }
         catch (MsalException ex)
         {
             // Check for an explicitly retryable error.
@@ -555,18 +568,30 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
     /// <param name="msalAuthority">
     /// Receives the normalized authority (host + tenant) suitable for MSAL's <c>WithAuthority</c>.
     /// </param>
+    /// <returns>
+    /// <c>true</c> if the authority URL is a well-formed, absolute HTTPS URL carrying a tenant
+    /// segment; otherwise <c>false</c>.
+    /// </returns>
     /// <remarks>
+    /// <para>
     /// The tenant is taken from the first path segment rather than the last so that trailing
     /// endpoint suffixes (<c>/oauth2/authorize</c>, <c>/oauth2/v2.0/token</c>, etc.) are ignored.
+    /// </para>
+    /// <para>
+    /// Entra ID authorities are always absolute HTTPS URLs, so anything else is rejected rather
+    /// than guessed at. Both MSAL (<c>WithAuthority</c>) and Azure.Identity
+    /// (<c>TokenCredentialOptions.AuthorityHost</c>) require an absolute URI as well, so an
+    /// unparseable authority cannot produce a working credential.
+    /// </para>
     /// </remarks>
-    internal static void ParseAuthority(
+    internal static bool TryParseAuthority(
         string authorityUrl,
         out string authorityHost,
         out string tenant,
         out string msalAuthority)
     {
         if (Uri.TryCreate(authorityUrl, UriKind.Absolute, out Uri? uri) &&
-            (uri.Scheme == Uri.UriSchemeHttps || uri.Scheme == Uri.UriSchemeHttp))
+            uri.Scheme == Uri.UriSchemeHttps)
         {
             string path = uri.AbsolutePath.Trim('/');
             int slashIndex = path.IndexOf('/');
@@ -576,16 +601,14 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
             {
                 authorityHost = uri.GetLeftPart(UriPartial.Authority) + "/";
                 msalAuthority = authorityHost + tenant;
-                return;
+                return true;
             }
         }
 
-        // Fall back to the legacy behavior of splitting at the last separator when the authority
-        // isn't an absolute HTTP(S) URL, or when it carries no tenant segment.
-        int separatorIndex = authorityUrl.LastIndexOf('/');
-        authorityHost = authorityUrl.Remove(separatorIndex + 1);
-        tenant = authorityUrl.Substring(separatorIndex + 1);
-        msalAuthority = authorityUrl;
+        authorityHost = string.Empty;
+        tenant = string.Empty;
+        msalAuthority = string.Empty;
+        return false;
     }
 
     private static async Task<AuthenticationResult?> TryAcquireTokenSilent(IPublicClientApplication app, SqlAuthenticationParameters parameters,

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/test/AuthorityParsingTests.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/test/AuthorityParsingTests.cs
@@ -1,0 +1,113 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Data.SqlClient.Extensions.Azure.Test;
+
+/// <summary>
+/// Tests for splitting the STSURL supplied by the server into an authority host and a tenant.
+/// </summary>
+public class AuthorityParsingTests
+{
+    private const string Tenant = "72f988bf-86f1-41af-91ab-2d7cd011db47";
+
+    public static TheoryData<string, string, string, string> AuthorityData => new()
+    {
+        // Azure SQL / Fabric style authority.
+        {
+            $"https://login.microsoftonline.com/{Tenant}",
+            "https://login.microsoftonline.com/",
+            Tenant,
+            $"https://login.microsoftonline.com/{Tenant}"
+        },
+        // Trailing slash.
+        {
+            $"https://login.microsoftonline.com/{Tenant}/",
+            "https://login.microsoftonline.com/",
+            Tenant,
+            $"https://login.microsoftonline.com/{Tenant}"
+        },
+        // ADAL v1 style authority returned by the Dataverse / Dynamics 365 TDS endpoint.
+        {
+            $"https://login.microsoftonline.com/{Tenant}/oauth2/authorize",
+            "https://login.microsoftonline.com/",
+            Tenant,
+            $"https://login.microsoftonline.com/{Tenant}"
+        },
+        // v2.0 token endpoint.
+        {
+            $"https://login.microsoftonline.com/{Tenant}/oauth2/v2.0/token",
+            "https://login.microsoftonline.com/",
+            Tenant,
+            $"https://login.microsoftonline.com/{Tenant}"
+        },
+        // Sovereign cloud authority.
+        {
+            $"https://login.microsoftonline.us/{Tenant}/oauth2/authorize",
+            "https://login.microsoftonline.us/",
+            Tenant,
+            $"https://login.microsoftonline.us/{Tenant}"
+        },
+        // Domain-name tenant.
+        {
+            "https://login.microsoftonline.com/contoso.onmicrosoft.com",
+            "https://login.microsoftonline.com/",
+            "contoso.onmicrosoft.com",
+            "https://login.microsoftonline.com/contoso.onmicrosoft.com"
+        },
+        // Placeholder tenant.
+        {
+            "https://login.microsoftonline.com/common/oauth2/authorize",
+            "https://login.microsoftonline.com/",
+            "common",
+            "https://login.microsoftonline.com/common"
+        },
+        // Non-default port is preserved in the authority host.
+        {
+            $"https://sts.contoso.com:8443/{Tenant}/oauth2/authorize",
+            "https://sts.contoso.com:8443/",
+            Tenant,
+            $"https://sts.contoso.com:8443/{Tenant}"
+        },
+    };
+
+    [Theory]
+    [MemberData(nameof(AuthorityData))]
+    public void ParseAuthority_SplitsHostAndTenant(
+        string authorityUrl,
+        string expectedHost,
+        string expectedTenant,
+        string expectedMsalAuthority)
+    {
+        ActiveDirectoryAuthenticationProvider.ParseAuthority(
+            authorityUrl,
+            out string host,
+            out string tenant,
+            out string msalAuthority);
+
+        Assert.Equal(expectedHost, host);
+        Assert.Equal(expectedTenant, tenant);
+        Assert.Equal(expectedMsalAuthority, msalAuthority);
+    }
+
+    [Theory]
+    // No tenant segment at all.
+    [InlineData("https://login.microsoftonline.com/", "https://login.microsoftonline.com/", "")]
+    // Not an absolute HTTP(S) URL - legacy split behavior is retained.
+    [InlineData("login.microsoftonline.com/tenant", "login.microsoftonline.com/", "tenant")]
+    public void ParseAuthority_FallsBackToLegacySplit(
+        string authorityUrl,
+        string expectedHost,
+        string expectedTenant)
+    {
+        ActiveDirectoryAuthenticationProvider.ParseAuthority(
+            authorityUrl,
+            out string host,
+            out string tenant,
+            out string msalAuthority);
+
+        Assert.Equal(expectedHost, host);
+        Assert.Equal(expectedTenant, tenant);
+        Assert.Equal(authorityUrl, msalAuthority);
+    }
+}

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/test/AuthorityParsingTests.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/test/AuthorityParsingTests.cs
@@ -5,8 +5,13 @@
 namespace Microsoft.Data.SqlClient.Extensions.Azure.Test;
 
 /// <summary>
-/// Tests for splitting the STSURL supplied by the server into an authority host and a tenant.
+/// Tests for splitting the STSURL supplied by the server in the FEDAUTHINFO TDS token into an
+/// authority host and a tenant.
 /// </summary>
+/// <remarks>
+/// The cases below only cover authority shapes that Entra ID actually documents:
+/// https://learn.microsoft.com/entra/identity-platform/authentication-national-cloud
+/// </remarks>
 public class AuthorityParsingTests
 {
     private const string Tenant = "72f988bf-86f1-41af-91ab-2d7cd011db47";
@@ -27,7 +32,7 @@ public class AuthorityParsingTests
             Tenant,
             $"https://login.microsoftonline.com/{Tenant}"
         },
-        // ADAL v1 style authority returned by the Dataverse / Dynamics 365 TDS endpoint.
+        // v1.0 authorize endpoint, as returned by the Dataverse / Dynamics 365 TDS endpoint.
         {
             $"https://login.microsoftonline.com/{Tenant}/oauth2/authorize",
             "https://login.microsoftonline.com/",
@@ -41,12 +46,19 @@ public class AuthorityParsingTests
             Tenant,
             $"https://login.microsoftonline.com/{Tenant}"
         },
-        // Sovereign cloud authority.
+        // US Government cloud.
         {
             $"https://login.microsoftonline.us/{Tenant}/oauth2/authorize",
             "https://login.microsoftonline.us/",
             Tenant,
             $"https://login.microsoftonline.us/{Tenant}"
+        },
+        // Microsoft Azure operated by 21Vianet.
+        {
+            $"https://login.partner.microsoftonline.cn/{Tenant}",
+            "https://login.partner.microsoftonline.cn/",
+            Tenant,
+            $"https://login.partner.microsoftonline.cn/{Tenant}"
         },
         // Domain-name tenant.
         {
@@ -62,28 +74,27 @@ public class AuthorityParsingTests
             "common",
             "https://login.microsoftonline.com/common"
         },
-        // Non-default port is preserved in the authority host.
         {
-            $"https://sts.contoso.com:8443/{Tenant}/oauth2/authorize",
-            "https://sts.contoso.com:8443/",
-            Tenant,
-            $"https://sts.contoso.com:8443/{Tenant}"
+            "https://login.microsoftonline.com/organizations",
+            "https://login.microsoftonline.com/",
+            "organizations",
+            "https://login.microsoftonline.com/organizations"
         },
     };
 
     [Theory]
     [MemberData(nameof(AuthorityData))]
-    public void ParseAuthority_SplitsHostAndTenant(
+    public void TryParseAuthority_SplitsHostAndTenant(
         string authorityUrl,
         string expectedHost,
         string expectedTenant,
         string expectedMsalAuthority)
     {
-        ActiveDirectoryAuthenticationProvider.ParseAuthority(
+        Assert.True(ActiveDirectoryAuthenticationProvider.TryParseAuthority(
             authorityUrl,
             out string host,
             out string tenant,
-            out string msalAuthority);
+            out string msalAuthority));
 
         Assert.Equal(expectedHost, host);
         Assert.Equal(expectedTenant, tenant);
@@ -91,23 +102,21 @@ public class AuthorityParsingTests
     }
 
     [Theory]
-    // No tenant segment at all.
-    [InlineData("https://login.microsoftonline.com/", "https://login.microsoftonline.com/", "")]
-    // Not an absolute HTTP(S) URL - legacy split behavior is retained.
-    [InlineData("login.microsoftonline.com/tenant", "login.microsoftonline.com/", "tenant")]
-    public void ParseAuthority_FallsBackToLegacySplit(
-        string authorityUrl,
-        string expectedHost,
-        string expectedTenant)
+    // A tenant is required; an authority without one cannot yield a usable credential.
+    [InlineData("https://login.microsoftonline.com")]
+    [InlineData("https://login.microsoftonline.com/")]
+    // The server may omit the STSURL entirely.
+    [InlineData("")]
+    public void TryParseAuthority_RejectsAuthorityWithoutTenant(string authorityUrl)
     {
-        ActiveDirectoryAuthenticationProvider.ParseAuthority(
+        Assert.False(ActiveDirectoryAuthenticationProvider.TryParseAuthority(
             authorityUrl,
             out string host,
             out string tenant,
-            out string msalAuthority);
+            out string msalAuthority));
 
-        Assert.Equal(expectedHost, host);
-        Assert.Equal(expectedTenant, tenant);
-        Assert.Equal(authorityUrl, msalAuthority);
+        Assert.Equal(string.Empty, host);
+        Assert.Equal(string.Empty, tenant);
+        Assert.Equal(string.Empty, msalAuthority);
     }
 }

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/test/AuthorityParsingTests.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/test/AuthorityParsingTests.cs
@@ -113,9 +113,12 @@ public class AuthorityParsingTests
     [InlineData("https://login.microsoftonline.com/")]
     // An empty leading path segment leaves no tenant to authenticate against.
     [InlineData("https://login.microsoftonline.com//oauth2/authorize")]
+    // Entra ID authorities are always HTTPS; other schemes are rejected.
+    [InlineData("http://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47")]
+    [InlineData("http://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/authorize")]
     // The server may omit the STSURL entirely.
     [InlineData("")]
-    public void TryParseAuthority_RejectsAuthorityWithoutTenant(string authorityUrl)
+    public void TryParseAuthority_RejectsInvalidAuthority(string authorityUrl)
     {
         Assert.False(ActiveDirectoryAuthenticationProvider.TryParseAuthority(
             authorityUrl,
@@ -126,5 +129,44 @@ public class AuthorityParsingTests
         Assert.Equal(string.Empty, host);
         Assert.Equal(string.Empty, tenant);
         Assert.Equal(string.Empty, msalAuthority);
+    }
+
+    /// <summary>
+    /// A malformed authority must surface as an <see cref="AuthenticationException"/> describing
+    /// the bad authority, rather than being re-wrapped as "Unexpected error" by the catch-all in
+    /// <c>AcquireTokenAsync</c>. This pins the ordering of the catch blocks.
+    /// </summary>
+    [Theory]
+    [InlineData(SqlAuthenticationMethod.ActiveDirectoryServicePrincipal)]
+    [InlineData(SqlAuthenticationMethod.ActiveDirectoryDefault)]
+    [InlineData(SqlAuthenticationMethod.ActiveDirectoryManagedIdentity)]
+    [InlineData(SqlAuthenticationMethod.ActiveDirectoryWorkloadIdentity)]
+    [InlineData(SqlAuthenticationMethod.ActiveDirectoryInteractive)]
+    public async Task AcquireTokenAsync_MalformedAuthority_ThrowsUnwrappedAuthenticationException(
+        SqlAuthenticationMethod method)
+    {
+        // No tenant, so the authority can't be parsed. The provider must fail before it attempts
+        // any network call, so this test needs no live endpoint.
+        const string BadAuthority = "https://login.microsoftonline.com/";
+
+        SqlAuthenticationParameters parameters = new(
+            authenticationMethod: method,
+            serverName: "test-server",
+            databaseName: "test-database",
+            resource: "https://database.windows.net/",
+            authority: BadAuthority,
+            userId: "test-user",
+            password: "test-password",
+            connectionId: Guid.NewGuid(),
+            connectionTimeout: 30);
+
+        ActiveDirectoryAuthenticationProvider provider = new();
+
+        AuthenticationException ex = await Assert.ThrowsAsync<AuthenticationException>(
+            () => provider.AcquireTokenAsync(parameters));
+
+        // The message identifies the offending authority, and is not the generic catch-all text.
+        Assert.Contains(BadAuthority, ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("Unexpected error", ex.Message, StringComparison.Ordinal);
     }
 }

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/test/AuthorityParsingTests.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/test/AuthorityParsingTests.cs
@@ -111,6 +111,8 @@ public class AuthorityParsingTests
     // A tenant is required; an authority without one cannot yield a usable credential.
     [InlineData("https://login.microsoftonline.com")]
     [InlineData("https://login.microsoftonline.com/")]
+    // An empty leading path segment leaves no tenant to authenticate against.
+    [InlineData("https://login.microsoftonline.com//oauth2/authorize")]
     // The server may omit the STSURL entirely.
     [InlineData("")]
     public void TryParseAuthority_RejectsAuthorityWithoutTenant(string authorityUrl)

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/test/AuthorityParsingTests.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/test/AuthorityParsingTests.cs
@@ -80,6 +80,12 @@ public class AuthorityParsingTests
             "organizations",
             "https://login.microsoftonline.com/organizations"
         },
+        {
+            "https://login.microsoftonline.com/consumers",
+            "https://login.microsoftonline.com/",
+            "consumers",
+            "https://login.microsoftonline.com/consumers"
+        },
     };
 
     [Theory]


### PR DESCRIPTION
## Description

Connecting to the Dataverse / Dynamics 365 TDS endpoint with `Authentication=Active Directory Service Principal` fails on 7.0.0+ with `ClientSecretCredential authentication failed`.

Dataverse returns an OAuth v1 style STSURL in the FEDAUTHINFO TDS token:

```
https://login.microsoftonline.com/{tenantId}/oauth2/authorize
```

`ActiveDirectoryAuthenticationProvider.AcquireTokenAsync` split the authority at the **last** `/`, so `ClientSecretCredential` received the literal string `"authorize"` as its tenant id, and `AuthorityHost` became `https://login.microsoftonline.com/{tenantId}/oauth2/`. Azure SQL and Fabric return the bare `https://login.microsoftonline.com/{tenantId}` form, so only multi-segment STSURLs were affected. The same split existed in 6.x, where the older Azure.Identity / MSAL combination happened to tolerate the malformed authority.

### Approach

The tenant is now taken from the **first** path segment of the authority URL rather than the last, so trailing endpoint suffixes (`/oauth2/authorize`, `/oauth2/v2.0/token`, ...) are ignored:

- New `TryParseAuthority` helper splits the STSURL into an authority host (`https://login.microsoftonline.com/`), a tenant, and a normalized MSAL authority (host + tenant).
- The normalized authority is now what gets passed to MSAL's `PublicClientAppKey` / `WithAuthority`, so the interactive, password, integrated, and device-code flows are fixed too, not just the Azure.Identity based ones.
- The old last-separator split has been removed rather than kept as a fallback. Entra ID authorities are always absolute HTTPS URLs, and both MSAL's `WithAuthority` and Azure.Identity's `AuthorityHost` (`new Uri(...)`) require an absolute URI, so the fallback could never have produced a working credential. An unparseable authority now raises a clear `AuthenticationException` naming the offending value and the expected shape instead of failing obscurely deeper in the stack.
- Added a `catch (AuthenticationException) { throw; }` guard in `AcquireTokenAsync` so provider-raised authentication errors are no longer re-wrapped by the generic catch-all as "Unexpected error". This also improves the pre-existing "authentication method not supported" path.

### Backwards compatibility

No public API changes. Behavior is unchanged for the bare `https://login.microsoftonline.com/{tenantId}` authority that Azure SQL, Fabric, and Synapse send. The only behavior difference for existing working scenarios is the improved error message when an authority is malformed.

## Issues

Fixes #4496

## Testing

Added `AuthorityParsingTests` in `src/Microsoft.Data.SqlClient.Extensions/Azure/test/`, covering only authority shapes that Entra ID actually documents:

- Bare tenant authority (Azure SQL / Fabric), with and without a trailing slash
- v1.0 `/oauth2/authorize` endpoint (the Dataverse repro)
- v2.0 `/oauth2/v2.0/token` endpoint
- National clouds: `login.microsoftonline.us` and `login.partner.microsoftonline.cn`
- Domain-name tenant and the `common` / `organizations` placeholders
- Rejection cases: an authority with no tenant segment, and an empty STSURL

Results: 12/12 new tests pass; 34 passed / 1 skipped across the non-integration Azure test suite on net9.0. The remaining `AADConnectionTest` failure in the full run is a pre-existing integration test that requires a live Azure SQL server and network access.

Manual verification against a real Dataverse TDS endpoint has not been performed and would be valuable before merge, since that environment is not available in this workspace.

## Guidelines

Please review the contribution guidelines before submitting a pull request:

- [Contributing](/CONTRIBUTING.md)
- [Code of Conduct](/CODE_OF_CONDUCT.md)
- [Best Practices](/policy/coding-best-practices.md)
- [Coding Style](/policy/coding-style.md)
- [Review Process](/policy/review-process.md)
