### PR TITLE
Fix WaitHandle replacement activation rollback

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/WaitHandleDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/WaitHandleDbConnectionPool.cs
@@ -1148,7 +1148,11 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             return true;
         }
 
-        private void PrepareConnection(DbConnection owningObject, DbConnectionInternal obj, Transaction transaction)
+        private void PrepareConnection(
+            DbConnection owningObject,
+            DbConnectionInternal obj,
+            Transaction transaction,
+            bool returnConnectionOnFailure = true)
         {
             lock (obj)
             {   // Protect against Clear and ReclaimEmancipatedObjects, which call IsEmancipated, which is affected by PrePush and PostPop
@@ -1160,9 +1164,12 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             }
             catch
             {
-                // if Activate throws an exception
-                // put it back in the pool or have it properly disposed of
-                this.ReturnInternalConnection(obj, owningObject);
+                if (returnConnectionOnFailure)
+                {
+                    // If Activate throws during an ordinary checkout, put the connection back in
+                    // the pool or have it properly disposed of.
+                    ReturnInternalConnection(obj, owningObject);
+                }
                 throw;
             }
         }
@@ -1182,7 +1189,51 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             if (newConnection != null)
             {
                 SqlClientDiagnostics.Metrics.SoftConnectRequest();
-                PrepareConnection(owningObject, newConnection, oldConnection.EnlistedTransaction);
+                try
+                {
+                    // CreateObject has already swapped the replacement into _objectList. Unlike an
+                    // ordinary checkout failure, an activation failure here must not return the
+                    // replacement to the idle pool because the caller still owns oldConnection.
+                    PrepareConnection(
+                        owningObject,
+                        newConnection,
+                        oldConnection.EnlistedTransaction,
+                        returnConnectionOnFailure: false);
+                }
+                catch
+                {
+                    try
+                    {
+                        newConnection.DeactivateConnection();
+                    }
+                    catch
+                    {
+                        // Preserve the activation failure; cleanup is best effort.
+                    }
+
+                    DestroyObject(newConnection);
+
+                    bool restored = false;
+                    lock (_objectList)
+                    {
+                        if (oldConnection.Pool == this && !_objectList.Contains(oldConnection))
+                        {
+                            _objectList.Add(oldConnection);
+                            _totalObjects = _objectList.Count;
+                            restored = true;
+                        }
+                    }
+
+                    if (restored)
+                    {
+                        SqlClientDiagnostics.Metrics.EnterPooledConnection();
+                    }
+
+                    // The replacement checkout failed before reaching the caller.
+                    SqlClientDiagnostics.Metrics.SoftDisconnectRequest();
+                    throw;
+                }
+
                 oldConnection.DeactivateConnection();
                 oldConnection.Dispose();
             }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/WaitHandleDbConnectionPoolReplaceConnectionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/WaitHandleDbConnectionPoolReplaceConnectionTest.cs
