### PR TITLE
Enhance VSM/HGS enclave session key binding validation

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
@@ -343,40 +343,84 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        // Verifies that the enclave's public key is bound to the signed report. A genuine VBS enclave places
-        // SHA-256(public key) in the first 32 bytes of the report's EnclaveData, which the report signature covers.
-        // Confirming this match ensures the key used to derive the session secret is the one committed to by the
-        // attested report. Mirrors the aas-ehd key binding on the AAS path.
+        /// <summary>
+        /// Verifies that the enclave's Diffie-Hellman public key is the one committed to by the signed
+        /// attestation report. A genuine VBS enclave writes SHA-256(public key) into the first 32 bytes of the
+        /// report's EnclaveData, and that EnclaveData is covered by the report signature that
+        /// <see cref="VerifyAttestationInfo"/> has already validated. Confirming this binding ensures the key used
+        /// to derive the session secret is the exact key the attested enclave committed to. This mirrors the
+        /// aas-ehd key binding performed on the AAS attestation path.
+        /// </summary>
+        /// <param name="enclaveReportPackage">
+        /// The signature-verified enclave report package. Its <c>Report.EnclaveData</c> supplies the committed
+        /// key hash.
+        /// </param>
+        /// <param name="enclavePublicKey">
+        /// The enclave public key that will be used to derive the session secret.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the report's EnclaveData does not match SHA-256 of <paramref name="enclavePublicKey"/>, or
+        /// when the required report or key data is missing. In either case attestation is rejected.
+        /// </exception>
         private void VerifyEnclavePublicKeyBinding(EnclaveReportPackage enclaveReportPackage, EnclavePublicKey enclavePublicKey)
         {
-            const int reportDataLength = 32; // SHA-256 digest length
+            const int ReportDataLength = 32; // SHA-256 digest length
 
-            // The first 32 bytes of EnclaveData must equal SHA-256 of the key we will use to derive the session secret.
-            byte[] reportData = enclaveReportPackage.Report.EnclaveData;
+            // The first 32 bytes of EnclaveData must equal SHA-256 of the key we will use to derive the session
+            // secret. Read both inputs defensively so missing data results in a clean rejection rather than a
+            // NullReferenceException (SHA256 hashing also throws on a null input).
+            byte[] reportData = enclaveReportPackage?.Report?.EnclaveData;
+            byte[] publicKey = enclavePublicKey?.PublicKey;
+
+            if (reportData == null || reportData.Length < ReportDataLength || publicKey == null)
+            {
+                throw new ArgumentException(Strings.VerifyEnclaveKeyBindingFailed);
+            }
+
+#if NET
+            // Hash directly into a stack buffer to avoid a heap allocation for the digest.
+            Span<byte> expectedBinding = stackalloc byte[ReportDataLength];
+            SHA256.HashData(publicKey, expectedBinding);
+
+            // Use a fixed-time comparison in this security-sensitive path so the check does not leak a timing
+            // signal about how many leading bytes matched.
+            bool bound = CryptographicOperations.FixedTimeEquals(
+                reportData.AsSpan(0, ReportDataLength), expectedBinding);
+#else
             byte[] expectedBinding;
             using (SHA256 sha256 = SHA256.Create())
             {
-                expectedBinding = sha256.ComputeHash(enclavePublicKey.PublicKey);
+                expectedBinding = sha256.ComputeHash(publicKey);
             }
 
-            bool bound = reportData != null && reportData.Length >= reportDataLength;
-            if (bound)
-            {
-                for (int index = 0; index < reportDataLength; index++)
-                {
-                    if (reportData[index] != expectedBinding[index])
-                    {
-                        bound = false;
-                        break;
-                    }
-                }
-            }
+            bool bound = FixedTimeEquals(reportData, expectedBinding, ReportDataLength);
+#endif
 
             if (!bound)
             {
                 throw new ArgumentException(Strings.VerifyEnclaveKeyBindingFailed);
             }
         }
+
+#if !NET
+        // CryptographicOperations.FixedTimeEquals is unavailable on .NET Framework, so hand-roll an equivalent
+        // constant-time comparison of the first <paramref name="length"/> bytes for the key-binding check above.
+        private static bool FixedTimeEquals(byte[] left, byte[] right, int length)
+        {
+            if (left == null || right == null || left.Length < length || right.Length < length)
+            {
+                return false;
+            }
+
+            int accumulator = 0;
+            for (int index = 0; index < length; index++)
+            {
+                accumulator |= left[index] ^ right[index];
+            }
+
+            return accumulator == 0;
+        }
+#endif
 
         // Verifies the enclave policy matches expected policy.
         private void VerifyEnclavePolicy(EnclaveReportPackage enclaveReportPackage)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
