### PR TITLE
Add cancellation coverage for the internal-end execute path

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
@@ -2394,6 +2394,118 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             }
         }
 
+        /// <summary>
+        /// Companion to TestAsyncCancellationSendsAttention_WithAlwaysEncryptedCommand.
+        ///
+        /// That test puts WAITFOR first, so nothing comes back from the server until the delay
+        /// expires. The CreateLocalCompletionTask continuation therefore never runs while the
+        /// server is busy, and cancellation is handled out in ExecuteReaderAsync's await, which
+        /// passes whether or not the internal-end path holds lock (_stateObj).
+        ///
+        /// Flushing a partial result before the delay is what exposes the retained lock:
+        /// localCompletion completes on that first packet, the continuation enters endFunc while
+        /// holding the monitor, and blocks reading the rest. TdsParserStateObject.Cancel() needs
+        /// that same monitor to send the attention signal, so cancellation is silently dropped
+        /// and ExecuteReaderAsync returns a reader once WAITFOR expires.
+        /// </summary>
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsTargetReadyForAeWithKeyStore))]
+        [ClassData(typeof(AEConnectionStringProvider))]
+        public async Task TestAsyncCancellationSendsAttention_WithAlwaysEncryptedCommand_AfterPartialResults(string connection)
+        {
+            CleanUpTable(connection, _tableName);
+
+            IList<object> values = GetValues(dataHint: 61);
+            int numberOfRows = 10;
+            int rowsAffected = InsertRows(tableName: _tableName, numberofRows: numberOfRows, values: values, connection: connection);
+            Assert.True(rowsAffected == numberOfRows, "number of rows affected is unexpected.");
+
+            using (SqlConnection sqlConnection = new SqlConnection(connection))
+            {
+                await sqlConnection.OpenAsync();
+
+                // Same CommandText for warm-up and cancellation so the second execution reads the
+                // parameter metadata from the cache, which is what routes completion through
+                // CreateLocalCompletionTask.
+                string commandText = $"RAISERROR('partial result', 10, 1) WITH NOWAIT; WAITFOR DELAY @Delay; SELECT CustomerId, FirstName, LastName FROM [{_tableName}] WHERE FirstName = @FirstName AND CustomerId = @CustomerId;";
+
+                using (SqlCommand warmupCmd = new SqlCommand(
+                    commandText, sqlConnection, null, SqlCommandColumnEncryptionSetting.Enabled))
+                {
+                    warmupCmd.Parameters.AddWithValue("@CustomerId", values[0]);
+                    warmupCmd.Parameters.AddWithValue("@FirstName", values[1]);
+                    warmupCmd.Parameters.AddWithValue("@Delay", "00:00:00");
+
+                    using (var reader = await warmupCmd.ExecuteReaderAsync())
+                    {
+                        while (await reader.ReadAsync()) { }
+                        while (await reader.NextResultAsync()) { }
+                    }
+                }
+
+                using (SqlCommand sqlCommand = new SqlCommand(
+                    commandText, sqlConnection, null, SqlCommandColumnEncryptionSetting.Enabled))
+                {
+                    sqlCommand.Parameters.AddWithValue("@CustomerId", values[0]);
+                    sqlCommand.Parameters.AddWithValue("@FirstName", values[1]);
+                    sqlCommand.Parameters.AddWithValue("@Delay", "00:01:00");
+                    sqlCommand.CommandTimeout = 120;
+
+                    using (CancellationTokenSource cts = new CancellationTokenSource())
+                    {
+                        System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
+                        Task<SqlDataReader> execTask = sqlCommand.ExecuteReaderAsync(cts.Token);
+
+                        // Wait for the RAISERROR NOWAIT packet so we know the continuation is
+                        // inside endFunc before cancelling.
+                        var infoMessageReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                        sqlConnection.InfoMessage += (_, __) => infoMessageReceived.TrySetResult(true);
+                        await Task.WhenAny(infoMessageReceived.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+
+                        long cancelledAtMs = stopwatch.ElapsedMilliseconds;
+                        cts.Cancel();
+
+                        Exception caughtException = null;
+                        bool readerReturned = false;
+                        try
+                        {
+                            using (SqlDataReader reader = await execTask)
+                            {
+                                readerReturned = true;
+                            }
+                        }
+                        catch (OperationCanceledException ex)
+                        {
+                            caughtException = ex;
+                        }
+                        catch (SqlException ex)
+                        {
+                            caughtException = ex;
+                        }
+
+                        stopwatch.Stop();
+                        long latency = stopwatch.ElapsedMilliseconds - cancelledAtMs;
+
+                        Assert.False(readerReturned,
+                            $"ExecuteReaderAsync returned a reader {latency}ms after cancellation was requested. " +
+                            "The retained lock (_stateObj) in CreateLocalCompletionTask blocked " +
+                            "TdsParserStateObject.Cancel() from sending the attention signal.");
+                        Assert.NotNull(caughtException);
+                        Assert.True(latency < 30000,
+                            $"Cancellation took {latency}ms, expected < 30000ms. " +
+                            "Attention signal was not delivered on the Always Encrypted internal-end path.");
+                    }
+                }
+
+                // Verify the connection is still usable after cancellation.
+                using (SqlCommand verifyCmd = new SqlCommand(
+                    $"SELECT COUNT(*) FROM [{_tableName}]", sqlConnection))
+                {
+                    object result = await verifyCmd.ExecuteScalarAsync();
+                    Assert.Equal(numberOfRows, (int)result);
+                }
+            }
+        }
+
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsSGXEnclaveConnStringSetup))]
         public void TestNoneAttestationProtocolWithSGXEnclave()
         {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
@@ -2452,14 +2452,17 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 
                     using (CancellationTokenSource cts = new CancellationTokenSource())
                     {
+                        // Subscribe BEFORE dispatching so the RAISERROR ... WITH NOWAIT
+                        // informational token cannot arrive before we are listening.
+                        var infoMessageReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                        sqlConnection.InfoMessage += (_, __) => infoMessageReceived.TrySetResult(true);
+
                         System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
                         Task<SqlDataReader> execTask = sqlCommand.ExecuteReaderAsync(cts.Token);
 
                         // Wait for the RAISERROR NOWAIT packet so we know the continuation is
                         // inside endFunc before cancelling.
-                        var infoMessageReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                        sqlConnection.InfoMessage += (_, __) => infoMessageReceived.TrySetResult(true);
-                        await Task.WhenAny(infoMessageReceived.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+                        await Task.WhenAny(infoMessageReceived.Task, Task.Delay(TimeSpan.FromSeconds(10)));
 
                         long cancelledAtMs = stopwatch.ElapsedMilliseconds;
                         cts.Cancel();
@@ -2490,6 +2493,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                             "The retained lock (_stateObj) in CreateLocalCompletionTask blocked " +
                             "TdsParserStateObject.Cancel() from sending the attention signal.");
                         Assert.NotNull(caughtException);
+                        // Fail loudly if the InfoMessage never arrived: without it we silently
+                        // degrade to a fixed-timer cancellation and no longer prove that
+                        // cancellation happened in the "partial results received" state.
+                        Assert.True(infoMessageReceived.Task.IsCompleted,
+                            "InfoMessage from RAISERROR ... WITH NOWAIT was never received; " +
+                            "the test did not exercise the partial-results cancellation path.");
                         Assert.True(latency < 30000,
                             $"Cancellation took {latency}ms, expected < 30000ms. " +
                             "Attention signal was not delivered on the Always Encrypted internal-end path.");

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -616,6 +616,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         // Synapse: UDT Test Database not compatible with Azure Synapse.
         public static bool IsUdtTestDatabasePresent() => IsDatabasePresent(UdtTestDbName) && IsNotAzureSynapse();
 
+        // True only when the driver under test exposes SqlCommand's DEBUG-only
+        // _forceInternalEndQuery hook. Gating on this makes dependent tests report as skipped
+        // against a Release driver instead of silently passing.
+        public static bool IsForceInternalEndQuerySupported() =>
+            SystemDataInternals.CommandHelper.IsForceInternalEndQuerySupported();
+
         public static bool AreConnStringsSetup()
         {
             return !string.IsNullOrEmpty(NPConnectionString) && !string.IsNullOrEmpty(TCPConnectionString);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Common/SystemDataInternals/CommandHelper.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Common/SystemDataInternals/CommandHelper.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SystemDataInternals
         public static FieldInfo s_rowsAffectedBySpDescribeParameterEncryption = s_sqlCommand.GetField(@"_rowsAffectedBySpDescribeParameterEncryption", BindingFlags.Instance | BindingFlags.NonPublic);
         public static FieldInfo s_sleepDuringRunExecuteReaderTdsForSpDescribeParameterEncryption = s_sqlCommand.GetField(@"_sleepDuringRunExecuteReaderTdsForSpDescribeParameterEncryption", BindingFlags.Static | BindingFlags.NonPublic);
         public static FieldInfo s_sleepAfterReadDescribeEncryptionParameterResults = s_sqlCommand.GetField(@"_sleepAfterReadDescribeEncryptionParameterResults", BindingFlags.Static | BindingFlags.NonPublic);
+        public static FieldInfo s_forceInternalEndQuery = s_sqlCommand.GetField(@"_forceInternalEndQuery", BindingFlags.Static | BindingFlags.NonPublic);
 
         internal static void CompletePendingReadWithSuccess(SqlCommand command, bool resetForcePendingReadsToWait)
         {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Common/SystemDataInternals/CommandHelper.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Common/SystemDataInternals/CommandHelper.cs
@@ -27,6 +27,13 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SystemDataInternals
         public static FieldInfo s_sleepAfterReadDescribeEncryptionParameterResults = s_sqlCommand.GetField(@"_sleepAfterReadDescribeEncryptionParameterResults", BindingFlags.Static | BindingFlags.NonPublic);
         public static FieldInfo s_forceInternalEndQuery = s_sqlCommand.GetField(@"_forceInternalEndQuery", BindingFlags.Static | BindingFlags.NonPublic);
 
+        /// <summary>
+        /// True when the loaded Microsoft.Data.SqlClient exposes the DEBUG-only
+        /// _forceInternalEndQuery hook. Tests that depend on the hook should gate on this so they
+        /// report as skipped against a Release driver rather than silently passing.
+        /// </summary>
+        public static bool IsForceInternalEndQuerySupported() => s_forceInternalEndQuery is not null;
+
         internal static void CompletePendingReadWithSuccess(SqlCommand command, bool resetForcePendingReadsToWait)
         {
             s_completePendingReadWithSuccess.Invoke(command, new object[] { resetForcePendingReadsToWait });

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderCancellationTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderCancellationTest.cs
@@ -372,14 +372,17 @@ SELECT 1 AS Result;";
                     {
                         command.CommandTimeout = 120;
 
+                        // Subscribe BEFORE dispatching so the RAISERROR ... WITH NOWAIT
+                        // informational token cannot arrive before we are listening.
+                        var infoMessageReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                        connection.InfoMessage += (_, __) => infoMessageReceived.TrySetResult(true);
+
                         Stopwatch stopwatch = Stopwatch.StartNew();
                         Task<SqlDataReader> execTask = command.ExecuteReaderAsync(cts.Token);
 
                         // Let the RAISERROR NOWAIT packet land so the internal-end continuation is
                         // inside endFunc, and therefore inside lock (_stateObj), before we cancel.
-                        var infoMessageReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                        connection.InfoMessage += (_, __) => infoMessageReceived.TrySetResult(true);
-                        await Task.WhenAny(infoMessageReceived.Task, Task.Delay(System.TimeSpan.FromSeconds(5)));
+                        await Task.WhenAny(infoMessageReceived.Task, Task.Delay(System.TimeSpan.FromSeconds(10)));
 
                         long cancelledAtMs = stopwatch.ElapsedMilliseconds;
                         cts.Cancel();
@@ -410,6 +413,12 @@ SELECT 1 AS Result;";
                             "The internal-end path held lock (_stateObj) across a blocking read, so " +
                             "TdsParserStateObject.Cancel() could not send the attention signal.");
                         Assert.NotNull(caughtException);
+                        // Fail loudly if the InfoMessage never arrived: without it we silently
+                        // degrade to a fixed-timer cancellation and no longer prove that
+                        // cancellation happened in the "partial results received" state.
+                        Assert.True(infoMessageReceived.Task.IsCompleted,
+                            "InfoMessage from RAISERROR ... WITH NOWAIT was never received; " +
+                            "the test did not exercise the partial-results cancellation path.");
                         Assert.True(latency < 30000,
                             $"Cancellation took {latency}ms, expected < 30000ms. " +
                             "Attention signal was not delivered on the internal-end path.");

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderCancellationTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderCancellationTest.cs
@@ -344,18 +344,14 @@ END";
         /// In production this path is taken when column encryption is enabled and the parameter
         /// metadata came from the cache. Here it is forced with the DEBUG-only
         /// _forceInternalEndQuery hook so the regression is covered without an Always Encrypted
-        /// setup. The test no-ops against a Release build of the driver, where the hook is absent.
+        /// setup. Against a Release build of the driver the hook is absent and the test reports as
+        /// skipped, so the lost coverage is visible in the run summary. In that configuration the
+        /// Always Encrypted variant in ApiShould is the only coverage for this path.
         /// Synapse: Incompatible query.
         /// </summary>
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsForceInternalEndQuerySupported))]
         public static async Task CancellationOnInternalEndExecutePath_SendsAttention()
         {
-            if (CommandHelper.s_forceInternalEndQuery is null)
-            {
-                // Release build of Microsoft.Data.SqlClient; the hook is compiled out.
-                return;
-            }
-
             // Partial results must arrive before the blocking statement. That is what completes
             // localCompletion early and gets the internal-end continuation into the monitor while
             // the server is still busy.

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderCancellationTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderCancellationTest.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient.ManualTesting.Tests.SystemDataInternals;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests
@@ -328,6 +329,100 @@ END";
                     object result = await verifyCmd.ExecuteScalarAsync();
                     Assert.Equal(1, (int)result);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Regression test for the CreateLocalCompletionTask "internal end" path, which still
+        /// takes lock (_stateObj) while calling endFunc. That continuation fires as soon as the
+        /// first packet arrives, not once the whole result is buffered, so when a query flushes
+        /// partial results (RAISERROR WITH NOWAIT) and then blocks (WAITFOR), endFunc performs a
+        /// blocking read while holding the monitor. TdsParserStateObject.Cancel() needs the same
+        /// monitor to send the TDS attention signal, so cancellation is dropped and the command
+        /// runs to completion.
+        ///
+        /// In production this path is taken when column encryption is enabled and the parameter
+        /// metadata came from the cache. Here it is forced with the DEBUG-only
+        /// _forceInternalEndQuery hook so the regression is covered without an Always Encrypted
+        /// setup. The test no-ops against a Release build of the driver, where the hook is absent.
+        /// Synapse: Incompatible query.
+        /// </summary>
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
+        public static async Task CancellationOnInternalEndExecutePath_SendsAttention()
+        {
+            if (CommandHelper.s_forceInternalEndQuery is null)
+            {
+                // Release build of Microsoft.Data.SqlClient; the hook is compiled out.
+                return;
+            }
+
+            // Partial results must arrive before the blocking statement. That is what completes
+            // localCompletion early and gets the internal-end continuation into the monitor while
+            // the server is still busy.
+            const string query = @"
+RAISERROR('partial result', 10, 1) WITH NOWAIT;
+WAITFOR DELAY '00:01:00';
+SELECT 1 AS Result;";
+
+            CommandHelper.s_forceInternalEndQuery.SetValue(null, true);
+            try
+            {
+                using (var cts = new CancellationTokenSource())
+                using (var connection = new SqlConnection(DataTestUtility.TCPConnectionString))
+                {
+                    await connection.OpenAsync();
+
+                    using (var command = new SqlCommand(query, connection))
+                    {
+                        command.CommandTimeout = 120;
+
+                        Stopwatch stopwatch = Stopwatch.StartNew();
+                        Task<SqlDataReader> execTask = command.ExecuteReaderAsync(cts.Token);
+
+                        // Let the RAISERROR NOWAIT packet land so the internal-end continuation is
+                        // inside endFunc, and therefore inside lock (_stateObj), before we cancel.
+                        var infoMessageReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                        connection.InfoMessage += (_, __) => infoMessageReceived.TrySetResult(true);
+                        await Task.WhenAny(infoMessageReceived.Task, Task.Delay(System.TimeSpan.FromSeconds(5)));
+
+                        long cancelledAtMs = stopwatch.ElapsedMilliseconds;
+                        cts.Cancel();
+
+                        System.Exception caughtException = null;
+                        bool readerReturned = false;
+                        try
+                        {
+                            using (var reader = await execTask)
+                            {
+                                readerReturned = true;
+                            }
+                        }
+                        catch (System.OperationCanceledException ex)
+                        {
+                            caughtException = ex;
+                        }
+                        catch (SqlException ex)
+                        {
+                            caughtException = ex;
+                        }
+
+                        stopwatch.Stop();
+                        long latency = stopwatch.ElapsedMilliseconds - cancelledAtMs;
+
+                        Assert.False(readerReturned,
+                            $"ExecuteReaderAsync returned a reader {latency}ms after cancellation was requested. " +
+                            "The internal-end path held lock (_stateObj) across a blocking read, so " +
+                            "TdsParserStateObject.Cancel() could not send the attention signal.");
+                        Assert.NotNull(caughtException);
+                        Assert.True(latency < 30000,
+                            $"Cancellation took {latency}ms, expected < 30000ms. " +
+                            "Attention signal was not delivered on the internal-end path.");
+                    }
+                }
+            }
+            finally
+            {
+                CommandHelper.s_forceInternalEndQuery.SetValue(null, false);
             }
         }
     }


### PR DESCRIPTION
Stacked on #4435. Base is `dev/cheena/fix-async-cancel-attention`, so the diff here is just the two tests.

Opening as a draft because **both new tests fail against the current head of #4435 by design.** They are the reproduction for the review feedback on that PR.

## Why

#4435 removes `lock (_stateObj)` from `EndExecuteReaderAsync`, `EndExecuteNonQueryAsync` and `EndExecuteXmlReaderAsync`, and keeps it in `CreateLocalCompletionTask`. The five tests it adds all exercise the paths where the lock was removed, so they pass with or without its own change. Nothing covers the path that is still locked.

That path is reachable in production whenever column encryption is enabled and the parameter metadata came from the cache.

## What the tests show

Cancelling 1s into a 60s `WAITFOR`, with the metadata cache warm and `_internalEndExecuteInitiated` confirmed true:

| | result |
|---|---|
| lock retained (head of #4435) | 60018ms, no exception, `ExecuteReaderAsync` **returns a reader** |
| lock removed | 1016ms, `SqlException` with `Number == 0` |

`Number == 0` is the error `TdsParser.TryRun` adds when it consumes the attention ack, so it is a direct signal that the round trip happened.

Full `DataReaderCancellationTest` class:
- head of #4435: 5 passed, 1 failed, `ExecuteReaderAsync returned a reader 60015ms after cancellation was requested`
- with the lock removed from `CreateLocalCompletionTask`: 6 passed, the new one in 12ms

## The two tests

**`CancellationOnInternalEndExecutePath_SendsAttention`** forces the path with the existing DEBUG `_forceInternalEndQuery` hook, so it runs without an Always Encrypted setup. It no-ops against a Release driver, where the hook is compiled out.

**`TestAsyncCancellationSendsAttention_WithAlwaysEncryptedCommand_AfterPartialResults`** is the Always Encrypted equivalent, verified against SQL Server 2022 with a custom key store provider.

It differs from the existing `TestAsyncCancellationSendsAttention_WithAlwaysEncryptedCommand` in one way: it flushes a partial result before the delay. Both shapes reach `CreateLocalCompletionTask`, but only this one catches the bug.

| query shape | result |
|---|---|
| `WAITFOR DELAY @Delay; SELECT ...` (existing test) | cancels in 27ms, passes |
| `RAISERROR(...) WITH NOWAIT; WAITFOR DELAY @Delay; SELECT ...` | 60018ms, reader returned, fails |

With `WAITFOR` first, nothing comes back until the delay expires, so the continuation never runs while the server is busy and cancellation is handled out in `ExecuteReaderAsync`'s await. The lock is never held across the blocking read, which is the thing under test.

## Suggested resolution on #4435

Remove the lock from `CreateLocalCompletionTask` as well. The justification comment there says the continuation runs after the data is buffered, but `localCompletion` is completed by `BeginExecuteReaderInternalReadStage` → `_stateObj.ReadSni(completion)`, which fires on the first packet.

`ac8acd72` restored that lock to fix an AE test. The cancellation exception on the unlocked path is a `SqlException` carrying two errors, `A severe error occurred on the current command.` followed by `Operation cancelled by user.`, and `TestCancellationToken` asserts an exact message match. That is a correct cancellation, so the assertion is worth relaxing to check `Number == 0` instead.

- [x] Tests added
- [ ] Public API changes documented (none)
- [x] Verified against a live SQL Server 2022 instance
- [x] No breaking changes