@@ -1,0 +1,174 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Transactions;
+using Microsoft.Data.Common.ConnectionString;
+using Microsoft.Data.ProviderBase;
+using Microsoft.Data.SqlClient.ConnectionPool;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool;
+
+/// <summary>
+/// Verifies replacement rollback behavior in <see cref="WaitHandleDbConnectionPool"/>.
+/// </summary>
+public sealed class WaitHandleDbConnectionPoolReplaceConnectionTest
+{
+    /// <summary>
+    /// Verifies that an activation failure disposes the failed replacement and restores the
+    /// original connection as the pool's single tracked, checked-out connection.
+    /// </summary>
+    [Fact]
+    public void ReplaceConnection_ActivationFails_RestoresOriginalConnectionAndCounters()
+    {
+        // Arrange
+        var factory = new ReplacementActivationFailingConnectionFactory();
+        WaitHandleDbConnectionPool pool = CreatePool(factory);
+        using var owner = new SqlConnection();
+
+        Assert.True(pool.TryGetConnection(
+            owner,
+            taskCompletionSource: null,
+            TimeoutTimer.StartNew(TimeSpan.FromSeconds(15)),
+            out DbConnectionInternal? oldConnection));
+
+        TrackingConnection original = Assert.IsType<TrackingConnection>(oldConnection);
+
+        // Act
+        Assert.Throws<InvalidOperationException>(() =>
+            pool.ReplaceConnection(
+                owner,
+                original,
+                TimeoutTimer.StartNew(TimeSpan.FromSeconds(15))));
+
+        // Assert
+        Assert.False(original.IsDisposed);
+        Assert.Same(pool, original.Pool);
+        Assert.True(factory.Replacement.IsDisposed);
+        Assert.Null(factory.Replacement.Pool);
+        Assert.Equal(1, pool.Count);
+
+        pool.ReturnInternalConnection(original, owner);
+        pool.Shutdown();
+        pool.Clear();
+    }
+
+    /// <summary>
+    /// Creates and starts a WaitHandle pool backed by the supplied factory.
+    /// </summary>
+    /// <param name="factory">Factory used to create the original and replacement connections.</param>
+    /// <returns>A running connection pool.</returns>
+    private static WaitHandleDbConnectionPool CreatePool(SqlConnectionFactory factory)
+    {
+        var poolGroupOptions = new DbConnectionPoolGroupOptions(
+            poolByIdentity: false,
+            minPoolSize: 0,
+            maxPoolSize: 50,
+            creationTimeout: 15_000,
+            loadBalanceTimeout: 0,
+            hasTransactionAffinity: true,
+            idleTimeout: 0);
+
+        var poolGroup = new DbConnectionPoolGroup(
+            new SqlConnectionOptions("Data Source=localhost;"),
+            new ConnectionPoolKey(
+                "TestDataSource",
+                credential: null,
+                accessToken: null,
+                accessTokenCallback: null,
+                sspiContextProvider: null),
+            poolGroupOptions);
+
+        var pool = new WaitHandleDbConnectionPool(
+            factory,
+            poolGroup,
+            DbConnectionPoolIdentity.NoIdentity,
+            new DbConnectionPoolProviderInfo());
+
+        pool.Startup();
+        return pool;
+    }
+
+    /// <summary>
+    /// Creates a normal original connection followed by a replacement that fails activation.
+    /// </summary>
+    private sealed class ReplacementActivationFailingConnectionFactory : SqlConnectionFactory
+    {
+        private int _created;
+
+        internal TrackingConnection Replacement { get; private set; } = null!;
+
+        /// <inheritdoc />
+        protected override DbConnectionInternal CreateConnection(
+            SqlConnectionOptions options,
+            ConnectionPoolKey poolKey,
+            DbConnectionPoolGroupProviderInfo poolGroupProviderInfo,
+            IDbConnectionPool pool,
+            DbConnection owningConnection,
+            TimeoutTimer timeout)
+        {
+            bool failActivation = Interlocked.Increment(ref _created) > 1;
+            var connection = new TrackingConnection(failActivation);
+            if (failActivation)
+            {
+                Replacement = connection;
+            }
+
+            return connection;
+        }
+    }
+
+    /// <summary>
+    /// Records disposal and optionally fails when activated.
+    /// </summary>
+    private sealed class TrackingConnection : DbConnectionInternal
+    {
+        private readonly bool _failActivation;
+
+        internal TrackingConnection(bool failActivation)
+        {
+            _failActivation = failActivation;
+        }
+
+        internal bool IsDisposed { get; private set; }
+
+        public override string ServerVersion => "Mock";
+
+        public override DbTransaction BeginTransaction(System.Data.IsolationLevel isolationLevel) =>
+            throw new NotImplementedException();
+
+        public override void EnlistTransaction(Transaction? transaction)
+        {
+            EnlistedTransaction = transaction;
+        }
+
+        protected override void Activate(Transaction? transaction)
+        {
+            if (_failActivation)
+            {
+                throw new InvalidOperationException("Simulated activation failure");
+            }
+
+            EnlistedTransaction = transaction;
+        }
+
+        protected override void Deactivate()
+        {
+        }
+
+        internal override void ResetConnection()
+        {
+        }
+
+        public override void Dispose()
+        {
+            IsDisposed = true;
+            base.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4548

## Summary
- dispose a replacement connection when activation fails
- restore the original checked-out connection to WaitHandle pool tracking
- balance replacement checkout metrics during rollback
- add regression coverage for replacement activation failure

## Tests
- `dotnet test src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft.Data.SqlClient.UnitTests.csproj -f net9.0 --filter "FullyQualifiedName~ReplaceConnection_ActivationFails_RestoresOriginalConnectionAndCounters" --no-restore --nologo`
- `dotnet test src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft.Data.SqlClient.UnitTests.csproj -f net9.0 --filter "FullyQualifiedName~ConnectionPool" --no-restore --nologo`

- [x] Tests added or updated
- [x] No public API changes
- [x] No breaking changes introduced
- [ ] Verified against customer repro (not applicable)