### PR TITLE
Cleanup | Remove dead code paths and Regexes from SqlConnectionOptions

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ConnectionString/DbConnectionString.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ConnectionString/DbConnectionString.netfx.cs
@@ -507,7 +507,7 @@ namespace Microsoft.Data.Common
                 int startPosition = nextStartPosition;
 
                 string keyname; // since parsing restrictions ignores values, it doesn't matter if we use ODBC rules or OLEDB rules
-                nextStartPosition = SqlConnectionOptions.GetKeyValuePair(restrictions, startPosition, buffer, false, out keyname, out _);
+                nextStartPosition = SqlConnectionOptions.GetKeyValuePair(restrictions, startPosition, buffer, out keyname, out _);
                 if (!string.IsNullOrEmpty(keyname))
                 {
 #if DEBUG

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -3986,7 +3986,6 @@ namespace Microsoft.Data.SqlClient.Connection
                         // Verify LocalHost for |DataDirectory| usage
                         SqlConnectionOptions.VerifyLocalHostAndFixup(
                             ref host,
-                            enforceLocalHost: true,
                             fixup: true);
                     }
                 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.Debug.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.Debug.cs
@@ -33,22 +33,6 @@ namespace Microsoft.Data.SqlClient
             + ")*"                                                     // repeat the key-value pair
             + "[\\s;]*[\u0000\\s]*";                                   // trailing whitespace/semicolons (DataSourceLocator), embedded nulls are allowed only in the end
         private static readonly Regex ConnectionStringRegex = new Regex(ConnectionStringPattern, RegexOptions.ExplicitCapture | RegexOptions.Compiled);
-
-        private const string ConnectionStringPatternOdbc =             // may not contain embedded null except trailing last value
-            "([\\s;]*"                                                 // leading whitespace and extra semicolons
-            + "(?![\\s;])"                                             // key does not start with space or semicolon
-            + "(?<key>([^=\\s\\p{Cc}]|\\s+[^=\\s\\p{Cc}])+)"           // allow any visible character for keyname except '='
-            + "\\s*=\\s*"                                              // the equal sign divides the key and value parts
-            + "(?<value>"
-            + "(\\{([^\\}\u0000]|\\}\\})*\\})"                         // quoted string, starts with { and ends with }
-            + "|"
-            + "((?![\\{\\s])"                                          // unquoted value must not start with { or space, would also like = but too late to change
-            + "([^;\\s\\p{Cc}]|\\s+[^;\\s\\p{Cc}])*"                   // control characters must be quoted
-            + ")"                                                      // although the spec does not allow {} embedded within a value, the retail code does.
-            + ")(\\s*)(;|[\u0000\\s]*$)"                               // whitespace after value up to semicolon or end-of-line
-            + ")*"                                                     // repeat the key-value pair
-            + "[\\s;]*[\u0000\\s]*";                                   // trailing whitespace/semicolons (DataSourceLocator), embedded nulls are allowed only in the end
-        private static readonly Regex ConnectionStringRegexOdbc = new Regex(ConnectionStringPatternOdbc, RegexOptions.ExplicitCapture | RegexOptions.Compiled);
         #endif
 
         [Conditional("DEBUG")]

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.Debug.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.Debug.cs
@@ -80,12 +80,11 @@ namespace Microsoft.Data.SqlClient
             Dictionary<string, string> parseTable,
             string connectionString,
             IReadOnlyDictionary<string, string> synonyms,