@@ -153,6 +153,68 @@ namespace Microsoft.Data.SqlClient
 
         #region Private helpers
 
+        /// <summary>
+        /// Verifies that the enclave's Diffie-Hellman public key is the one committed to by the signed
+        /// attestation report. A genuine VBS enclave writes SHA-256(public key) into the first 32 bytes of the
+        /// report's EnclaveData, and that EnclaveData is covered by the report signature that
+        /// <see cref="VerifyAttestationInfo"/> has already validated. Confirming this binding ensures the key used
+        /// to derive the session secret is the exact key the attested enclave committed to. This mirrors the
+        /// aas-ehd key binding performed on the AAS attestation path.
+        /// </summary>
+        /// <param name="enclaveReportPackage">
+        /// The signature-verified enclave report package. Its <c>Report.EnclaveData</c> supplies the committed
+        /// key hash.
+        /// </param>
+        /// <param name="enclavePublicKey">
+        /// The enclave public key that will be used to derive the session secret.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the report's EnclaveData does not match SHA-256 of <paramref name="enclavePublicKey"/>, or
+        /// when the required report or key data is missing. In either case attestation is rejected.
+        /// </exception>
+        /// <remarks>
+        /// This is internal to allow for targeted unit testing without resorting to reflection.
+        /// </remarks>
+        internal static void VerifyEnclavePublicKeyBinding(EnclaveReportPackage enclaveReportPackage, EnclavePublicKey enclavePublicKey)
+        {
+            const int ReportDataLength = 32; // SHA-256 digest length
+
+            // The first 32 bytes of EnclaveData must equal SHA-256 of the key we will use to derive the session
+            // secret. Read both inputs defensively so missing data results in a clean rejection rather than a
+            // NullReferenceException (SHA256 hashing also throws on a null input).
+            byte[] reportData = enclaveReportPackage?.Report?.EnclaveData;
+            byte[] publicKey = enclavePublicKey?.PublicKey;
+
+            if (reportData == null || reportData.Length < ReportDataLength || publicKey == null || publicKey.Length == 0)
+            {
+                throw new ArgumentException(Strings.VerifyEnclaveKeyBindingFailed);
+            }
+
+#if NET
+            // Hash directly into a stack buffer to avoid a heap allocation for the digest.
+            Span<byte> expectedBinding = stackalloc byte[ReportDataLength];
+            SHA256.HashData(publicKey, expectedBinding);
+
+            // Use a fixed-time comparison in this security-sensitive path so the check does not leak a timing
+            // signal about how many leading bytes matched.
+            bool bound = CryptographicOperations.FixedTimeEquals(
+                reportData.AsSpan(0, ReportDataLength), expectedBinding);
+#else
+            byte[] expectedBinding;
+            using (SHA256 sha256 = SHA256.Create())
+            {
+                expectedBinding = sha256.ComputeHash(publicKey);
+            }
+
+            bool bound = FixedTimeEquals(reportData, expectedBinding, ReportDataLength);
+#endif
+
+            if (!bound)
+            {
+                throw new ArgumentException(Strings.VerifyEnclaveKeyBindingFailed);
+            }
+        }
+
         // Performs Attestation per the protocol used by Virtual Secure Modules.
         private void VerifyAttestationInfo(string attestationUrl, HealthReport healthReport, EnclaveReportPackage enclaveReportPackage)
         {
@@ -244,7 +306,7 @@ namespace Microsoft.Data.SqlClient
         /// <summary>
         /// Verifies that a chain of trust can be built from the health report provided
         /// by SQL Server and the attestation service's root signing certificate(s).
-        /// 
+        ///
         /// If the method returns false, the value of chainStatus doesn't matter. The chain could not be validated.
         /// </summary>
         /// <param name="signingCerts"></param>
@@ -340,65 +402,6 @@ namespace Microsoft.Data.SqlClient
                 {
                     throw new ArgumentException(Strings.VerifyEnclaveReportFailed);
                 }
-            }
-        }
-
-        /// <summary>
-        /// Verifies that the enclave's Diffie-Hellman public key is the one committed to by the signed
-        /// attestation report. A genuine VBS enclave writes SHA-256(public key) into the first 32 bytes of the
-        /// report's EnclaveData, and that EnclaveData is covered by the report signature that
-        /// <see cref="VerifyAttestationInfo"/> has already validated. Confirming this binding ensures the key used
-        /// to derive the session secret is the exact key the attested enclave committed to. This mirrors the
-        /// aas-ehd key binding performed on the AAS attestation path.
-        /// </summary>
-        /// <param name="enclaveReportPackage">
-        /// The signature-verified enclave report package. Its <c>Report.EnclaveData</c> supplies the committed
-        /// key hash.
-        /// </param>
-        /// <param name="enclavePublicKey">
-        /// The enclave public key that will be used to derive the session secret.
-        /// </param>
-        /// <exception cref="ArgumentException">
-        /// Thrown when the report's EnclaveData does not match SHA-256 of <paramref name="enclavePublicKey"/>, or
-        /// when the required report or key data is missing. In either case attestation is rejected.
-        /// </exception>
-        private void VerifyEnclavePublicKeyBinding(EnclaveReportPackage enclaveReportPackage, EnclavePublicKey enclavePublicKey)
-        {
-            const int ReportDataLength = 32; // SHA-256 digest length
-
-            // The first 32 bytes of EnclaveData must equal SHA-256 of the key we will use to derive the session
-            // secret. Read both inputs defensively so missing data results in a clean rejection rather than a
-            // NullReferenceException (SHA256 hashing also throws on a null input).
-            byte[] reportData = enclaveReportPackage?.Report?.EnclaveData;
-            byte[] publicKey = enclavePublicKey?.PublicKey;
-
-            if (reportData == null || reportData.Length < ReportDataLength || publicKey == null || publicKey.Length == 0)
-            {
-                throw new ArgumentException(Strings.VerifyEnclaveKeyBindingFailed);
-            }
-
-#if NET
-            // Hash directly into a stack buffer to avoid a heap allocation for the digest.
-            Span<byte> expectedBinding = stackalloc byte[ReportDataLength];
-            SHA256.HashData(publicKey, expectedBinding);
-
-            // Use a fixed-time comparison in this security-sensitive path so the check does not leak a timing
-            // signal about how many leading bytes matched.
-            bool bound = CryptographicOperations.FixedTimeEquals(
-                reportData.AsSpan(0, ReportDataLength), expectedBinding);
-#else
-            byte[] expectedBinding;
-            using (SHA256 sha256 = SHA256.Create())
-            {
-                expectedBinding = sha256.ComputeHash(publicKey);
-            }
-
-            bool bound = FixedTimeEquals(reportData, expectedBinding, ReportDataLength);
-#endif
-
-            if (!bound)
-            {
-                throw new ArgumentException(Strings.VerifyEnclaveKeyBindingFailed);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
@@ -122,6 +122,9 @@ namespace Microsoft.Data.SqlClient
                         // Perform Attestation per VSM protocol
                         VerifyAttestationInfo(enclaveSessionParameters.AttestationUrl, info.HealthReport, info.EnclaveReportPackage);
 
+                        // Verify the enclave public key is bound to the signed report, before it is used for key exchange
+                        VerifyEnclavePublicKeyBinding(info.EnclaveReportPackage, info.Identity);
+
                         // Set up shared secret and validate signature
                         byte[] sharedSecret = GetSharedSecret(info.Identity, info.EnclaveDHInfo, clientDHKey);
 
@@ -337,6 +340,41 @@ namespace Microsoft.Data.SqlClient
                 {
                     throw new ArgumentException(Strings.VerifyEnclaveReportFailed);
                 }
+            }
+        }
+
+        // Verifies that the enclave's public key is bound to the signed report. A genuine VBS enclave places
+        // SHA-256(public key) in the first 32 bytes of the report's EnclaveData, which the report signature covers.
+        // Confirming this match ensures the key used to derive the session secret is the one committed to by the
+        // attested report. Mirrors the aas-ehd key binding on the AAS path.
+        private void VerifyEnclavePublicKeyBinding(EnclaveReportPackage enclaveReportPackage, EnclavePublicKey enclavePublicKey)
+        {
+            const int reportDataLength = 32; // SHA-256 digest length
+
+            // The first 32 bytes of EnclaveData must equal SHA-256 of the key we will use to derive the session secret.
+            byte[] reportData = enclaveReportPackage.Report.EnclaveData;
+            byte[] expectedBinding;
+            using (SHA256 sha256 = SHA256.Create())
+            {
+                expectedBinding = sha256.ComputeHash(enclavePublicKey.PublicKey);
+            }
+
+            bool bound = reportData != null && reportData.Length >= reportDataLength;
+            if (bound)
+            {
+                for (int index = 0; index < reportDataLength; index++)
+                {
+                    if (reportData[index] != expectedBinding[index])
+                    {
+                        bound = false;
+                        break;
+                    }
+                }
+            }
+
+            if (!bound)
+            {
+                throw new ArgumentException(Strings.VerifyEnclaveKeyBindingFailed);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
@@ -372,7 +372,7 @@ namespace Microsoft.Data.SqlClient
             byte[] reportData = enclaveReportPackage?.Report?.EnclaveData;
             byte[] publicKey = enclavePublicKey?.PublicKey;
 
-            if (reportData == null || reportData.Length < ReportDataLength || publicKey == null)
+            if (reportData == null || reportData.Length < ReportDataLength || publicKey == null || publicKey.Length == 0)
             {
                 throw new ArgumentException(Strings.VerifyEnclaveKeyBindingFailed);
             }

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
@@ -6343,6 +6343,15 @@ namespace System {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enclave attestation failed because the signed enclave report did not bind to the enclave public key used to establish the session. The enclave public key must match the value committed to by the signed report - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details. If correct, contact Customer Support Services..
+        /// </summary>
+        internal static string VerifyEnclaveKeyBindingFailed {
+            get {
+                return ResourceManager.GetString("VerifyEnclaveKeyBindingFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The enclave report received from SQL Server is not in the correct format. Contact Customer Support Services..
         /// </summary>
         internal static string VerifyEnclaveReportFormatFailed {

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
@@ -1968,6 +1968,9 @@
   <data name="VerifyEnclaveReportFailed" xml:space="preserve">
     <value>Signature verification of the enclave report failed. The report signature does not match the signature computed using the HGS root certificate. Verify the DNS mapping for the endpoint - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details. If correct, contact Customer Support Services.</value>
   </data>
+  <data name="VerifyEnclaveKeyBindingFailed" xml:space="preserve">
+    <value>Enclave attestation failed because the signed enclave report did not bind to the enclave public key used to establish the session. The enclave public key must match the value committed to by the signed report - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details. If correct, contact Customer Support Services.</value>
+  </data>
   <data name="VerifyEnclaveReportFormatFailed" xml:space="preserve">
     <value>The enclave report received from SQL Server is not in the correct format. Contact Customer Support Services.</value>
   </data>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderTest.cs
@@ -27,9 +27,11 @@ public class VirtualSecureModeEnclaveProviderTest
     [Fact]
     public void VerifyEnclavePublicKeyBinding_GenuineKey_Succeeds()
     {
+        // Arrange
         byte[] enclaveKey = Encoding.UTF8.GetBytes("genuine-enclave-public-key-blob");
         EnclaveReportPackage package = BuildReportPackage(Sha256(enclaveKey));
 
+        // Act / Assert
         // Report commits to enclaveKey and the session uses enclaveKey: the binding holds, so no exception.
         InvokeVerifyEnclavePublicKeyBinding(package, new EnclavePublicKey(enclaveKey));
     }
@@ -40,6 +42,7 @@ public class VirtualSecureModeEnclaveProviderTest
     [Fact]
     public void VerifyEnclavePublicKeyBinding_SwappedKey_Throws()
     {
+        // Arrange
         byte[] committedKey = Encoding.UTF8.GetBytes("committed-enclave-public-key-blob");
         // The signed report commits to committedKey...
         EnclaveReportPackage package = BuildReportPackage(Sha256(committedKey));
@@ -47,8 +50,11 @@ public class VirtualSecureModeEnclaveProviderTest
         // ...but a different enclave public key is offered for the session.
         byte[] substitutedKey = Encoding.UTF8.GetBytes("substituted-enclave-public-key");
 
-        ArgumentException ex = Assert.Throws<ArgumentException>(
-            () => InvokeVerifyEnclavePublicKeyBinding(package, new EnclavePublicKey(substitutedKey)));
+        // Act
+        Action action = () => InvokeVerifyEnclavePublicKeyBinding(package, new EnclavePublicKey(substitutedKey));
+
+        // Assert
+        ArgumentException ex = Assert.Throws<ArgumentException>(action);
         Assert.Equal(Strings.VerifyEnclaveKeyBindingFailed, ex.Message);
     }
 

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderTest.cs
@@ -3,10 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
-using Microsoft.Data.SqlClient;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.UnitTests;
@@ -29,11 +27,12 @@ public class VirtualSecureModeEnclaveProviderTest
     {
         // Arrange
         byte[] enclaveKey = Encoding.UTF8.GetBytes("genuine-enclave-public-key-blob");
-        EnclaveReportPackage package = BuildReportPackage(Sha256(enclaveKey));
+        EnclaveReportPackage testPackage = BuildReportPackage(Sha256(enclaveKey));
+        EnclavePublicKey testKey = new EnclavePublicKey(enclaveKey);
 
         // Act / Assert
         // Report commits to enclaveKey and the session uses enclaveKey: the binding holds, so no exception.
-        InvokeVerifyEnclavePublicKeyBinding(package, new EnclavePublicKey(enclaveKey));
+        VirtualizationBasedSecurityEnclaveProviderBase.VerifyEnclavePublicKeyBinding(testPackage, testKey);
     }
 
     /// <summary>
@@ -43,15 +42,20 @@ public class VirtualSecureModeEnclaveProviderTest
     public void VerifyEnclavePublicKeyBinding_SwappedKey_Throws()
     {
         // Arrange
-        byte[] committedKey = Encoding.UTF8.GetBytes("committed-enclave-public-key-blob");
+        byte[] committedKeyBytes = Encoding.UTF8.GetBytes("committed-enclave-public-key-blob");
+
         // The signed report commits to committedKey...
-        EnclaveReportPackage package = BuildReportPackage(Sha256(committedKey));
+        EnclaveReportPackage testPackage = BuildReportPackage(Sha256(committedKeyBytes));
 
         // ...but a different enclave public key is offered for the session.
-        byte[] substitutedKey = Encoding.UTF8.GetBytes("substituted-enclave-public-key");
+        byte[] substitutedKeyBytes = Encoding.UTF8.GetBytes("substituted-enclave-public-key");
+        EnclavePublicKey substitutedKey = new EnclavePublicKey(substitutedKeyBytes);
+
 
         // Act
-        Action action = () => InvokeVerifyEnclavePublicKeyBinding(package, new EnclavePublicKey(substitutedKey));
+        Action action = () => VirtualizationBasedSecurityEnclaveProviderBase.VerifyEnclavePublicKeyBinding(
+            testPackage,
+            substitutedKey);
 
         // Assert
         ArgumentException ex = Assert.Throws<ArgumentException>(action);
@@ -85,26 +89,6 @@ public class VirtualSecureModeEnclaveProviderTest
         Array.Copy(enclaveDataFirst32, 0, payload, offset, 32); // EnclaveData: first 32 bytes = SHA-256(public key)
 
         return new EnclaveReportPackage(payload);
-    }
-
-    // Invokes the private binding method via reflection, unwrapping the reflection exception so the
-    // caller sees the real ArgumentException.
-    private static void InvokeVerifyEnclavePublicKeyBinding(EnclaveReportPackage package, EnclavePublicKey enclavePublicKey)
-    {
-        MethodInfo method = typeof(VirtualizationBasedSecurityEnclaveProviderBase)
-            .GetMethod("VerifyEnclavePublicKeyBinding", BindingFlags.Instance | BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException("VerifyEnclavePublicKeyBinding not found");
-
-        var provider = new HostGuardianServiceEnclaveProvider();
-
-        try
-        {
-            method.Invoke(provider, new object[] { package, enclavePublicKey });
-        }
-        catch (TargetInvocationException ex) when (ex.InnerException != null)
-        {
-            throw ex.InnerException;
-        }
     }
 
     private static byte[] Sha256(byte[] data)

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderTest.cs
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Data.SqlClient;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests;
+
+/// <summary>
+/// Tests the enclave public key binding check on the VSM/HGS attestation path. A genuine VBS enclave
+/// commits to its public key by placing SHA-256(public key) in the first 32 bytes of the report's
+/// signature-covered EnclaveData, so the binding must accept a matching key and reject any other.
+/// </summary>
+public class VirtualSecureModeEnclaveProviderTest
+{
+    private const int EnclaveReportPackageHeaderSize = 6 * sizeof(uint); // 24
+    private const int EnclaveReportSize = (sizeof(uint) * 2) + 64 + 152;  // ReportSize + ReportVersion + EnclaveData + EnclaveIdentity = 224
+
+    /// <summary>
+    /// A report whose EnclaveData commits to the key used for the session passes the binding check.
+    /// </summary>
+    [Fact]
+    public void VerifyEnclavePublicKeyBinding_GenuineKey_Succeeds()
+    {
+        byte[] enclaveKey = Encoding.UTF8.GetBytes("genuine-enclave-public-key-blob");
+        EnclaveReportPackage package = BuildReportPackage(Sha256(enclaveKey));
+
+        // Report commits to enclaveKey and the session uses enclaveKey: the binding holds, so no exception.
+        InvokeVerifyEnclavePublicKeyBinding(package, new EnclavePublicKey(enclaveKey));
+    }
+
+    /// <summary>
+    /// A report whose committed data does not match the session's enclave public key is rejected.
+    /// </summary>
+    [Fact]
+    public void VerifyEnclavePublicKeyBinding_SwappedKey_Throws()
+    {
+        byte[] committedKey = Encoding.UTF8.GetBytes("committed-enclave-public-key-blob");
+        // The signed report commits to committedKey...
+        EnclaveReportPackage package = BuildReportPackage(Sha256(committedKey));
+
+        // ...but a different enclave public key is offered for the session.
+        byte[] substitutedKey = Encoding.UTF8.GetBytes("substituted-enclave-public-key");
+
+        ArgumentException ex = Assert.Throws<ArgumentException>(
+            () => InvokeVerifyEnclavePublicKeyBinding(package, new EnclavePublicKey(substitutedKey)));
+        Assert.Equal(Strings.VerifyEnclaveKeyBindingFailed, ex.Message);
+    }
+
+    // Builds a minimal EnclaveReportPackage whose report EnclaveData begins with the given 32-byte
+    // binding value. The signature is empty because this targets the binding, not the report signature.
+    private static EnclaveReportPackage BuildReportPackage(byte[] enclaveDataFirst32)
+    {
+        byte[] payload = new byte[EnclaveReportPackageHeaderSize + EnclaveReportSize];
+        int offset = 0;
+
+        void WriteUInt(uint value)
+        {
+            BitConverter.GetBytes(value).CopyTo(payload, offset);
+            offset += sizeof(uint);
+        }
+
+        // EnclaveReportPackageHeader
+        WriteUInt((uint)payload.Length);      // PackageSize
+        WriteUInt(1);                         // Version
+        WriteUInt(1);                         // SignatureScheme
+        WriteUInt(EnclaveReportSize);         // SignedStatementSize
+        WriteUInt(0);                         // SignatureSize
+        WriteUInt(0);                         // Reserved
+
+        // EnclaveReport
+        WriteUInt(EnclaveReportSize);         // ReportSize
+        WriteUInt(1);                         // ReportVersion
+        Array.Copy(enclaveDataFirst32, 0, payload, offset, 32); // EnclaveData: first 32 bytes = SHA-256(public key)
+
+        return new EnclaveReportPackage(payload);
+    }
+
+    // Invokes the private binding method via reflection, unwrapping the reflection exception so the
+    // caller sees the real ArgumentException.
+    private static void InvokeVerifyEnclavePublicKeyBinding(EnclaveReportPackage package, EnclavePublicKey enclavePublicKey)
+    {
+        MethodInfo method = typeof(VirtualizationBasedSecurityEnclaveProviderBase)
+            .GetMethod("VerifyEnclavePublicKeyBinding", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("VerifyEnclavePublicKeyBinding not found");
+
+        var provider = new HostGuardianServiceEnclaveProvider();
+
+        try
+        {
+            method.Invoke(provider, new object[] { package, enclavePublicKey });
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException != null)
+        {
+            throw ex.InnerException;
+        }
+    }
+
+    private static byte[] Sha256(byte[] data)
+    {
+        using SHA256 sha256 = SHA256.Create();
+        return sha256.ComputeHash(data);
+    }
+}


### PR DESCRIPTION
## Description
This change strengthens the Always Encrypted VSM/HGS enclave attestation flow by validating that the enclave public key used to establish the session is the same key committed to by the signed enclave report.
During enclave session setup, the provider now verifies that SHA-256(enclave public key) matches the value in the first 32 bytes of the report’s EnclaveData after attestation report verification and before deriving the shared secret. If the report data is missing, malformed, or does not match the session key, attestation is rejected with a dedicated error message.

## Changes
* Adds enclave public key binding validation to the VSM/HGS attestation path.
* Uses fixed-time comparison for the key binding check.
* Adds a .NET Framework-compatible fixed-time comparison helper.
* Adds a localized attestation failure message for key binding mismatches.
* Adds unit tests covering successful binding validation and rejection of a substituted enclave public key.

## Testing
* Added unit coverage in VirtualSecureModeEnclaveProviderTest for matching and mismatched enclave public key binding scenarios.