-            bool firstKey,
             Exception e)
         {
             try
             {
-                var parsedValues = SplitConnectionString(connectionString, synonyms, firstKey);
+                var parsedValues = SplitConnectionString(connectionString, synonyms, false);
                 foreach (var parsedValue in parsedValues)
                 {
                     string key = parsedValue.Key;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.Debug.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.Debug.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Data.SqlClient
         {
             try
             {
-                var parsedValues = SplitConnectionString(connectionString, synonyms, false);
+                var parsedValues = SplitConnectionString(connectionString, synonyms);
                 foreach (var parsedValue in parsedValues)
                 {
                     string key = parsedValue.Key;
@@ -139,11 +139,10 @@ namespace Microsoft.Data.SqlClient
         #if DEBUG
         private static Dictionary<string, string> SplitConnectionString(
             string connectionString,
-            IReadOnlyDictionary<string, string> synonyms,
-            bool firstKey)
+            IReadOnlyDictionary<string, string> synonyms)
         {
             var parseTable = new Dictionary<string, string>();
-            Regex parser = firstKey ? ConnectionStringRegexOdbc : ConnectionStringRegex;
+            Regex parser = ConnectionStringRegex;
 
             const int KeyIndex = 1, ValueIndex = 2;
             Debug.Assert(KeyIndex == parser.GroupNumberFromName("key"), "wrong key index");
@@ -161,23 +160,20 @@ namespace Microsoft.Data.SqlClient
                 CaptureCollection keyValues = match.Groups[ValueIndex].Captures;
                 foreach (Capture keypair in match.Groups[KeyIndex].Captures)
                 {
-                    string keyName = (firstKey ? keypair.Value : keypair.Value.Replace("==", "=")).ToLower(CultureInfo.InvariantCulture);
+                    string keyName = keypair.Value.Replace("==", "=").ToLower(CultureInfo.InvariantCulture);
                     string keyValue = keyValues[indexValue++].Value;
                     if (0 < keyValue.Length)
                     {
-                        if (!firstKey)
+                        switch (keyValue[0])
                         {
-                            switch (keyValue[0])
-                            {
-                                case '\"':
-                                    keyValue = keyValue.Substring(1, keyValue.Length - 2).Replace("\"\"", "\"");
-                                    break;
-                                case '\'':
-                                    keyValue = keyValue.Substring(1, keyValue.Length - 2).Replace("\'\'", "\'");
-                                    break;
-                                default:
-                                    break;
-                            }
+                            case '\"':
+                                keyValue = keyValue.Substring(1, keyValue.Length - 2).Replace("\"\"", "\"");
+                                break;
+                            case '\'':
+                                keyValue = keyValue.Substring(1, keyValue.Length - 2).Replace("\'\'", "\'");
+                                break;
+                            default:
+                                break;
                         }
                     }
                     else
@@ -195,10 +191,8 @@ namespace Microsoft.Data.SqlClient
                         throw ADP.KeywordNotSupported(keyName);
                     }
 
-                    if (!firstKey || !parseTable.ContainsKey(realKeyName))
-                    {
-                        parseTable[realKeyName] = keyValue; // last key-value pair wins (or first)
-                    }
+                    // Last key-value pair wins
+                    parseTable[realKeyName] = keyValue;
                 }
             }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.Debug.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.Debug.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Data.SqlClient
     internal sealed partial class SqlConnectionOptions
     {
         #if DEBUG
+        private const string ConnectionStringValidKeyPattern = "^(?![;\\s])[^\\p{Cc}]+(?<!\\s)$"; // key not allowed to start with semi-colon or space or contain non-visible characters or end with space
+        private const string ConnectionStringValidValuePattern = "^[^\u0000]*$";                    // value not allowed to contain embedded null
         private const string ConnectionStringPattern =                     // may not contain embedded null except trailing last value
             "([\\s;]*"                                                 // leading whitespace and extra semicolons
             + "(?![\\s;])"                                             // key does not start with space or semicolon
@@ -32,6 +34,9 @@ namespace Microsoft.Data.SqlClient
             + ")(\\s*)(;|[\u0000\\s]*$)"                               // whitespace after value up to semicolon or end-of-line
             + ")*"                                                     // repeat the key-value pair
             + "[\\s;]*[\u0000\\s]*";                                   // trailing whitespace/semicolons (DataSourceLocator), embedded nulls are allowed only in the end
+
+        private static readonly Regex s_connectionStringValidKeyRegex = new Regex(ConnectionStringValidKeyPattern, RegexOptions.Compiled);
+        private static readonly Regex s_connectionStringValidValueRegex = new Regex(ConnectionStringValidValuePattern, RegexOptions.Compiled);
         private static readonly Regex ConnectionStringRegex = new Regex(ConnectionStringPattern, RegexOptions.ExplicitCapture | RegexOptions.Compiled);
         #endif
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
@@ -31,13 +31,11 @@ namespace Microsoft.Data.SqlClient
         private const string ConnectionStringValidKeyPattern = "^(?![;\\s])[^\\p{Cc}]+(?<!\\s)$"; // key not allowed to start with semi-colon or space or contain non-visible characters or end with space
         private const string ConnectionStringValidValuePattern = "^[^\u0000]*$";                    // value not allowed to contain embedded null
         private const string ConnectionStringQuoteValuePattern = "^[^\"'=;\\s\\p{Cc}]*$";           // generally do not quote the value if it matches the pattern
-        private const string ConnectionStringQuoteOdbcValuePattern = "^\\{([^\\}\u0000]|\\}\\})*\\}$"; // do not quote odbc value if it matches this pattern
         internal const string DataDirectory = "|datadirectory|";
 
         private static readonly Regex s_connectionStringValidKeyRegex = new Regex(ConnectionStringValidKeyPattern, RegexOptions.Compiled);
         private static readonly Regex s_connectionStringValidValueRegex = new Regex(ConnectionStringValidValuePattern, RegexOptions.Compiled);
         private static readonly Regex s_connectionStringQuoteValueRegex = new Regex(ConnectionStringQuoteValuePattern, RegexOptions.Compiled);
-        private static readonly Regex s_connectionStringQuoteOdbcValueRegex = new Regex(ConnectionStringQuoteOdbcValuePattern, RegexOptions.ExplicitCapture | RegexOptions.Compiled);
 
         internal readonly bool _hasPasswordKeyword;
         internal readonly bool _hasUserIdKeyword;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
@@ -1227,8 +1227,6 @@ namespace Microsoft.Data.SqlClient
             DoubleQuoteValueQuote,
             SingleQuoteValue,
             SingleQuoteValueQuote,
-            BraceQuoteValue,
-            BraceQuoteValueQuote,
             QuotedValueEnd,
             NullTermination,
         };
@@ -1343,20 +1341,6 @@ namespace Microsoft.Data.SqlClient
                         parserState = ParserState.QuotedValueEnd;
                         goto case ParserState.QuotedValueEnd;
 
-                    case ParserState.BraceQuoteValue: // "(\\{([^\\}\\u0000]|\\}\\})*\\})"
-                        if ('}' == currentChar)
-                        { parserState = ParserState.BraceQuoteValueQuote; break; }
-                        if ('\0' == currentChar)
-                        { throw ADP.ConnectionStringSyntax(startposition); }
-                        break;
-
-                    case ParserState.BraceQuoteValueQuote:
-                        if ('}' == currentChar)
-                        { parserState = ParserState.BraceQuoteValue; break; }
-                        keyvalue = GetKeyValue(buffer, false);
-                        parserState = ParserState.QuotedValueEnd;
-                        goto case ParserState.QuotedValueEnd;
-
                     case ParserState.QuotedValueEnd:
                         if (char.IsWhiteSpace(currentChar))
                         { continue; }
@@ -1384,7 +1368,6 @@ namespace Microsoft.Data.SqlClient
                 case ParserState.Key:
                 case ParserState.DoubleQuoteValue:
                 case ParserState.SingleQuoteValue:
-                case ParserState.BraceQuoteValue:
                     // keyword not found/unbalanced double/single quote
                     throw ADP.ConnectionStringSyntax(startposition);
 
@@ -1408,7 +1391,6 @@ namespace Microsoft.Data.SqlClient
 
                 case ParserState.DoubleQuoteValueQuote:
                 case ParserState.SingleQuoteValueQuote:
-                case ParserState.BraceQuoteValueQuote:
                 case ParserState.QuotedValueEnd:
                     // quoted value at end of line
                     keyvalue = GetKeyValue(buffer, false);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
@@ -435,7 +435,7 @@ namespace Microsoft.Data.SqlClient
                     string protocol = _networkLibrary;
                     TdsParserStaticMethods.AliasRegistryLookup(ref host, ref protocol);
 #endif
-                    VerifyLocalHostAndFixup(ref host, true, false /*don't fix-up*/);
+                    VerifyLocalHostAndFixup(ref host, fixup: false);
                 }
             }
             else if (0 <= _attachDBFileName.IndexOf('|'))
@@ -765,7 +765,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        internal static void VerifyLocalHostAndFixup(ref string host, bool enforceLocalHost, bool fixup)
+        internal static void VerifyLocalHostAndFixup(ref string host, bool fixup)
         {
             if (string.IsNullOrEmpty(host))
             {
@@ -784,10 +784,7 @@ namespace Microsoft.Data.SqlClient
                     int separatorPos = name.IndexOf('.'); // to compare just 'machine' part
                     if ((separatorPos <= 0) || !CompareHostName(ref host, name.Substring(0, separatorPos), fixup))
                     {
-                        if (enforceLocalHost)
-                        {
-                            throw ADP.InvalidConnectionOptionValue(DbConnectionStringKeywords.AttachDbFilename);
-                        }
+                        throw ADP.InvalidConnectionOptionValue(DbConnectionStringKeywords.AttachDbFilename);
                     }
                 }
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Data.SqlClient
             _usersConnectionString = connectionString ?? "";
             if (_usersConnectionString.Length > 0)
             {
-                _keyChain = ParseInternal(_parsetable, _usersConnectionString, true, s_keywordMap);
+                _keyChain = ParseInternal(_parsetable, _usersConnectionString, s_keywordMap);
                 _hasPasswordKeyword = _parsetable.ContainsKey(DbConnectionStringKeywords.Password) ||
                                       _parsetable.ContainsKey(DbConnectionStringSynonyms.Pwd);
                 _hasUserIdKeyword = _parsetable.ContainsKey(DbConnectionStringKeywords.UserId) ||
@@ -1471,7 +1471,6 @@ namespace Microsoft.Data.SqlClient
         private static NameValuePair ParseInternal(
             Dictionary<string, string> parsetable,
             string connectionString,
-            bool buildChain,
             IReadOnlyDictionary<string, string> synonyms)
         {
             Debug.Assert(connectionString != null, "null connectionstring");
@@ -1515,8 +1514,9 @@ namespace Microsoft.Data.SqlClient
                     {
                         localKeychain = localKeychain.Next = new NameValuePair(realkeyname, keyvalue, nextStartPosition - startPosition);
                     }
-                    else if (buildChain)
-                    { // first time only - don't contain modified chain from UDL file
+                    else
+                    {
+                        // first time only - don't contain modified chain from UDL file
                         keychain = localKeychain = new NameValuePair(realkeyname, keyvalue, nextStartPosition - startPosition);
                     }
                 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
@@ -1516,10 +1516,10 @@ namespace Microsoft.Data.SqlClient
             }
             catch (ArgumentException e)
             {
-                ParseComparison(parsetable, connectionString, synonyms, false, e);
+                ParseComparison(parsetable, connectionString, synonyms, e);
                 throw;
             }
-            ParseComparison(parsetable, connectionString, synonyms, false, null);
+            ParseComparison(parsetable, connectionString, synonyms, null);
             #endif
 
             return keychain;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
@@ -1238,7 +1238,7 @@ namespace Microsoft.Data.SqlClient
         };
 
         // @TODO: This should probably be extracted into its own parser class
-        internal static int GetKeyValuePair(string connectionString, int currentPosition, StringBuilder buffer, bool useOdbcRules, out string keyname, out string keyvalue)
+        internal static int GetKeyValuePair(string connectionString, int currentPosition, StringBuilder buffer, out string keyname, out string keyvalue)
         {
             int startposition = currentPosition;
 
@@ -1287,7 +1287,7 @@ namespace Microsoft.Data.SqlClient
                         break;
 
                     case ParserState.KeyEqual: // \\s*=(?!=)\\s*
-                        if (!useOdbcRules && '=' == currentChar)
+                        if ('=' == currentChar)
                         { parserState = ParserState.Key; break; }
                         keyname = GetKeyName(buffer);
                         if (string.IsNullOrEmpty(keyname))
@@ -1299,18 +1299,10 @@ namespace Microsoft.Data.SqlClient
                     case ParserState.KeyEnd:
                         if (char.IsWhiteSpace(currentChar))
                         { continue; }
-                        if (useOdbcRules)
-                        {
-                            if ('{' == currentChar)
-                            { parserState = ParserState.BraceQuoteValue; break; }
-                        }
-                        else
-                        {
-                            if ('\'' == currentChar)
-                            { parserState = ParserState.SingleQuoteValue; continue; }
-                            if ('"' == currentChar)
-                            { parserState = ParserState.DoubleQuoteValue; continue; }
-                        }
+                        if ('\'' == currentChar)
+                        { parserState = ParserState.SingleQuoteValue; continue; }
+                        if ('"' == currentChar)
+                        { parserState = ParserState.DoubleQuoteValue; continue; }
                         if (';' == currentChar)
                         { goto ParserExit; }
                         if ('\0' == currentChar)
@@ -1412,7 +1404,7 @@ namespace Microsoft.Data.SqlClient
                     keyvalue = GetKeyValue(buffer, true);
 
                     char tmpChar = keyvalue[keyvalue.Length - 1];
-                    if (!useOdbcRules && (('\'' == tmpChar) || ('"' == tmpChar)))
+                    if (('\'' == tmpChar) || ('"' == tmpChar))
                     {
                         throw ADP.ConnectionStringSyntax(startposition);    // unquoted value must not end in quote, except for odbc
                     }
@@ -1488,7 +1480,7 @@ namespace Microsoft.Data.SqlClient
                     int startPosition = nextStartPosition;
 
                     string keyname, keyvalue;
-                    nextStartPosition = GetKeyValuePair(connectionString, startPosition, buffer, false, out keyname, out keyvalue);
+                    nextStartPosition = GetKeyValuePair(connectionString, startPosition, buffer, out keyname, out keyvalue);
                     if (string.IsNullOrEmpty(keyname))
                     {
                         // if (nextStartPosition != endPosition) { throw; }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Data.SqlClient
             _usersConnectionString = connectionString ?? "";
             if (_usersConnectionString.Length > 0)
             {
-                _keyChain = ParseInternal(_parsetable, _usersConnectionString, true, s_keywordMap, false);
+                _keyChain = ParseInternal(_parsetable, _usersConnectionString, true, s_keywordMap);
                 _hasPasswordKeyword = _parsetable.ContainsKey(DbConnectionStringKeywords.Password) ||
                                       _parsetable.ContainsKey(DbConnectionStringSynonyms.Pwd);
                 _hasUserIdKeyword = _parsetable.ContainsKey(DbConnectionStringKeywords.UserId) ||
@@ -1472,8 +1472,7 @@ namespace Microsoft.Data.SqlClient
             Dictionary<string, string> parsetable,
             string connectionString,
             bool buildChain,
-            IReadOnlyDictionary<string, string> synonyms,
-            bool firstKey)
+            IReadOnlyDictionary<string, string> synonyms)
         {
             Debug.Assert(connectionString != null, "null connectionstring");
             StringBuilder buffer = new StringBuilder();
@@ -1490,7 +1489,7 @@ namespace Microsoft.Data.SqlClient
                     int startPosition = nextStartPosition;
 
                     string keyname, keyvalue;
-                    nextStartPosition = GetKeyValuePair(connectionString, startPosition, buffer, firstKey, out keyname, out keyvalue);
+                    nextStartPosition = GetKeyValuePair(connectionString, startPosition, buffer, false, out keyname, out keyvalue);
                     if (string.IsNullOrEmpty(keyname))
                     {
                         // if (nextStartPosition != endPosition) { throw; }
@@ -1509,10 +1508,8 @@ namespace Microsoft.Data.SqlClient
                     {
                         throw ADP.KeywordNotSupported(keyname);
                     }
-                    if (!firstKey || !parsetable.ContainsKey(realkeyname))
-                    {
-                        parsetable[realkeyname] = keyvalue; // last key-value pair wins (or first)
-                    }
+                    // Last key-value pair wins
+                    parsetable[realkeyname] = keyvalue;
 
                     if (localKeychain != null)
                     {
@@ -1527,10 +1524,10 @@ namespace Microsoft.Data.SqlClient
             }
             catch (ArgumentException e)
             {
-                ParseComparison(parsetable, connectionString, synonyms, firstKey, e);
+                ParseComparison(parsetable, connectionString, synonyms, false, e);
                 throw;
             }
-            ParseComparison(parsetable, connectionString, synonyms, firstKey, null);
+            ParseComparison(parsetable, connectionString, synonyms, false, null);
             #endif
 
             return keychain;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
@@ -1451,7 +1451,7 @@ namespace Microsoft.Data.SqlClient
             {
 #if DEBUG
                 bool compValue = s_connectionStringValidKeyRegex.IsMatch(keyname);
-                Debug.Assert(((0 < keyname.Length) && (';' != keyname[0]) && !char.IsWhiteSpace(keyname[0]) && (-1 == keyname.IndexOf('\u0000'))) == compValue, "IsValueValid mismatch with regex");
+                Debug.Assert(((0 < keyname.Length) && (';' != keyname[0]) && !char.IsWhiteSpace(keyname[0]) && (-1 == keyname.IndexOf('\u0000'))) == compValue, "IsKeyNameValid mismatch with regex");
 #endif
                 return ((0 < keyname.Length) && (';' != keyname[0]) && !char.IsWhiteSpace(keyname[0]) && (-1 == keyname.IndexOf('\u0000')));
             }
@@ -1715,7 +1715,7 @@ namespace Microsoft.Data.SqlClient
             ADP.CheckArgumentNull(builder, nameof(builder));
             ADP.CheckArgumentLength(keyName, nameof(keyName));
 
-            if (keyName == null || !s_connectionStringValidKeyRegex.IsMatch(keyName))
+            if (keyName == null || !IsKeyNameValid(keyName))
             {
                 throw ADP.InvalidKeyname(keyName);
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
@@ -27,11 +27,13 @@ namespace Microsoft.Data.SqlClient
         // when not worried about the class being modified during execution
 
         #region DbConnectionOptions fields
-
-        private const string ConnectionStringQuoteValuePattern = "^[^\"'=;\\s\\p{Cc}]*$";           // generally do not quote the value if it matches the pattern
         internal const string DataDirectory = "|datadirectory|";
 
+        #if NETFRAMEWORK
+        private const string ConnectionStringQuoteValuePattern = "^[^\"'=;\\s\\p{Cc}]*$";           // generally do not quote the value if it matches the pattern
+
         private static readonly Regex s_connectionStringQuoteValueRegex = new Regex(ConnectionStringQuoteValuePattern, RegexOptions.Compiled);
+        #endif
 
         internal readonly bool _hasPasswordKeyword;
         internal readonly bool _hasUserIdKeyword;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
@@ -28,13 +28,9 @@ namespace Microsoft.Data.SqlClient
 
         #region DbConnectionOptions fields
 
-        private const string ConnectionStringValidKeyPattern = "^(?![;\\s])[^\\p{Cc}]+(?<!\\s)$"; // key not allowed to start with semi-colon or space or contain non-visible characters or end with space
-        private const string ConnectionStringValidValuePattern = "^[^\u0000]*$";                    // value not allowed to contain embedded null
         private const string ConnectionStringQuoteValuePattern = "^[^\"'=;\\s\\p{Cc}]*$";           // generally do not quote the value if it matches the pattern
         internal const string DataDirectory = "|datadirectory|";
 
-        private static readonly Regex s_connectionStringValidKeyRegex = new Regex(ConnectionStringValidKeyPattern, RegexOptions.Compiled);
-        private static readonly Regex s_connectionStringValidValueRegex = new Regex(ConnectionStringValidValuePattern, RegexOptions.Compiled);
         private static readonly Regex s_connectionStringQuoteValueRegex = new Regex(ConnectionStringQuoteValuePattern, RegexOptions.Compiled);
 
         internal readonly bool _hasPasswordKeyword;


### PR DESCRIPTION
## Description

`SqlConnectionOptions` has a handful of code paths which were inherited from the need to write a generic parser for ODBC connection strings. These code paths are no longer used, so this PR just cleans them up.

In the case of `GetKeyValuePair`, there are a few code paths which could never be called, and codecov demonstrates this. In the other cases, they were criteria which would always be met.

One interesting point emerges from this: `SqlConnectionOptions` has four statically-initialised compiled Regex instances. One of them is completely unused, one is only used by netfx code and two are only used in Debug builds. I've cleaned these up, so the static constructor for the class sheds some load.

This is cleanup work which has an incidental performance benefit - it doesn't have a benchmark attached to it, and I couldn't see any results because we're dealing with static constructors.

For review, this can move commit-by-commit.

## Issues

None.

## Testing

All unit tests for connection string parsing continue to pass. All changes can be statically verified.