### PR TITLE
Add client certificate loopback authentication

### DIFF
--- a/doc/samples/SqlConnection_ClientCertificateAuthentication.cs
+++ b/doc/samples/SqlConnection_ClientCertificateAuthentication.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+
+internal static class SqlConnectionClientCertificateAuthentication
+{
+    // <ClientCertificateAuthentication>
+    internal static async Task OpenLoopbackConnectionAsync()
+    {
+        string dataSource = Environment.GetEnvironmentVariable("SQLCLIENT_LOOPBACK_DATA_SOURCE")
+            ?? throw new InvalidOperationException("Set SQLCLIENT_LOOPBACK_DATA_SOURCE.");
+        string clientCertificate = Environment.GetEnvironmentVariable("SQLCLIENT_CLIENT_CERTIFICATE")
+            ?? throw new InvalidOperationException("Set SQLCLIENT_CLIENT_CERTIFICATE.");
+        string clientKey = Environment.GetEnvironmentVariable("SQLCLIENT_CLIENT_KEY") ?? string.Empty;
+        string clientKeyPassword = Environment.GetEnvironmentVariable("SQLCLIENT_CLIENT_KEY_PASSWORD") ?? string.Empty;
+
+        SqlConnectionStringBuilder builder = new()
+        {
+            DataSource = dataSource,
+            InitialCatalog = "master",
+            Encrypt = SqlConnectionEncryptOption.Mandatory,
+            ClientCertificate = clientCertificate,
+            ClientKey = clientKey,
+            ClientKeyPassword = clientKeyPassword,
+        };
+
+        using SqlConnection connection = new(builder.ConnectionString);
+        await connection.OpenAsync();
+    }
+    // </ClientCertificateAuthentication>
+}

--- a/doc/samples/SqlConnection_ClientCertificateAuthentication.cs
+++ b/doc/samples/SqlConnection_ClientCertificateAuthentication.cs
@@ -23,6 +23,10 @@ internal static class SqlConnectionClientCertificateAuthentication
             DataSource = dataSource,
             InitialCatalog = "master",
             Encrypt = SqlConnectionEncryptOption.Mandatory,
+            // A loopback connection presents a certificate for "localhost" that is normally not
+            // chain-trusted. Supply ServerCertificate or HostNameInCertificate instead of trusting
+            // every certificate when connecting to anything other than the local machine.
+            TrustServerCertificate = true,
             ClientCertificate = clientCertificate,
             ClientKey = clientKey,
             ClientKeyPassword = clientKeyPassword,

--- a/doc/samples/SqlConnection_ClientCertificateAuthentication.cs
+++ b/doc/samples/SqlConnection_ClientCertificateAuthentication.cs
@@ -1,39 +1,60 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+// The Samples project references the released Microsoft.Data.SqlClient package, which does not yet
+// expose the client certificate properties. Remove this guard once a package containing them ships.
+#if false
 
+namespace SqlConnection_ClientCertificateAuthentication;
+
+// <Snippet1>
 using System;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 
-internal static class SqlConnectionClientCertificateAuthentication
+class Program
 {
-    // <ClientCertificateAuthentication>
-    internal static async Task OpenLoopbackConnectionAsync()
+    static async Task Main()
     {
+        await OpenLoopbackConnectionAsync();
+    }
+
+    private static async Task OpenLoopbackConnectionAsync()
+    {
+        // Read the certificate locations from the environment so that no path or password is
+        // committed to source control.
         string dataSource = Environment.GetEnvironmentVariable("SQLCLIENT_LOOPBACK_DATA_SOURCE")
             ?? throw new InvalidOperationException("Set SQLCLIENT_LOOPBACK_DATA_SOURCE.");
         string clientCertificate = Environment.GetEnvironmentVariable("SQLCLIENT_CLIENT_CERTIFICATE")
             ?? throw new InvalidOperationException("Set SQLCLIENT_CLIENT_CERTIFICATE.");
-        string clientKey = Environment.GetEnvironmentVariable("SQLCLIENT_CLIENT_KEY") ?? string.Empty;
-        string clientKeyPassword = Environment.GetEnvironmentVariable("SQLCLIENT_CLIENT_KEY_PASSWORD") ?? string.Empty;
 
-        SqlConnectionStringBuilder builder = new()
+        // Client Key is only needed when the certificate is PEM or DER encoded. A PKCS#12 (PFX or
+        // P12) certificate already contains its private key.
+        string clientKey = Environment.GetEnvironmentVariable("SQLCLIENT_CLIENT_KEY")
+            ?? string.Empty;
+        string clientKeyPassword = Environment.GetEnvironmentVariable("SQLCLIENT_CLIENT_KEY_PASSWORD")
+            ?? string.Empty;
+
+        SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder
         {
             DataSource = dataSource,
             InitialCatalog = "master",
             Encrypt = SqlConnectionEncryptOption.Mandatory,
-            // A loopback connection presents a certificate for "localhost" that is normally not
-            // chain-trusted. Supply ServerCertificate or HostNameInCertificate instead of trusting
-            // every certificate when connecting to anything other than the local machine.
+
+            // A loopback instance presents a certificate for "localhost" that is normally not
+            // chain-trusted. When connecting to anything other than the local machine, supply
+            // ServerCertificate or HostNameInCertificate instead of trusting every certificate.
             TrustServerCertificate = true,
+
             ClientCertificate = clientCertificate,
             ClientKey = clientKey,
             ClientKeyPassword = clientKeyPassword,
         };
 
-        using SqlConnection connection = new(builder.ConnectionString);
-        await connection.OpenAsync();
+        using (SqlConnection connection = new SqlConnection(builder.ConnectionString))
+        {
+            await connection.OpenAsync();
+            Console.WriteLine("State: {0}", connection.State);
+        }
     }
-    // </ClientCertificateAuthentication>
 }
+// </Snippet1>
+
+#endif

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml
@@ -748,9 +748,15 @@ This property corresponds to the "HostNameInCertificate" and "Host Name in Certi
           <![CDATA[
 This property corresponds to the "Client Certificate" and "ClientCertificate" keys within the connection string.
 
-Client certificate authentication is supported for SQL Server on Linux loopback connections when managed networking is used. PFX and P12 certificates can contain their private key. PEM, DER, and CER certificates require <xref:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.ClientKey>, which supports RSA PKCS#1 and PKCS#8 private keys.
+Client certificate authentication is supported for SQL Server on Linux loopback connections when managed networking is used. It is available on .NET only; the keyword is not recognized on .NET Framework, and it requires managed SNI (native SNI on Windows throws <xref:System.PlatformNotSupportedException>).
 
-Client certificate authentication cannot be combined with SQL credentials, integrated security, Microsoft Entra authentication, access tokens, or a custom SSPI context provider.
+The container format is detected from the file contents, not the file extension. A PKCS#12 (PFX or P12) file can contain its own private key. A PEM, DER, or CER certificate requires <xref:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.ClientKey>, which supports RSA private keys only.
+
+The ODBC driver's `file:` path prefix is not accepted. Specify the certificate and key file paths directly.
+
+Client certificate authentication cannot be combined with SQL credentials, integrated security, Microsoft Entra authentication, access tokens, a custom SSPI context provider, or <xref:Microsoft.Data.SqlClient.SqlConnection.ChangePassword%2A>.
+
+The certificate is read when a pooled physical connection is created and is cached for the lifetime of that connection. To pick up a rotated certificate, call <xref:Microsoft.Data.SqlClient.SqlConnection.ClearPool%2A> or disable pooling.
 ]]>
         </format>
       </remarks>
@@ -763,7 +769,7 @@ Client certificate authentication cannot be combined with SQL credentials, integ
         The private key path, or <see langword="String.Empty" /> if none has been supplied.
       </value>
       <remarks>
-        This property corresponds to the "Client Key" and "ClientKey" keys within the connection string. The key must be an RSA PKCS#1 or PKCS#8 private key. To use another key algorithm, provide a PFX or P12 file through <see cref="P:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.ClientCertificate" />.
+        This property corresponds to the "Client Key" and "ClientKey" keys within the connection string. The key must be an unencrypted RSA PKCS#1 or an RSA PKCS#8 private key; password-protected keys must use encrypted PKCS#8. To use another key algorithm, provide a PKCS#12 (PFX or P12) file through <see cref="P:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.ClientCertificate" />. This property is available on .NET only.
       </remarks>
     </ClientKey>
     <ClientKeyPassword>
@@ -776,7 +782,7 @@ Client certificate authentication cannot be combined with SQL credentials, integ
       <remarks>
         <format type="text/markdown">
           <![CDATA[
-This property corresponds to the "Client Key Password" and "ClientKeyPassword" keys within the connection string.
+This property corresponds to the "Client Key Password" and "ClientKeyPassword" keys within the connection string. It is available on .NET only.
 
 The value is removed from <xref:Microsoft.Data.SqlClient.SqlConnection.ConnectionString> after the connection is opened unless `Persist Security Info=true`. Store this value in a secure secret provider rather than source code or configuration committed to source control.
 ]]>

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml
@@ -736,6 +736,53 @@ This property corresponds to the "HostNameInCertificate" and "Host Name in Certi
         </format>
       </remarks>
     </HostNameInCertificate>
+    <ClientCertificate>
+      <summary>
+        Gets or sets the path to a client certificate used to authenticate a loopback connection to SQL Server on Linux.
+      </summary>
+      <value>
+        The client certificate path, or <see langword="String.Empty" /> if none has been supplied.
+      </value>
+      <remarks>
+        <format type="text/markdown">
+          <![CDATA[
+This property corresponds to the "Client Certificate" and "ClientCertificate" keys within the connection string.
+
+Client certificate authentication is supported for SQL Server on Linux loopback connections when managed networking is used. PFX and P12 certificates can contain their private key. PEM, DER, and CER certificates require <xref:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.ClientKey>, which supports RSA PKCS#1 and PKCS#8 private keys.
+
+Client certificate authentication cannot be combined with SQL credentials, integrated security, Microsoft Entra authentication, access tokens, or a custom SSPI context provider.
+]]>
+        </format>
+      </remarks>
+    </ClientCertificate>
+    <ClientKey>
+      <summary>
+        Gets or sets the path to the private key associated with <see cref="P:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.ClientCertificate" />.
+      </summary>
+      <value>
+        The private key path, or <see langword="String.Empty" /> if none has been supplied.
+      </value>
+      <remarks>
+        This property corresponds to the "Client Key" and "ClientKey" keys within the connection string. The key must be an RSA PKCS#1 or PKCS#8 private key. To use another key algorithm, provide a PFX or P12 file through <see cref="P:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.ClientCertificate" />.
+      </remarks>
+    </ClientKey>
+    <ClientKeyPassword>
+      <summary>
+        Gets or sets the password used to access the client certificate or private key.
+      </summary>
+      <value>
+        The password, or <see langword="String.Empty" /> if none has been supplied.
+      </value>
+      <remarks>
+        <format type="text/markdown">
+          <![CDATA[
+This property corresponds to the "Client Key Password" and "ClientKeyPassword" keys within the connection string.
+
+The value is removed from <xref:Microsoft.Data.SqlClient.SqlConnection.ConnectionString> after the connection is opened unless `Persist Security Info=true`. Store this value in a secure secret provider rather than source code or configuration committed to source control.
+]]>
+        </format>
+      </remarks>
+    </ClientKeyPassword>
     <InitialCatalog>
       <summary>
         Gets or sets the name of the database associated with the connection.

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml
@@ -313,6 +313,65 @@ The following example supplies a simple SQL Server connection string in the <xre
         </code>
       </example>
     </Clear>
+    <ClientCertificate>
+      <summary>
+        Gets or sets the path to a client certificate used to authenticate a loopback connection to SQL Server on Linux.
+      </summary>
+      <value>
+        The client certificate path, or <see langword="String.Empty" /> if none has been supplied.
+      </value>
+      <remarks>
+        <format type="text/markdown">
+          <![CDATA[
+This property corresponds to the "Client Certificate" and "ClientCertificate" keys within the connection string.
+
+Client certificate authentication is supported for SQL Server on Linux loopback connections when managed networking is used. It is available on .NET only; the keyword is not recognized on .NET Framework, and it requires managed SNI (native SNI on Windows throws <xref:System.PlatformNotSupportedException>).
+
+The container format is detected from the file contents, not the file extension. A PKCS#12 (PFX or P12) file can contain its own private key. A PEM, DER, or CER certificate requires <xref:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.ClientKey>, which supports RSA private keys only.
+
+The ODBC driver's `file:` path prefix is not accepted. Specify the certificate and key file paths directly.
+
+Client certificate authentication cannot be combined with SQL credentials, integrated security, Microsoft Entra authentication, access tokens, a custom SSPI context provider, or <xref:Microsoft.Data.SqlClient.SqlConnection.ChangePassword%2A>.
+
+The certificate is read when a pooled physical connection is created and is cached for the lifetime of that connection. To pick up a rotated certificate, call <xref:Microsoft.Data.SqlClient.SqlConnection.ClearPool%2A> or disable pooling.
+
+## Examples
+
+The following example opens a loopback connection to SQL Server on Linux using a client certificate.
+
+[!code-csharp[SqlConnection_ClientCertificateAuthentication Example#1](~/../sqlclient/doc/samples/SqlConnection_ClientCertificateAuthentication.cs#1)]
+]]>
+        </format>
+      </remarks>
+    </ClientCertificate>
+    <ClientKey>
+      <summary>
+        Gets or sets the path to the private key associated with <see cref="P:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.ClientCertificate" />.
+      </summary>
+      <value>
+        The private key path, or <see langword="String.Empty" /> if none has been supplied.
+      </value>
+      <remarks>
+        This property corresponds to the "Client Key" and "ClientKey" keys within the connection string. The key must be an unencrypted RSA PKCS#1 or an RSA PKCS#8 private key; password-protected keys must use encrypted PKCS#8. To use another key algorithm, provide a PKCS#12 (PFX or P12) file through <see cref="P:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.ClientCertificate" />. This property cannot be combined with a PKCS#12 certificate, which already contains its private key. This property is available on .NET only.
+      </remarks>
+    </ClientKey>
+    <ClientKeyPassword>
+      <summary>
+        Gets or sets the password used to access the client certificate or private key.
+      </summary>
+      <value>
+        The password, or <see langword="String.Empty" /> if none has been supplied.
+      </value>
+      <remarks>
+        <format type="text/markdown">
+          <![CDATA[
+This property corresponds to the "Client Key Password" and "ClientKeyPassword" keys within the connection string. It is available on .NET only.
+
+The value is removed from <xref:Microsoft.Data.SqlClient.SqlConnection.ConnectionString> after the connection is opened unless `Persist Security Info=true`. Store this value in a secure secret provider rather than source code or configuration committed to source control.
+]]>
+        </format>
+      </remarks>
+    </ClientKeyPassword>
     <ColumnEncryptionSetting>
       <summary>
         Gets or sets the column encryption settings for the connection string builder.
@@ -736,59 +795,6 @@ This property corresponds to the "HostNameInCertificate" and "Host Name in Certi
         </format>
       </remarks>
     </HostNameInCertificate>
-    <ClientCertificate>
-      <summary>
-        Gets or sets the path to a client certificate used to authenticate a loopback connection to SQL Server on Linux.
-      </summary>
-      <value>
-        The client certificate path, or <see langword="String.Empty" /> if none has been supplied.
-      </value>
-      <remarks>
-        <format type="text/markdown">
-          <![CDATA[
-This property corresponds to the "Client Certificate" and "ClientCertificate" keys within the connection string.
-
-Client certificate authentication is supported for SQL Server on Linux loopback connections when managed networking is used. It is available on .NET only; the keyword is not recognized on .NET Framework, and it requires managed SNI (native SNI on Windows throws <xref:System.PlatformNotSupportedException>).
-
-The container format is detected from the file contents, not the file extension. A PKCS#12 (PFX or P12) file can contain its own private key. A PEM, DER, or CER certificate requires <xref:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.ClientKey>, which supports RSA private keys only.
-
-The ODBC driver's `file:` path prefix is not accepted. Specify the certificate and key file paths directly.
-
-Client certificate authentication cannot be combined with SQL credentials, integrated security, Microsoft Entra authentication, access tokens, a custom SSPI context provider, or <xref:Microsoft.Data.SqlClient.SqlConnection.ChangePassword%2A>.
-
-The certificate is read when a pooled physical connection is created and is cached for the lifetime of that connection. To pick up a rotated certificate, call <xref:Microsoft.Data.SqlClient.SqlConnection.ClearPool%2A> or disable pooling.
-]]>
-        </format>
-      </remarks>
-    </ClientCertificate>
-    <ClientKey>
-      <summary>
-        Gets or sets the path to the private key associated with <see cref="P:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.ClientCertificate" />.
-      </summary>
-      <value>
-        The private key path, or <see langword="String.Empty" /> if none has been supplied.
-      </value>
-      <remarks>
-        This property corresponds to the "Client Key" and "ClientKey" keys within the connection string. The key must be an unencrypted RSA PKCS#1 or an RSA PKCS#8 private key; password-protected keys must use encrypted PKCS#8. To use another key algorithm, provide a PKCS#12 (PFX or P12) file through <see cref="P:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.ClientCertificate" />. This property cannot be combined with a PKCS#12 certificate, which already contains its private key. This property is available on .NET only.
-      </remarks>
-    </ClientKey>
-    <ClientKeyPassword>
-      <summary>
-        Gets or sets the password used to access the client certificate or private key.
-      </summary>
-      <value>
-        The password, or <see langword="String.Empty" /> if none has been supplied.
-      </value>
-      <remarks>
-        <format type="text/markdown">
-          <![CDATA[
-This property corresponds to the "Client Key Password" and "ClientKeyPassword" keys within the connection string. It is available on .NET only.
-
-The value is removed from <xref:Microsoft.Data.SqlClient.SqlConnection.ConnectionString> after the connection is opened unless `Persist Security Info=true`. Store this value in a secure secret provider rather than source code or configuration committed to source control.
-]]>
-        </format>
-      </remarks>
-    </ClientKeyPassword>
     <InitialCatalog>
       <summary>
         Gets or sets the name of the database associated with the connection.

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml
@@ -329,6 +329,8 @@ Client certificate authentication is supported for SQL Server on Linux loopback 
 
 The container format is detected from the file contents, not the file extension. A PKCS#12 (PFX or P12) file can contain its own private key. A PEM, DER, or CER certificate requires <xref:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.ClientKey>, which supports RSA private keys only and is available on .NET only. On .NET Framework the certificate must therefore be a PKCS#12 file.
 
+When managed networking is used, issuer certificates found alongside the client certificate are presented during the handshake. Native SNI presents the end-entity certificate only, so a server that requires the intermediate certificates must already trust them. The SQL Server on Linux loopback scenario issues a single certificate and is unaffected.
+
 The ODBC driver's `file:` path prefix is not accepted. Specify the certificate and key file paths directly.
 
 Client certificate authentication cannot be combined with SQL credentials, integrated security, Microsoft Entra authentication, access tokens, a custom SSPI context provider, or <xref:Microsoft.Data.SqlClient.SqlConnection.ChangePassword%2A>.

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml
@@ -769,7 +769,7 @@ The certificate is read when a pooled physical connection is created and is cach
         The private key path, or <see langword="String.Empty" /> if none has been supplied.
       </value>
       <remarks>
-        This property corresponds to the "Client Key" and "ClientKey" keys within the connection string. The key must be an unencrypted RSA PKCS#1 or an RSA PKCS#8 private key; password-protected keys must use encrypted PKCS#8. To use another key algorithm, provide a PKCS#12 (PFX or P12) file through <see cref="P:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.ClientCertificate" />. This property is available on .NET only.
+        This property corresponds to the "Client Key" and "ClientKey" keys within the connection string. The key must be an unencrypted RSA PKCS#1 or an RSA PKCS#8 private key; password-protected keys must use encrypted PKCS#8. To use another key algorithm, provide a PKCS#12 (PFX or P12) file through <see cref="P:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.ClientCertificate" />. This property cannot be combined with a PKCS#12 certificate, which already contains its private key. This property is available on .NET only.
       </remarks>
     </ClientKey>
     <ClientKeyPassword>

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml
@@ -325,9 +325,9 @@ The following example supplies a simple SQL Server connection string in the <xre
           <![CDATA[
 This property corresponds to the "Client Certificate" and "ClientCertificate" keys within the connection string.
 
-Client certificate authentication is supported for SQL Server on Linux loopback connections when managed networking is used. It is available on .NET only; the keyword is not recognized on .NET Framework, and it requires managed SNI (native SNI on Windows throws <xref:System.PlatformNotSupportedException>).
+Client certificate authentication is supported for SQL Server on Linux loopback connections. It works with both managed and native SNI.
 
-The container format is detected from the file contents, not the file extension. A PKCS#12 (PFX or P12) file can contain its own private key. A PEM, DER, or CER certificate requires <xref:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.ClientKey>, which supports RSA private keys only.
+The container format is detected from the file contents, not the file extension. A PKCS#12 (PFX or P12) file can contain its own private key. A PEM, DER, or CER certificate requires <xref:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.ClientKey>, which supports RSA private keys only and is available on .NET only. On .NET Framework the certificate must therefore be a PKCS#12 file.
 
 The ODBC driver's `file:` path prefix is not accepted. Specify the certificate and key file paths directly.
 
@@ -352,7 +352,7 @@ The following example opens a loopback connection to SQL Server on Linux using a
         The private key path, or <see langword="String.Empty" /> if none has been supplied.
       </value>
       <remarks>
-        This property corresponds to the "Client Key" and "ClientKey" keys within the connection string. The key must be an unencrypted RSA PKCS#1 or an RSA PKCS#8 private key; password-protected keys must use encrypted PKCS#8. To use another key algorithm, provide a PKCS#12 (PFX or P12) file through <see cref="P:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.ClientCertificate" />. This property cannot be combined with a PKCS#12 certificate, which already contains its private key. This property is available on .NET only.
+        This property corresponds to the "Client Key" and "ClientKey" keys within the connection string. The key must be an unencrypted RSA PKCS#1 or an RSA PKCS#8 private key; password-protected keys must use encrypted PKCS#8. To use another key algorithm, provide a PKCS#12 (PFX or P12) file through <see cref="P:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.ClientCertificate" />. This property cannot be combined with a PKCS#12 certificate, which already contains its private key. Detached private keys are supported on .NET only; on .NET Framework, supply a PKCS#12 certificate instead.
       </remarks>
     </ClientKey>
     <ClientKeyPassword>
@@ -365,7 +365,7 @@ The following example opens a loopback connection to SQL Server on Linux using a
       <remarks>
         <format type="text/markdown">
           <![CDATA[
-This property corresponds to the "Client Key Password" and "ClientKeyPassword" keys within the connection string. It is available on .NET only.
+This property corresponds to the "Client Key Password" and "ClientKeyPassword" keys within the connection string.
 
 The value is removed from <xref:Microsoft.Data.SqlClient.SqlConnection.ConnectionString> after the connection is opened unless `Persist Security Info=true`. Store this value in a secure secret provider rather than source code or configuration committed to source control.
 ]]>

--- a/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs
@@ -1357,6 +1357,19 @@ public sealed class SqlConnectionStringBuilder : System.Data.Common.DbConnection
     [System.ComponentModel.DisplayNameAttribute("Server Certificate")]
     [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]
     public string ServerCertificate { get { throw null; } set { } }
+    /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/ClientCertificate/*'/>
+    [System.ComponentModel.DisplayNameAttribute("Client Certificate")]
+    [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]
+    public string ClientCertificate { get { throw null; } set { } }
+    /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/ClientKey/*'/>
+    [System.ComponentModel.DisplayNameAttribute("Client Key")]
+    [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]
+    public string ClientKey { get { throw null; } set { } }
+    /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/ClientKeyPassword/*'/>
+    [System.ComponentModel.DisplayNameAttribute("Client Key Password")]
+    [System.ComponentModel.PasswordPropertyTextAttribute(true)]
+    [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]
+    public string ClientKeyPassword { get { throw null; } set { } }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/Enlist/*'/>
     [System.ComponentModel.DisplayNameAttribute("Enlist")]
     [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]

--- a/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs
@@ -1357,6 +1357,7 @@ public sealed class SqlConnectionStringBuilder : System.Data.Common.DbConnection
     [System.ComponentModel.DisplayNameAttribute("Server Certificate")]
     [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]
     public string ServerCertificate { get { throw null; } set { } }
+#if NET
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/ClientCertificate/*'/>
     [System.ComponentModel.DisplayNameAttribute("Client Certificate")]
     [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]
@@ -1370,6 +1371,7 @@ public sealed class SqlConnectionStringBuilder : System.Data.Common.DbConnection
     [System.ComponentModel.PasswordPropertyTextAttribute(true)]
     [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]
     public string ClientKeyPassword { get { throw null; } set { } }
+#endif
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/Enlist/*'/>
     [System.ComponentModel.DisplayNameAttribute("Enlist")]
     [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]

--- a/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs
@@ -1357,7 +1357,6 @@ public sealed class SqlConnectionStringBuilder : System.Data.Common.DbConnection
     [System.ComponentModel.DisplayNameAttribute("Server Certificate")]
     [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]
     public string ServerCertificate { get { throw null; } set { } }
-#if NET
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/ClientCertificate/*'/>
     [System.ComponentModel.DisplayNameAttribute("Client Certificate")]
     [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]
@@ -1371,7 +1370,6 @@ public sealed class SqlConnectionStringBuilder : System.Data.Common.DbConnection
     [System.ComponentModel.PasswordPropertyTextAttribute(true)]
     [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]
     public string ClientKeyPassword { get { throw null; } set { } }
-#endif
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/Enlist/*'/>
     [System.ComponentModel.DisplayNameAttribute("Enlist")]
     [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Crypt32/Crypt32.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Crypt32/Crypt32.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Interop.Windows.Crypt32
+{
+    internal static class Crypt32
+    {
+        private const string DllName = "crypt32.dll";
+
+        /// <summary>
+        /// <a href="https://learn.microsoft.com/windows/win32/api/wincrypt/nf-wincrypt-certduplicatecertificatecontext">CertDuplicateCertificateContext</a>
+        /// increments the reference count of a certificate context.
+        /// </summary>
+        /// <param name="certContext">The certificate context to duplicate.</param>
+        /// <returns>
+        /// The duplicated certificate context, which the caller must release with
+        /// <c>CertFreeCertificateContext</c>, or <see cref="IntPtr.Zero" /> on failure.
+        /// </returns>
+        [DllImport(DllName, SetLastError = true)]
+        internal static extern IntPtr CertDuplicateCertificateContext(IntPtr certContext);
+    }
+}

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/AuthProviderInfo.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/AuthProviderInfo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Runtime.InteropServices;
 
 namespace Interop.Windows.Sni
@@ -12,12 +13,16 @@ namespace Interop.Windows.Sni
         public uint flags;
         [MarshalAs(UnmanagedType.Bool)]
         public bool tlsFirst;
-        public object certContext;
+        /// <summary>
+        /// A <c>PCCERT_CONTEXT</c> for the client certificate to present, or
+        /// <see cref="IntPtr.Zero" />. SNI duplicates the context, so the caller retains ownership.
+        /// </summary>
+        public IntPtr certContext;
         [MarshalAs(UnmanagedType.LPWStr)]
         public string certId;
         [MarshalAs(UnmanagedType.Bool)]
         public bool certHash;
-        public object clientCertificateCallbackContext;
+        public IntPtr clientCertificateCallbackContext;
         public SqlClientCertificateDelegate clientCertificateCallback;
         [MarshalAs(UnmanagedType.LPWStr)]
         public string serverCertFileName;

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/AuthProviderInfo.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/AuthProviderInfo.cs
@@ -14,12 +14,22 @@ namespace Interop.Windows.Sni
         [MarshalAs(UnmanagedType.Bool)]
         public bool tlsFirst;
         /// <summary>
-        /// A <c>PCCERT_CONTEXT</c> for the client certificate to present, or
-        /// <see cref="IntPtr.Zero" />. SNI duplicates the context, so the caller retains ownership.
+        /// A <c>PCCERT_CONTEXT</c> reserved by the SNI header. The shipping provider never reads
+        /// this field, so a client certificate must be supplied through <see cref="certId" /> or
+        /// <see cref="clientCertificateCallback" /> instead.
         /// </summary>
         public IntPtr certContext;
+        /// <summary>
+        /// The SHA-1 hash or subject name of the client certificate to present, or
+        /// <see langword="null" /> to disable certificate authentication. SNI searches the
+        /// LocalMachine and CurrentUser personal stores for a match before falling back to
+        /// <see cref="clientCertificateCallback" />.
+        /// </summary>
         [MarshalAs(UnmanagedType.LPWStr)]
         public string certId;
+        /// <summary>
+        /// Whether <see cref="certId" /> is a SHA-1 hash rather than a subject name.
+        /// </summary>
         [MarshalAs(UnmanagedType.Bool)]
         public bool certHash;
         public IntPtr clientCertificateCallbackContext;

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/Delegates.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/Delegates.cs
@@ -9,6 +9,31 @@ namespace Interop.Windows.Sni
 {
     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     internal delegate void SqlAsyncCallbackDelegate(IntPtr m_ConsKey, IntPtr pPacket, uint dwError);
-    
-    internal delegate IntPtr SqlClientCertificateDelegate(IntPtr pCallbackContext);
+
+    /// <summary>
+    /// Supplies a client certificate to SNI when neither the LocalMachine nor the CurrentUser
+    /// personal store holds a certificate matching <paramref name="certId" />.
+    /// </summary>
+    /// <param name="callbackContext">The context supplied in <see cref="AuthProviderInfo.clientCertificateCallbackContext" />.</param>
+    /// <param name="certHash">Whether <paramref name="certId" /> is a SHA-1 hash rather than a subject name.</param>
+    /// <param name="certId">The certificate identifier that the store lookup failed to resolve.</param>
+    /// <param name="certContext">
+    /// Receives a <c>PCCERT_CONTEXT</c> that SNI releases with <c>CertFreeCertificateContext</c>.
+    /// </param>
+    /// <param name="keyContainerFlags">Receives the flags used to delete a temporary key container.</param>
+    /// <param name="keyContainerLength">The capacity, in characters, of <paramref name="keyContainer" />.</param>
+    /// <param name="keyContainer">
+    /// A caller-allocated buffer that receives the name of a temporary key container to delete when
+    /// the connection closes. Leaving it empty tells SNI that there is nothing to clean up.
+    /// </param>
+    /// <returns>A Windows error code, where zero indicates success.</returns>
+    [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode)]
+    internal delegate uint SqlClientCertificateDelegate(
+        IntPtr callbackContext,
+        [MarshalAs(UnmanagedType.Bool)] bool certHash,
+        [MarshalAs(UnmanagedType.LPWStr)] string certId,
+        out IntPtr certContext,
+        out uint keyContainerFlags,
+        uint keyContainerLength,
+        IntPtr keyContainer);
 }

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
@@ -65,12 +65,6 @@ namespace Microsoft.Data.SqlClient
             Provider providerEnum,
             AuthProviderInfo authInfo)
         {
-            // The native client-certificate fallback callback is declared by SNI but is not
-            // implemented by the shipping provider, so a certificate must be supplied through
-            // AuthProviderInfo.certContext or AuthProviderInfo.certId instead.
-            Debug.Assert(authInfo.clientCertificateCallback == null,
-                "SNI does not invoke the client certificate callback; use certContext or certId.");
-
             uint ret = SniAddProvider(pConn, providerEnum, ref authInfo);
             if (ret == SystemErrors.ERROR_SUCCESS)
             {

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
@@ -65,7 +65,11 @@ namespace Microsoft.Data.SqlClient
             Provider providerEnum,
             AuthProviderInfo authInfo)
         {
-            Debug.Assert(authInfo.clientCertificateCallback == null, "CTAIP support has been removed");
+            // The native client-certificate fallback callback is declared by SNI but is not
+            // implemented by the shipping provider, so a certificate must be supplied through
+            // AuthProviderInfo.certContext or AuthProviderInfo.certId instead.
+            Debug.Assert(authInfo.clientCertificateCallback == null,
+                "SNI does not invoke the client certificate callback; use certContext or certId.");
 
             uint ret = SniAddProvider(pConn, providerEnum, ref authInfo);
             if (ret == SystemErrors.ERROR_SUCCESS)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -1467,6 +1467,12 @@ namespace Microsoft.Data.Common
         internal static ArgumentException InvalidMixedArgumentOfSecureCredentialAndIntegratedSecurity()
             => Argument(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfSecureCredentialAndIntegratedSecurity));
 
+        internal static InvalidOperationException InvalidMixedUsageOfClientCertificateAuthentication()
+            => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfClientCertificateAuthentication));
+
+        internal static ArgumentException InvalidMixedArgumentOfClientCertificateAuthentication()
+            => Argument(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfClientCertificateAuthentication));
+
         internal static InvalidOperationException InvalidMixedUsageOfAccessTokenAndIntegratedSecurity()
             => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfAccessTokenAndIntegratedSecurity));
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -395,6 +395,13 @@ namespace Microsoft.Data.Common
             TraceExceptionAsReturnValue(e);
             return e;
         }
+
+        internal static AuthenticationException SSLCertificateAuthenticationException(string message, Exception innerException)
+        {
+            AuthenticationException e = new(message, innerException);
+            TraceExceptionAsReturnValue(e);
+            return e;
+        }
         #endregion
 
         #region Helper Functions

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ConnectionString/DbConnectionString.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ConnectionString/DbConnectionString.netfx.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Data.Common
 
             // grab all the parsed details from DbConnectionOptions
             _encryptedUsersConnectionString = connectionOptions.UsersConnectionString(false);
-            _hasPassword = connectionOptions._hasPasswordKeyword;
+            _hasPassword = connectionOptions.HasSensitiveInfoKeyword;
             _parsetable = connectionOptions.Parsetable;
             _keychain = connectionOptions._keyChain;
 
@@ -117,9 +117,13 @@ namespace Microsoft.Data.Common
                 {
                     _parsetable[DbConnectionStringSynonyms.Pwd] = star;
                 }
+                if (_parsetable.ContainsKey(DbConnectionStringKeywords.ClientKeyPassword))
+                {
+                    _parsetable[DbConnectionStringKeywords.ClientKeyPassword] = star;
+                }
 
-                // replace user's password/pwd value with "*" in the linked list and build a new string
-                _keychain = connectionOptions.ReplacePasswordPwd(out _encryptedUsersConnectionString, true);
+                // replace sensitive values with "*" in the linked list and build a new string
+                _keychain = connectionOptions.ReplaceSensitiveValues(out _encryptedUsersConnectionString, true);
             }
 
             if (!string.IsNullOrEmpty(restrictions))

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ConnectionString/DbConnectionStringDefaults.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ConnectionString/DbConnectionStringDefaults.cs
@@ -20,6 +20,9 @@ namespace Microsoft.Data.Common.ConnectionString
         internal static readonly SqlAuthenticationMethod Authentication = SqlAuthenticationMethod.NotSpecified;
         internal const SqlConnectionColumnEncryptionSetting ColumnEncryptionSetting = SqlConnectionColumnEncryptionSetting.Disabled;
         internal const int CommandTimeout = 30;
+        internal const string ClientCertificate = "";
+        internal const string ClientKey = "";
+        internal const string ClientKeyPassword = "";
         internal const int ConnectRetryCount = 1;
         internal const int ConnectRetryInterval = 10;
         internal const int ConnectTimeout = 15;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ConnectionString/DbConnectionStringKeywords.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ConnectionString/DbConnectionStringKeywords.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Data.Common.ConnectionString
         internal const string AttachDbFilename = "AttachDbFilename";
         internal const string AttestationProtocol = "Attestation Protocol";
         internal const string Authentication = "Authentication";
+        internal const string ClientCertificate = "Client Certificate";
+        internal const string ClientKey = "Client Key";
+        internal const string ClientKeyPassword = "Client Key Password";
         internal const string ColumnEncryptionSetting = "Column Encryption Setting";
         internal const string CommandTimeout = "Command Timeout";
         internal const string ConnectionReset = "Connection Reset";

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ConnectionString/DbConnectionStringSynonyms.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ConnectionString/DbConnectionStringSynonyms.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Data.Common.ConnectionString
         internal const string Address = "address";
         internal const string App = "app";
         internal const string ApplicationIntent = "applicationintent";
+        internal const string ClientCertificate = "clientcertificate";
+        internal const string ClientKey = "clientkey";
+        internal const string ClientKeyPassword = "clientkeypassword";
         internal const string ColumnEncryption = "columnEncryption";
         internal const string ConnectionLifetime = "connection lifetime";
         internal const string ConnectionTimeout = "connection timeout";

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -2952,8 +2952,8 @@ namespace Microsoft.Data.SqlClient.Connection
             login.timeout = timeoutInSeconds;
             login.userInstance = ConnectionOptions.UserInstance;
             login.hostName = ConnectionOptions.ObtainWorkstationId();
-            login.userName = ConnectionOptions.UserID;
-            login.password = ConnectionOptions.Password;
+            login.userName = ConnectionOptions.UsesClientCertificate ? string.Empty : ConnectionOptions.UserID;
+            login.password = ConnectionOptions.UsesClientCertificate ? string.Empty : ConnectionOptions.Password;
             login.applicationName = ConnectionOptions.ApplicationName;
             login.language = _currentLanguage;
 
@@ -2977,7 +2977,7 @@ namespace Microsoft.Data.SqlClient.Connection
             login.packetSize = PacketSize;
             login.newPassword = newPassword;
             login.readOnlyIntent = ConnectionOptions.ApplicationIntent == ApplicationIntent.ReadOnly;
-            login.credential = _credential;
+            login.credential = ConnectionOptions.UsesClientCertificate ? null : _credential;
 
             if (newSecurePassword != null)
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniHandle.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniHandle.netcore.cs
@@ -19,24 +19,68 @@ namespace Microsoft.Data.SqlClient.ManagedSni
     /// </summary>
     internal abstract class SniHandle
     {
+        private SqlClientCertificateContext _clientCertificateContext;
+
         protected static readonly SslProtocols s_supportedProtocols = SslProtocols.None;
 
         protected static readonly List<SslApplicationProtocol> s_tdsProtocols = new List<SslApplicationProtocol>(1) { new(TdsEnums.TDS8_Protocol) };
 
-        protected static async Task AuthenticateAsClientAsync(SslStream sslStream, string serverNameIndication, X509CertificateCollection certificate, CancellationToken token)
+        protected static async Task AuthenticateAsClientAsync(
+            SslStream sslStream,
+            string serverNameIndication,
+            SslStreamCertificateContext certificateContext,
+            bool useTds8Alpn,
+            CancellationToken token)
         {
             SslClientAuthenticationOptions sslClientOptions = new()
             {
                 TargetHost = serverNameIndication,
-                ApplicationProtocols = s_tdsProtocols,
-                ClientCertificates = certificate
+                EnabledSslProtocols = s_supportedProtocols,
+                ClientCertificateContext = certificateContext,
             };
+            if (useTds8Alpn)
+            {
+                sslClientOptions.ApplicationProtocols = s_tdsProtocols;
+            }
+
             await sslStream.AuthenticateAsClientAsync(sslClientOptions, token);
         }
 
-        protected static void AuthenticateAsClient(SslStream sslStream, string serverNameIndication, X509CertificateCollection certificate)
+        protected static void AuthenticateAsClient(
+            SslStream sslStream,
+            string serverNameIndication,
+            SslStreamCertificateContext certificateContext,
+            bool useTds8Alpn)
         {
-            AuthenticateAsClientAsync(sslStream, serverNameIndication, certificate, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+            AuthenticateAsClientAsync(
+                sslStream,
+                serverNameIndication,
+                certificateContext,
+                useTds8Alpn,
+                CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+
+        protected SslStreamCertificateContext GetClientCertificateContext(
+            string certificatePath,
+            string keyPath,
+            string keyPassword)
+        {
+            if (string.IsNullOrEmpty(certificatePath))
+            {
+                return null;
+            }
+
+            _clientCertificateContext ??= SqlClientCertificateLoader.Load(
+                certificatePath,
+                keyPath,
+                keyPassword);
+            return _clientCertificateContext.SslContext;
+        }
+
+        protected void DisposeClientCertificate()
+        {
+            _clientCertificateContext?.Dispose();
+            _clientCertificateContext = null;
         }
 
         /// <summary>
@@ -89,7 +133,7 @@ namespace Microsoft.Data.SqlClient.ManagedSni
         /// <summary>
         /// Enable SSL
         /// </summary>
-        public abstract uint EnableSsl(uint options);
+        public abstract uint EnableSsl(uint options, string clientCertificate, string clientKey, string clientKeyPassword);
 
         /// <summary>
         /// Disable SSL

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniHandle.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniHandle.netcore.cs
@@ -8,9 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.Net.Security;
 using System.Security.Authentication;
-using System.Security.Cryptography.X509Certificates;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.Data.SqlClient.ManagedSni
 {
@@ -25,12 +22,17 @@ namespace Microsoft.Data.SqlClient.ManagedSni
 
         protected static readonly List<SslApplicationProtocol> s_tdsProtocols = new List<SslApplicationProtocol>(1) { new(TdsEnums.TDS8_Protocol) };
 
-        protected static async Task AuthenticateAsClientAsync(
-            SslStream sslStream,
+        /// <summary>
+        /// Builds the TLS client options used for both the synchronous and asynchronous handshakes.
+        /// </summary>
+        /// <param name="serverNameIndication">The server name to present as SNI.</param>
+        /// <param name="certificateContext">The client certificate chain, or <see langword="null" /> when no client certificate is configured.</param>
+        /// <param name="useTds8Alpn">Whether to advertise the TDS 8.0 ALPN protocol.</param>
+        /// <returns>The configured client authentication options.</returns>
+        private static SslClientAuthenticationOptions CreateClientAuthenticationOptions(
             string serverNameIndication,
             SslStreamCertificateContext certificateContext,
-            bool useTds8Alpn,
-            CancellationToken token)
+            bool useTds8Alpn)
         {
             SslClientAuthenticationOptions sslClientOptions = new()
             {
@@ -43,21 +45,31 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                 sslClientOptions.ApplicationProtocols = s_tdsProtocols;
             }
 
-            await sslStream.AuthenticateAsClientAsync(sslClientOptions, token);
+            return sslClientOptions;
         }
 
+        /// <summary>
+        /// Performs the TLS handshake synchronously.
+        /// </summary>
+        /// <remarks>
+        /// This intentionally uses the synchronous <c>AuthenticateAsClient</c> overload. Blocking on
+        /// the asynchronous overload would require a second thread to run the continuation, which
+        /// deadlocks under thread-pool starvation and on single-threaded synchronization contexts.
+        /// </remarks>
+        /// <param name="sslStream">The stream to authenticate.</param>
+        /// <param name="serverNameIndication">The server name to present as SNI.</param>
+        /// <param name="certificateContext">The client certificate chain, or <see langword="null" /> when no client certificate is configured.</param>
+        /// <param name="useTds8Alpn">Whether to advertise the TDS 8.0 ALPN protocol.</param>
         protected static void AuthenticateAsClient(
             SslStream sslStream,
             string serverNameIndication,
             SslStreamCertificateContext certificateContext,
             bool useTds8Alpn)
         {
-            AuthenticateAsClientAsync(
-                sslStream,
-                serverNameIndication,
-                certificateContext,
-                useTds8Alpn,
-                CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+            SslClientAuthenticationOptions sslClientOptions =
+                CreateClientAuthenticationOptions(serverNameIndication, certificateContext, useTds8Alpn);
+
+            sslStream.AuthenticateAsClient(sslClientOptions);
         }
 
         protected SslStreamCertificateContext GetClientCertificateContext(

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniMarsConnection.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniMarsConnection.netcore.cs
@@ -362,11 +362,11 @@ namespace Microsoft.Data.SqlClient.ManagedSni
         /// <summary>
         /// Enable SSL
         /// </summary>
-        public uint EnableSsl(uint options)
+        public uint EnableSsl(uint options, string clientCertificate, string clientKey, string clientKeyPassword)
         {
             using (SqlClientSNIEventScope.Create(nameof(SniMarsConnection)))
             {
-                return _lowerHandle.EnableSsl(options);
+                return _lowerHandle.EnableSsl(options, clientCertificate, clientKey, clientKeyPassword);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniMarsHandle.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniMarsHandle.netcore.cs
@@ -555,7 +555,8 @@ namespace Microsoft.Data.SqlClient.ManagedSni
         {
         }
 
-        public override uint EnableSsl(uint options) => _connection.EnableSsl(options);
+        public override uint EnableSsl(uint options, string clientCertificate, string clientKey, string clientKeyPassword)
+            => _connection.EnableSsl(options, clientCertificate, clientKey, clientKeyPassword);
 
         public override void DisableSsl() => _connection.DisableSsl();
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniNpHandle.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniNpHandle.netcore.cs
@@ -178,6 +178,8 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                     _pipeStream = null;
                 }
 
+                DisposeClientCertificate();
+
                 //Release any references held by _stream.
                 _stream = null;
                 SqlClientEventSource.Log.TrySNITraceEvent(nameof(SniNpHandle), EventType.INFO, "Connection Id {0}, All streams disposed and references cleared.", args0: _connectionId);
@@ -326,22 +328,22 @@ namespace Microsoft.Data.SqlClient.ManagedSni
             _sendCallback = sendCallback;
         }
 
-        public override uint EnableSsl(uint options)
+        public override uint EnableSsl(uint options, string clientCertificate, string clientKey, string clientKeyPassword)
         {
             using (SqlClientSNIEventScope.Create(nameof(SniNpHandle)))
             {
                 _validateCert = (options & TdsEnums.SNI_SSL_VALIDATE_CERTIFICATE) != 0;
                 try
                 {
-                    if (_tlsFirst)
-                    {
-                        AuthenticateAsClient(_sslStream, _targetServer, null);
-                    }
-                    else
-                    {
-                        // TODO: Resolve whether to send _serverNameIndication or _targetServer. _serverNameIndication currently results in error. Why?
-                        _sslStream.AuthenticateAsClient(_targetServer, null, s_supportedProtocols, false);
-                    }
+                    SslStreamCertificateContext clientCertificateContext = GetClientCertificateContext(
+                        clientCertificate,
+                        clientKey,
+                        clientKeyPassword);
+                    AuthenticateAsClient(
+                        _sslStream,
+                        _targetServer,
+                        clientCertificateContext,
+                        useTds8Alpn: _tlsFirst);
                     if (_sslOverTdsStream is not null)
                     {
                         _sslOverTdsStream.FinishHandshake();

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniTcpHandle.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniTcpHandle.netcore.cs
@@ -71,6 +71,8 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                     _tcpStream = null;
                 }
 
+                DisposeClientCertificate();
+
                 //Release any references held by _stream.
                 _stream = null;
                 SqlClientEventSource.Log.TrySNITraceEvent(nameof(SniTcpHandle), EventType.INFO, "Connection Id {0}, All streams disposed.", args0: _connectionId);
@@ -722,7 +724,7 @@ namespace Microsoft.Data.SqlClient.ManagedSni
         /// <summary>
         /// Enable SSL
         /// </summary>
-        public override uint EnableSsl(uint options)
+        public override uint EnableSsl(uint options, string clientCertificate, string clientKey, string clientKeyPassword)
         {
             using (SqlClientSNIEventScope.Create(nameof(SniHandle)))
             {
@@ -730,14 +732,15 @@ namespace Microsoft.Data.SqlClient.ManagedSni
 
                 try
                 {
-                    if (_tlsFirst)
-                    {
-                        AuthenticateAsClient(_sslStream, _targetServer, null);
-                    }
-                    else
-                    {
-                        _sslStream.AuthenticateAsClient(_targetServer, null, s_supportedProtocols, false);
-                    }
+                    SslStreamCertificateContext clientCertificateContext = GetClientCertificateContext(
+                        clientCertificate,
+                        clientKey,
+                        clientKeyPassword);
+                    AuthenticateAsClient(
+                        _sslStream,
+                        _targetServer,
+                        clientCertificateContext,
+                        useTds8Alpn: _tlsFirst);
                     if (_sslOverTdsStream is not null)
                     {
                         _sslOverTdsStream.FinishHandshake();

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SqlClientCertificateLoader.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SqlClientCertificateLoader.netcore.cs
@@ -1,0 +1,472 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NET
+
+using System;
+using System.IO;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace Microsoft.Data.SqlClient.ManagedSni
+{
+    internal sealed class SqlClientCertificateContext : IDisposable
+    {
+        private readonly X509Certificate2Collection _additionalCertificates;
+        private bool _disposed;
+
+        internal SqlClientCertificateContext(
+            X509Certificate2 certificate,
+            X509Certificate2Collection additionalCertificates)
+        {
+            Certificate = certificate;
+            _additionalCertificates = additionalCertificates;
+            SslContext = SslStreamCertificateContext.Create(
+                certificate,
+                additionalCertificates,
+                offline: true);
+        }
+
+        internal X509Certificate2 Certificate { get; }
+
+        internal SslStreamCertificateContext SslContext { get; }
+
+        internal int AdditionalCertificateCount => _additionalCertificates?.Count ?? 0;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            Certificate.Dispose();
+            DisposeCertificates(_additionalCertificates);
+        }
+
+        private static void DisposeCertificates(X509Certificate2Collection certificates)
+        {
+            if (certificates == null)
+            {
+                return;
+            }
+
+            foreach (X509Certificate2 certificate in certificates)
+            {
+                certificate.Dispose();
+            }
+        }
+    }
+
+    internal static class SqlClientCertificateLoader
+    {
+        private static X509KeyStorageFlags PrivateKeyStorageFlags =>
+            OsConstants.IsWindows
+                ? X509KeyStorageFlags.UserKeySet
+                : X509KeyStorageFlags.EphemeralKeySet;
+
+        internal static SqlClientCertificateContext Load(string certificatePath, string keyPath, string keyPassword)
+        {
+            if (string.IsNullOrEmpty(certificatePath))
+            {
+                return null;
+            }
+
+            X509Certificate2 certificate = null;
+            X509Certificate2Collection additionalCertificates = null;
+            try
+            {
+                certificate = string.IsNullOrEmpty(keyPath)
+                    ? LoadPkcs12(
+                        certificatePath,
+                        keyPassword,
+                        out additionalCertificates)
+                    : LoadWithPrivateKey(
+                        certificatePath,
+                        keyPath,
+                        keyPassword,
+                        out additionalCertificates);
+
+                if (!certificate.HasPrivateKey)
+                {
+                    throw new AuthenticationException(StringsHelper.GetString(Strings.SQL_ClientCertificateMissingPrivateKey));
+                }
+
+                DateTime now = DateTime.Now;
+                if (now < certificate.NotBefore || now > certificate.NotAfter)
+                {
+                    throw new AuthenticationException(StringsHelper.GetString(Strings.SQL_ClientCertificateNotValid));
+                }
+
+                SqlClientCertificateContext context = new(certificate, additionalCertificates);
+                certificate = null;
+                additionalCertificates = null;
+                return context;
+            }
+            catch (Exception e) when (
+                e is CryptographicException or
+                IOException or
+                UnauthorizedAccessException or
+                ArgumentException)
+            {
+                throw new AuthenticationException(StringsHelper.GetString(Strings.SQL_ClientCertificateLoadFailed), e);
+            }
+            finally
+            {
+                certificate?.Dispose();
+                DisposeCertificates(additionalCertificates);
+            }
+        }
+
+        private static X509Certificate2 LoadPkcs12(
+            string certificatePath,
+            string password,
+            out X509Certificate2Collection additionalCertificates)
+        {
+            string effectivePassword = string.IsNullOrEmpty(password) ? null : password;
+            X509KeyStorageFlags collectionStorageFlags = PrivateKeyStorageFlags;
+            if (OsConstants.IsWindows)
+            {
+                collectionStorageFlags |= X509KeyStorageFlags.Exportable;
+            }
+
+            X509Certificate2Collection certificates;
+#if NET9_0_OR_GREATER
+            certificates = X509CertificateLoader.LoadPkcs12CollectionFromFile(
+                certificatePath,
+                effectivePassword,
+                collectionStorageFlags);
+#else
+            certificates = new X509Certificate2Collection();
+#pragma warning disable SYSLIB0057
+            certificates.Import(
+                certificatePath,
+                effectivePassword,
+                collectionStorageFlags);
+#pragma warning restore SYSLIB0057
+#endif
+
+            additionalCertificates = null;
+            try
+            {
+                int leafCertificateIndex = -1;
+                for (int index = 0; index < certificates.Count; index++)
+                {
+                    if (certificates[index].HasPrivateKey)
+                    {
+                        leafCertificateIndex = index;
+                        break;
+                    }
+                }
+
+                if (leafCertificateIndex < 0)
+                {
+                    throw new CryptographicException(StringsHelper.GetString(Strings.SQL_ClientCertificateMissingPrivateKey));
+                }
+
+                additionalCertificates = new X509Certificate2Collection();
+                for (int index = 0; index < certificates.Count; index++)
+                {
+                    if (index != leafCertificateIndex)
+                    {
+                        additionalCertificates.Add(certificates[index]);
+                    }
+                }
+
+                return MaterializeForTls(certificates[leafCertificateIndex]);
+            }
+            catch
+            {
+                DisposeCertificates(certificates);
+                additionalCertificates = null;
+                throw;
+            }
+        }
+
+        private static X509Certificate2 LoadWithPrivateKey(
+            string certificatePath,
+            string keyPath,
+            string password,
+            out X509Certificate2Collection additionalCertificates)
+        {
+            X509Certificate2Collection publicCertificates = LoadPublicCertificates(certificatePath);
+            additionalCertificates = null;
+            using RSA privateKey = RSA.Create();
+            byte[] keyBytes = null;
+
+            try
+            {
+                keyBytes = File.ReadAllBytes(keyPath);
+                try
+                {
+                    ImportRsaPrivateKey(privateKey, keyBytes, password);
+                }
+                catch (Exception e) when (
+                    (e is CryptographicException || e is ArgumentException) &&
+                    CanImportEcdsaPrivateKey(keyBytes, password))
+                {
+                    throw new AuthenticationException(
+                        StringsHelper.GetString(Strings.SQL_ClientCertificateUnsupportedKeyAlgorithm));
+                }
+
+                X509Certificate2 combinedCertificate = null;
+                int matchingCertificateIndex = -1;
+                for (int index = 0; index < publicCertificates.Count; index++)
+                {
+                    try
+                    {
+                        combinedCertificate = publicCertificates[index].CopyWithPrivateKey(privateKey);
+                        matchingCertificateIndex = index;
+                        break;
+                    }
+                    catch (ArgumentException)
+                    {
+                    }
+                    catch (CryptographicException)
+                    {
+                    }
+                }
+
+                if (combinedCertificate == null)
+                {
+                    throw new CryptographicException(StringsHelper.GetString(Strings.SQL_ClientCertificateLoadFailed));
+                }
+
+                combinedCertificate = MaterializeForTls(combinedCertificate);
+                additionalCertificates = new X509Certificate2Collection();
+                for (int index = 0; index < publicCertificates.Count; index++)
+                {
+                    if (index != matchingCertificateIndex)
+                    {
+                        additionalCertificates.Add(publicCertificates[index]);
+                    }
+                }
+
+                publicCertificates[matchingCertificateIndex].Dispose();
+                return combinedCertificate;
+            }
+            catch
+            {
+                DisposeCertificates(publicCertificates);
+                throw;
+            }
+            finally
+            {
+                if (keyBytes != null)
+                {
+                    CryptographicOperations.ZeroMemory(keyBytes);
+                }
+            }
+        }
+
+        private static X509Certificate2 MaterializeForTls(X509Certificate2 certificate)
+        {
+            if (!OsConstants.IsWindows)
+            {
+                return certificate;
+            }
+
+            // Schannel cannot acquire credentials from an ephemeral private key. Importing
+            // without PersistKeySet creates a temporary user key container that is deleted
+            // when the certificate is disposed.
+            using (certificate)
+            {
+                byte[] pkcs12 = certificate.Export(X509ContentType.Pkcs12);
+                try
+                {
+#if NET9_0_OR_GREATER
+                    return X509CertificateLoader.LoadPkcs12(
+                        pkcs12,
+                        password: null,
+                        X509KeyStorageFlags.UserKeySet);
+#else
+#pragma warning disable SYSLIB0057
+                    return new X509Certificate2(
+                        pkcs12,
+                        (string)null,
+                        X509KeyStorageFlags.UserKeySet);
+#pragma warning restore SYSLIB0057
+#endif
+                }
+                finally
+                {
+                    CryptographicOperations.ZeroMemory(pkcs12);
+                }
+            }
+        }
+
+        private static X509Certificate2Collection LoadPublicCertificates(string certificatePath)
+        {
+            byte[] certificateBytes = File.ReadAllBytes(certificatePath);
+            try
+            {
+                if (IsPem(certificateBytes))
+                {
+                    char[] certificateCharacters = Encoding.ASCII.GetChars(certificateBytes);
+                    try
+                    {
+                        X509Certificate2Collection pemCertificates = new();
+                        pemCertificates.ImportFromPem(certificateCharacters);
+                        if (pemCertificates.Count == 0)
+                        {
+                            throw new CryptographicException(StringsHelper.GetString(Strings.SQL_ClientCertificateLoadFailed));
+                        }
+
+                        return pemCertificates;
+                    }
+                    finally
+                    {
+                        Array.Clear(certificateCharacters, 0, certificateCharacters.Length);
+                    }
+                }
+
+#if NET9_0_OR_GREATER
+                X509Certificate2 certificate = X509CertificateLoader.LoadCertificate(certificateBytes);
+#else
+#pragma warning disable SYSLIB0057
+                X509Certificate2 certificate = new(certificateBytes);
+#pragma warning restore SYSLIB0057
+#endif
+                return new X509Certificate2Collection(certificate);
+            }
+            finally
+            {
+                Array.Clear(certificateBytes, 0, certificateBytes.Length);
+            }
+        }
+
+        private static void ImportDerPrivateKey(RSA privateKey, byte[] keyBytes, string password)
+        {
+            int bytesRead;
+            if (!string.IsNullOrEmpty(password))
+            {
+                privateKey.ImportEncryptedPkcs8PrivateKey(password, keyBytes, out bytesRead);
+            }
+            else
+            {
+                try
+                {
+                    privateKey.ImportPkcs8PrivateKey(keyBytes, out bytesRead);
+                }
+                catch (CryptographicException)
+                {
+                    privateKey.ImportRSAPrivateKey(keyBytes, out bytesRead);
+                }
+            }
+
+            if (bytesRead != keyBytes.Length)
+            {
+                throw new CryptographicException(StringsHelper.GetString(Strings.SQL_ClientCertificateLoadFailed));
+            }
+        }
+
+        private static void ImportRsaPrivateKey(RSA privateKey, byte[] keyBytes, string password)
+        {
+            if (!IsPem(keyBytes))
+            {
+                ImportDerPrivateKey(privateKey, keyBytes, password);
+                return;
+            }
+
+            char[] keyCharacters = Encoding.ASCII.GetChars(keyBytes);
+            try
+            {
+                if (string.IsNullOrEmpty(password))
+                {
+                    privateKey.ImportFromPem(keyCharacters);
+                }
+                else
+                {
+                    privateKey.ImportFromEncryptedPem(keyCharacters, password);
+                }
+            }
+            finally
+            {
+                Array.Clear(keyCharacters, 0, keyCharacters.Length);
+            }
+        }
+
+        private static bool CanImportEcdsaPrivateKey(byte[] keyBytes, string password)
+        {
+            if (keyBytes.AsSpan().IndexOf("-----BEGIN EC PRIVATE KEY-----"u8) >= 0)
+            {
+                return true;
+            }
+
+            try
+            {
+                using ECDsa privateKey = ECDsa.Create();
+                if (IsPem(keyBytes))
+                {
+                    char[] keyCharacters = Encoding.ASCII.GetChars(keyBytes);
+                    try
+                    {
+                        if (string.IsNullOrEmpty(password))
+                        {
+                            privateKey.ImportFromPem(keyCharacters);
+                        }
+                        else
+                        {
+                            privateKey.ImportFromEncryptedPem(keyCharacters, password);
+                        }
+                    }
+                    finally
+                    {
+                        Array.Clear(keyCharacters, 0, keyCharacters.Length);
+                    }
+
+                    return true;
+                }
+
+                int bytesRead;
+                if (!string.IsNullOrEmpty(password))
+                {
+                    privateKey.ImportEncryptedPkcs8PrivateKey(password, keyBytes, out bytesRead);
+                }
+                else
+                {
+                    try
+                    {
+                        privateKey.ImportPkcs8PrivateKey(keyBytes, out bytesRead);
+                    }
+                    catch (CryptographicException)
+                    {
+                        privateKey.ImportECPrivateKey(keyBytes, out bytesRead);
+                    }
+                }
+
+                return bytesRead == keyBytes.Length;
+            }
+            catch (Exception e) when (e is CryptographicException or ArgumentException)
+            {
+                return false;
+            }
+        }
+
+        private static bool IsPem(byte[] bytes)
+        {
+            ReadOnlySpan<byte> marker = "-----BEGIN"u8;
+            return bytes.AsSpan().IndexOf(marker) >= 0;
+        }
+
+        private static void DisposeCertificates(X509Certificate2Collection certificates)
+        {
+            if (certificates == null)
+            {
+                return;
+            }
+
+            foreach (X509Certificate2 certificate in certificates)
+            {
+                certificate.Dispose();
+            }
+        }
+    }
+}
+
+#endif

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SqlClientCertificateLoader.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SqlClientCertificateLoader.netcore.cs
@@ -77,6 +77,9 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                 return null;
             }
 
+            ThrowIfOdbcStylePath(certificatePath);
+            ThrowIfOdbcStylePath(keyPath);
+
             X509Certificate2 certificate = null;
             X509Certificate2Collection additionalCertificates = null;
             try
@@ -154,16 +157,7 @@ namespace Microsoft.Data.SqlClient.ManagedSni
             additionalCertificates = null;
             try
             {
-                int leafCertificateIndex = -1;
-                for (int index = 0; index < certificates.Count; index++)
-                {
-                    if (certificates[index].HasPrivateKey)
-                    {
-                        leafCertificateIndex = index;
-                        break;
-                    }
-                }
-
+                int leafCertificateIndex = FindLeafCertificateIndex(certificates);
                 if (leafCertificateIndex < 0)
                 {
                     throw new CryptographicException(StringsHelper.GetString(Strings.SQL_ClientCertificateMissingPrivateKey));
@@ -373,6 +367,14 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                 return;
             }
 
+            // Traditional (PKCS#1) PEM encryption is identified by Proc-Type/DEK-Info headers and is
+            // not supported by RSA.ImportFromEncryptedPem, which reads PKCS#8 EncryptedPrivateKeyInfo.
+            if (keyBytes.AsSpan().IndexOf("Proc-Type:"u8) >= 0)
+            {
+                throw new AuthenticationException(
+                    StringsHelper.GetString(Strings.SQL_ClientCertificateEncryptedPkcs1NotSupported));
+            }
+
             char[] keyCharacters = Encoding.ASCII.GetChars(keyBytes);
             try
             {
@@ -452,6 +454,100 @@ namespace Microsoft.Data.SqlClient.ManagedSni
         {
             ReadOnlySpan<byte> marker = "-----BEGIN"u8;
             return bytes.AsSpan().IndexOf(marker) >= 0;
+        }
+
+        /// <summary>
+        /// Rejects the ODBC driver's <c>file:</c> path syntax, which this driver does not accept.
+        /// </summary>
+        /// <param name="path">The configured certificate or key path.</param>
+        private static void ThrowIfOdbcStylePath(string path)
+        {
+            if (!string.IsNullOrEmpty(path) &&
+                path.StartsWith("file:", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new AuthenticationException(
+                    StringsHelper.GetString(Strings.SQL_ClientCertificateOdbcPathSyntax));
+            }
+        }
+
+        /// <summary>
+        /// Selects the end-entity certificate from a PKCS#12 bundle.
+        /// </summary>
+        /// <remarks>
+        /// A bundle can contain issuer certificates that also carry private keys, and collection
+        /// ordering is provider-specific. The end-entity certificate is therefore identified by
+        /// content rather than by position.
+        /// </remarks>
+        /// <param name="certificates">The certificates loaded from the bundle.</param>
+        /// <returns>The index of the end-entity certificate, or -1 when no private key is present.</returns>
+        private static int FindLeafCertificateIndex(X509Certificate2Collection certificates)
+        {
+            int fallbackIndex = -1;
+            for (int index = 0; index < certificates.Count; index++)
+            {
+                X509Certificate2 candidate = certificates[index];
+                if (!candidate.HasPrivateKey)
+                {
+                    continue;
+                }
+
+                if (fallbackIndex < 0)
+                {
+                    fallbackIndex = index;
+                }
+
+                if (IsCertificateAuthority(candidate) || IssuesAnotherCertificate(certificates, index))
+                {
+                    continue;
+                }
+
+                return index;
+            }
+
+            return fallbackIndex;
+        }
+
+        /// <summary>
+        /// Reports whether the certificate is marked as a certificate authority.
+        /// </summary>
+        /// <param name="certificate">The certificate to inspect.</param>
+        /// <returns><see langword="true" /> when basic constraints mark the certificate as a CA.</returns>
+        private static bool IsCertificateAuthority(X509Certificate2 certificate)
+        {
+            foreach (X509Extension extension in certificate.Extensions)
+            {
+                if (extension is X509BasicConstraintsExtension basicConstraints)
+                {
+                    return basicConstraints.CertificateAuthority;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Reports whether the certificate issued another certificate in the same bundle.
+        /// </summary>
+        /// <param name="certificates">The certificates loaded from the bundle.</param>
+        /// <param name="candidateIndex">The index of the certificate to test.</param>
+        /// <returns><see langword="true" /> when the certificate is an issuer within the bundle.</returns>
+        private static bool IssuesAnotherCertificate(X509Certificate2Collection certificates, int candidateIndex)
+        {
+            byte[] subject = certificates[candidateIndex].SubjectName.RawData;
+            for (int index = 0; index < certificates.Count; index++)
+            {
+                if (index == candidateIndex)
+                {
+                    continue;
+                }
+
+                if (subject.AsSpan().SequenceEqual(certificates[index].IssuerName.RawData))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private static void DisposeCertificates(X509Certificate2Collection certificates)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SqlClientCertificateLoader.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SqlClientCertificateLoader.netcore.cs
@@ -11,9 +11,13 @@ using System.Security.Authentication;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using Microsoft.Data.Common;
 
 namespace Microsoft.Data.SqlClient.ManagedSni
 {
+    /// <summary>
+    /// Owns a client certificate, its issuer chain, and the TLS certificate context built from them.
+    /// </summary>
     internal sealed class SqlClientCertificateContext : IDisposable
     {
         private readonly X509Certificate2Collection _additionalCertificates;
@@ -37,6 +41,9 @@ namespace Microsoft.Data.SqlClient.ManagedSni
 
         internal int AdditionalCertificateCount => _additionalCertificates?.Count ?? 0;
 
+        /// <summary>
+        /// Disposes the certificate and its issuer chain.
+        /// </summary>
         public void Dispose()
         {
             if (_disposed)
@@ -49,6 +56,10 @@ namespace Microsoft.Data.SqlClient.ManagedSni
             DisposeCertificates(_additionalCertificates);
         }
 
+        /// <summary>
+        /// Disposes every certificate in the collection.
+        /// </summary>
+        /// <param name="certificates">The certificates to dispose, or <see langword="null" />.</param>
         private static void DisposeCertificates(X509Certificate2Collection certificates)
         {
             if (certificates == null)
@@ -63,6 +74,9 @@ namespace Microsoft.Data.SqlClient.ManagedSni
         }
     }
 
+    /// <summary>
+    /// Loads the client certificate and private key configured for certificate authentication.
+    /// </summary>
     internal static class SqlClientCertificateLoader
     {
         private static X509KeyStorageFlags PrivateKeyStorageFlags =>
@@ -70,6 +84,14 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                 ? X509KeyStorageFlags.UserKeySet
                 : X509KeyStorageFlags.EphemeralKeySet;
 
+        /// <summary>
+        /// Loads the configured client certificate and private key.
+        /// </summary>
+        /// <param name="certificatePath">The certificate file path.</param>
+        /// <param name="keyPath">The detached private key file path, or <see langword="null" /> when the certificate carries its own key.</param>
+        /// <param name="keyPassword">The certificate or private key password, or <see langword="null" /> when none is configured.</param>
+        /// <returns>The loaded certificate context, or <see langword="null" /> when no certificate is configured.</returns>
+        /// <exception cref="AuthenticationException">The certificate or private key could not be loaded, or is not currently valid.</exception>
         internal static SqlClientCertificateContext Load(string certificatePath, string keyPath, string keyPassword)
         {
             if (string.IsNullOrEmpty(certificatePath))
@@ -97,13 +119,13 @@ namespace Microsoft.Data.SqlClient.ManagedSni
 
                 if (!certificate.HasPrivateKey)
                 {
-                    throw new AuthenticationException(StringsHelper.GetString(Strings.SQL_ClientCertificateMissingPrivateKey));
+                    throw ADP.SSLCertificateAuthenticationException(StringsHelper.GetString(Strings.SQL_ClientCertificateMissingPrivateKey));
                 }
 
                 DateTime now = DateTime.Now;
                 if (now < certificate.NotBefore || now > certificate.NotAfter)
                 {
-                    throw new AuthenticationException(StringsHelper.GetString(Strings.SQL_ClientCertificateNotValid));
+                    throw ADP.SSLCertificateAuthenticationException(StringsHelper.GetString(Strings.SQL_ClientCertificateNotValid));
                 }
 
                 SqlClientCertificateContext context = new(certificate, additionalCertificates);
@@ -117,7 +139,7 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                 UnauthorizedAccessException or
                 ArgumentException)
             {
-                throw new AuthenticationException(StringsHelper.GetString(Strings.SQL_ClientCertificateLoadFailed), e);
+                throw ADP.SSLCertificateAuthenticationException(StringsHelper.GetString(Strings.SQL_ClientCertificateLoadFailed), e);
             }
             finally
             {
@@ -126,6 +148,13 @@ namespace Microsoft.Data.SqlClient.ManagedSni
             }
         }
 
+        /// <summary>
+        /// Loads a PKCS#12 bundle that carries its own private key.
+        /// </summary>
+        /// <param name="certificatePath">The bundle file path.</param>
+        /// <param name="password">The bundle password, or <see langword="null" /> when none is configured.</param>
+        /// <param name="additionalCertificates">Receives the issuer certificates found in the bundle.</param>
+        /// <returns>The end-entity certificate with its private key.</returns>
         private static X509Certificate2 LoadPkcs12(
             string certificatePath,
             string password,
@@ -182,6 +211,14 @@ namespace Microsoft.Data.SqlClient.ManagedSni
             }
         }
 
+        /// <summary>
+        /// Combines a certificate with a detached private key file.
+        /// </summary>
+        /// <param name="certificatePath">The certificate file path.</param>
+        /// <param name="keyPath">The private key file path.</param>
+        /// <param name="password">The private key password, or <see langword="null" /> when the key is not encrypted.</param>
+        /// <param name="additionalCertificates">Receives the issuer certificates supplied alongside the leaf.</param>
+        /// <returns>The end-entity certificate with its private key.</returns>
         private static X509Certificate2 LoadWithPrivateKey(
             string certificatePath,
             string keyPath,
@@ -204,7 +241,7 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                     (e is CryptographicException || e is ArgumentException) &&
                     CanImportEcdsaPrivateKey(keyBytes, password))
                 {
-                    throw new AuthenticationException(
+                    throw ADP.SSLCertificateAuthenticationException(
                         StringsHelper.GetString(Strings.SQL_ClientCertificateUnsupportedKeyAlgorithm));
                 }
 
@@ -258,6 +295,11 @@ namespace Microsoft.Data.SqlClient.ManagedSni
             }
         }
 
+        /// <summary>
+        /// Returns a certificate whose private key Schannel can use for a TLS handshake.
+        /// </summary>
+        /// <param name="certificate">The loaded certificate. It is disposed and replaced on Windows.</param>
+        /// <returns>The certificate to present during the handshake.</returns>
         private static X509Certificate2 MaterializeForTls(X509Certificate2 certificate)
         {
             if (!OsConstants.IsWindows)
@@ -294,6 +336,11 @@ namespace Microsoft.Data.SqlClient.ManagedSni
             }
         }
 
+        /// <summary>
+        /// Reads the public certificates from a PEM or DER certificate file.
+        /// </summary>
+        /// <param name="certificatePath">The certificate file path.</param>
+        /// <returns>The certificates found in the file, leaf first for PEM bundles.</returns>
         private static X509Certificate2Collection LoadPublicCertificates(string certificatePath)
         {
             byte[] certificateBytes = File.ReadAllBytes(certificatePath);
@@ -324,7 +371,7 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                 // as an unspecified certificate-load failure.
                 if (X509Certificate2.GetCertContentType(certificateBytes) == X509ContentType.Pkcs12)
                 {
-                    throw new AuthenticationException(
+                    throw ADP.SSLCertificateAuthenticationException(
                         StringsHelper.GetString(Strings.SQL_ClientKeyWithPkcs12Certificate));
                 }
 
@@ -343,6 +390,12 @@ namespace Microsoft.Data.SqlClient.ManagedSni
             }
         }
 
+        /// <summary>
+        /// Imports a DER-encoded RSA private key.
+        /// </summary>
+        /// <param name="privateKey">The key to populate.</param>
+        /// <param name="keyBytes">The DER-encoded key material.</param>
+        /// <param name="password">The key password, or <see langword="null" /> when the key is not encrypted.</param>
         private static void ImportDerPrivateKey(RSA privateKey, byte[] keyBytes, string password)
         {
             int bytesRead;
@@ -368,6 +421,12 @@ namespace Microsoft.Data.SqlClient.ManagedSni
             }
         }
 
+        /// <summary>
+        /// Imports an RSA private key in PEM or DER form.
+        /// </summary>
+        /// <param name="privateKey">The key to populate.</param>
+        /// <param name="keyBytes">The encoded key material.</param>
+        /// <param name="password">The key password, or <see langword="null" /> when the key is not encrypted.</param>
         private static void ImportRsaPrivateKey(RSA privateKey, byte[] keyBytes, string password)
         {
             if (!IsPem(keyBytes))
@@ -380,7 +439,7 @@ namespace Microsoft.Data.SqlClient.ManagedSni
             // not supported by RSA.ImportFromEncryptedPem, which reads PKCS#8 EncryptedPrivateKeyInfo.
             if (keyBytes.AsSpan().IndexOf("Proc-Type:"u8) >= 0)
             {
-                throw new AuthenticationException(
+                throw ADP.SSLCertificateAuthenticationException(
                     StringsHelper.GetString(Strings.SQL_ClientCertificateEncryptedPkcs1NotSupported));
             }
 
@@ -402,6 +461,13 @@ namespace Microsoft.Data.SqlClient.ManagedSni
             }
         }
 
+        /// <summary>
+        /// Reports whether the key material is an ECDSA private key, so an RSA import failure can be
+        /// reported as an unsupported key algorithm rather than a malformed key.
+        /// </summary>
+        /// <param name="keyBytes">The encoded key material.</param>
+        /// <param name="password">The key password, or <see langword="null" /> when the key is not encrypted.</param>
+        /// <returns><see langword="true" /> when the material parses as an ECDSA private key.</returns>
         private static bool CanImportEcdsaPrivateKey(byte[] keyBytes, string password)
         {
             if (keyBytes.AsSpan().IndexOf("-----BEGIN EC PRIVATE KEY-----"u8) >= 0)
@@ -459,6 +525,11 @@ namespace Microsoft.Data.SqlClient.ManagedSni
             }
         }
 
+        /// <summary>
+        /// Reports whether the bytes contain a PEM armour header.
+        /// </summary>
+        /// <param name="bytes">The file contents to inspect.</param>
+        /// <returns><see langword="true" /> when the contents are PEM encoded.</returns>
         private static bool IsPem(byte[] bytes)
         {
             ReadOnlySpan<byte> marker = "-----BEGIN"u8;
@@ -474,7 +545,7 @@ namespace Microsoft.Data.SqlClient.ManagedSni
             if (!string.IsNullOrEmpty(path) &&
                 path.StartsWith("file:", StringComparison.OrdinalIgnoreCase))
             {
-                throw new AuthenticationException(
+                throw ADP.SSLCertificateAuthenticationException(
                     StringsHelper.GetString(Strings.SQL_ClientCertificateOdbcPathSyntax));
             }
         }
@@ -559,6 +630,10 @@ namespace Microsoft.Data.SqlClient.ManagedSni
             return false;
         }
 
+        /// <summary>
+        /// Disposes every certificate in the collection.
+        /// </summary>
+        /// <param name="certificates">The certificates to dispose, or <see langword="null" />.</param>
         private static void DisposeCertificates(X509Certificate2Collection certificates)
         {
             if (certificates == null)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SqlClientCertificateLoader.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SqlClientCertificateLoader.netcore.cs
@@ -319,6 +319,15 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                     }
                 }
 
+                // A PKCS#12 bundle already carries its private key. Combining it with a detached key
+                // is a misconfiguration, and the certificate loader below would otherwise report it
+                // as an unspecified certificate-load failure.
+                if (X509Certificate2.GetCertContentType(certificateBytes) == X509ContentType.Pkcs12)
+                {
+                    throw new AuthenticationException(
+                        StringsHelper.GetString(Strings.SQL_ClientKeyWithPkcs12Certificate));
+                }
+
 #if NET9_0_OR_GREATER
                 X509Certificate2 certificate = X509CertificateLoader.LoadCertificate(certificateBytes);
 #else

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientCertificateLoader.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientCertificateLoader.cs
@@ -20,8 +20,10 @@ namespace Microsoft.Data.SqlClient
     /// </summary>
     /// <remarks>
     /// On .NET this also builds the <c>SslStreamCertificateContext</c> that managed SNI hands to
-    /// <c>SslStream</c>. Native SNI instead consumes the <c>PCCERT_CONTEXT</c> exposed by
-    /// <see cref="Certificate" />.
+    /// <c>SslStream</c>, which presents the issuer chain during the handshake. Native SNI instead
+    /// consumes the <c>PCCERT_CONTEXT</c> exposed by <see cref="Certificate" />, and
+    /// <c>SNIAuthProviderInfo</c> has no field for the chain, so only the end-entity certificate is
+    /// presented on that path.
     /// </remarks>
     internal sealed class SqlClientCertificateContext : IDisposable
     {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientCertificateLoader.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientCertificateLoader.cs
@@ -2,22 +2,27 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NET
-
 using System;
 using System.IO;
-using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using Microsoft.Data.Common;
+#if NET
+using System.Net.Security;
+using System.Text;
+#endif
 
-namespace Microsoft.Data.SqlClient.ManagedSni
+namespace Microsoft.Data.SqlClient
 {
     /// <summary>
-    /// Owns a client certificate, its issuer chain, and the TLS certificate context built from them.
+    /// Owns a client certificate and its issuer chain.
     /// </summary>
+    /// <remarks>
+    /// On .NET this also builds the <c>SslStreamCertificateContext</c> that managed SNI hands to
+    /// <c>SslStream</c>. Native SNI instead consumes the <c>PCCERT_CONTEXT</c> exposed by
+    /// <see cref="Certificate" />.
+    /// </remarks>
     internal sealed class SqlClientCertificateContext : IDisposable
     {
         private readonly X509Certificate2Collection _additionalCertificates;
@@ -29,15 +34,19 @@ namespace Microsoft.Data.SqlClient.ManagedSni
         {
             Certificate = certificate;
             _additionalCertificates = additionalCertificates;
+#if NET
             SslContext = SslStreamCertificateContext.Create(
                 certificate,
                 additionalCertificates,
                 offline: true);
+#endif
         }
 
         internal X509Certificate2 Certificate { get; }
 
+#if NET
         internal SslStreamCertificateContext SslContext { get; }
+#endif
 
         internal int AdditionalCertificateCount => _additionalCertificates?.Count ?? 0;
 
@@ -80,9 +89,14 @@ namespace Microsoft.Data.SqlClient.ManagedSni
     internal static class SqlClientCertificateLoader
     {
         private static X509KeyStorageFlags PrivateKeyStorageFlags =>
+#if NET
             OsConstants.IsWindows
                 ? X509KeyStorageFlags.UserKeySet
                 : X509KeyStorageFlags.EphemeralKeySet;
+#else
+            // .NET Framework runs on Windows only, and Schannel cannot use ephemeral keys.
+            X509KeyStorageFlags.UserKeySet;
+#endif
 
         /// <summary>
         /// Loads the configured client certificate and private key.
@@ -116,7 +130,6 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                         keyPath,
                         keyPassword,
                         out additionalCertificates);
-
                 if (!certificate.HasPrivateKey)
                 {
                     throw ADP.SSLCertificateAuthenticationException(StringsHelper.GetString(Strings.SQL_ClientCertificateMissingPrivateKey));
@@ -211,6 +224,7 @@ namespace Microsoft.Data.SqlClient.ManagedSni
             }
         }
 
+#if NET
         /// <summary>
         /// Combines a certificate with a detached private key file.
         /// </summary>
@@ -295,6 +309,32 @@ namespace Microsoft.Data.SqlClient.ManagedSni
             }
         }
 
+#else
+        /// <summary>
+        /// Rejects a detached private key on .NET Framework.
+        /// </summary>
+        /// <remarks>
+        /// Importing a PEM or DER private key needs <c>RSA.ImportFromPem</c> and
+        /// <c>RSA.ImportPkcs8PrivateKey</c>, which .NET Framework does not provide. A PKCS#12
+        /// certificate, which carries its own key, is supported on every target.
+        /// </remarks>
+        /// <param name="certificatePath">The certificate file path.</param>
+        /// <param name="keyPath">The private key file path.</param>
+        /// <param name="password">The private key password.</param>
+        /// <param name="additionalCertificates">Always <see langword="null" />.</param>
+        /// <returns>This method always throws.</returns>
+        private static X509Certificate2 LoadWithPrivateKey(
+            string certificatePath,
+            string keyPath,
+            string password,
+            out X509Certificate2Collection additionalCertificates)
+        {
+            additionalCertificates = null;
+            throw ADP.SSLCertificateAuthenticationException(
+                StringsHelper.GetString(Strings.SQL_ClientKeyRequiresNetCore));
+        }
+#endif
+
         /// <summary>
         /// Returns a certificate whose private key Schannel can use for a TLS handshake.
         /// </summary>
@@ -331,11 +371,17 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                 }
                 finally
                 {
+#if NET
                     CryptographicOperations.ZeroMemory(pkcs12);
+#else
+                    // CryptographicOperations is unavailable on .NET Framework.
+                    Array.Clear(pkcs12, 0, pkcs12.Length);
+#endif
                 }
             }
         }
 
+#if NET
         /// <summary>
         /// Reads the public certificates from a PEM or DER certificate file.
         /// </summary>
@@ -535,6 +581,7 @@ namespace Microsoft.Data.SqlClient.ManagedSni
             ReadOnlySpan<byte> marker = "-----BEGIN"u8;
             return bytes.AsSpan().IndexOf(marker) >= 0;
         }
+#endif
 
         /// <summary>
         /// Rejects the ODBC driver's <c>file:</c> path syntax, which this driver does not accept.
@@ -648,5 +695,3 @@ namespace Microsoft.Data.SqlClient.ManagedSni
         }
     }
 }
-
-#endif

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -212,6 +212,10 @@ namespace Microsoft.Data.SqlClient
                 {
                     throw ADP.InvalidMixedArgumentOfSecureCredentialAndIntegratedSecurity();
                 }
+                else if (UsesClientCertificate(ConnectionOptions))
+                {
+                    throw ADP.InvalidMixedArgumentOfClientCertificateAuthentication();
+                }
                 else if (UsesActiveDirectoryIntegrated(ConnectionOptions))
                 {
                     throw SQL.SettingCredentialWithIntegratedArgument();
@@ -602,6 +606,11 @@ namespace Microsoft.Data.SqlClient
             return opt != null && opt.Authentication != SqlAuthenticationMethod.NotSpecified;
         }
 
+        private bool UsesClientCertificate(SqlConnectionOptions opt)
+        {
+            return opt?.UsesClientCertificate == true;
+        }
+
         // Does this connection use Integrated Security?
         private bool UsesIntegratedSecurity(SqlConnectionOptions opt)
         {
@@ -656,7 +665,7 @@ namespace Microsoft.Data.SqlClient
             }
             set
             {
-                if (_credential != null || _accessToken != null || _accessTokenCallback != null)
+                if (_credential != null || _accessToken != null || _accessTokenCallback != null || _sspiContextProvider != null)
                 {
                     SqlConnectionOptions connectionOptions = new SqlConnectionOptions(value);
                     if (_credential != null)
@@ -705,6 +714,11 @@ namespace Microsoft.Data.SqlClient
                     if (_accessTokenCallback != null)
                     {
                         CheckAndThrowOnInvalidCombinationOfConnectionOptionAndAccessTokenCallback(connectionOptions);
+                    }
+
+                    if (_sspiContextProvider != null && UsesClientCertificate(connectionOptions))
+                    {
+                        throw ADP.InvalidMixedUsageOfClientCertificateAuthentication();
                     }
                 }
                 ConnectionString_Set(new ConnectionPoolKey(value, _credential, _accessToken, _accessTokenCallback, _sspiContextProvider));
@@ -802,6 +816,11 @@ namespace Microsoft.Data.SqlClient
                 if (!InnerConnection.AllowSetConnectionString)
                 {
                     throw ADP.OpenConnectionPropertySet(nameof(SspiContextProvider), InnerConnection.State);
+                }
+
+                if (value != null && UsesClientCertificate(ConnectionOptions))
+                {
+                    throw ADP.InvalidMixedUsageOfClientCertificateAuthentication();
                 }
 
                 ConnectionString_Set(new ConnectionPoolKey(_connectionString, credential: _credential, accessToken: null, accessTokenCallback: null, sspiContextProvider: value));
@@ -1120,6 +1139,11 @@ namespace Microsoft.Data.SqlClient
             {
                 throw ADP.InvalidMixedUsageOfSecureCredentialAndIntegratedSecurity();
             }
+
+            if (UsesClientCertificate(connectionOptions))
+            {
+                throw ADP.InvalidMixedUsageOfClientCertificateAuthentication();
+            }
         }
 
         // CheckAndThrowOnInvalidCombinationOfConnectionOptionAndAccessToken: check if the usage of AccessToken has any conflict
@@ -1141,6 +1165,11 @@ namespace Microsoft.Data.SqlClient
             if (UsesAuthentication(connectionOptions))
             {
                 throw ADP.InvalidMixedUsageOfAccessTokenAndAuthentication();
+            }
+
+            if (UsesClientCertificate(connectionOptions))
+            {
+                throw ADP.InvalidMixedUsageOfClientCertificateAuthentication();
             }
 
             // Check if the usage of AccessToken has the conflict with credential
@@ -1173,6 +1202,11 @@ namespace Microsoft.Data.SqlClient
             if (UsesAuthentication(connectionOptions))
             {
                 throw ADP.InvalidMixedUsageOfAccessTokenCallbackAndAuthentication();
+            }
+
+            if (UsesClientCertificate(connectionOptions))
+            {
+                throw ADP.InvalidMixedUsageOfClientCertificateAuthentication();
             }
 
             if (_accessToken != null)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -2774,6 +2774,10 @@ namespace Microsoft.Data.SqlClient
                 {
                     throw SQL.ChangePasswordConflictsWithSSPI();
                 }
+                if (connectionOptions.UsesClientCertificate)
+                {
+                    throw SQL.ChangePasswordConflictsWithClientCertificate();
+                }
                 if (!string.IsNullOrEmpty(connectionOptions.AttachDBFilename))
                 {
                     throw SQL.ChangePasswordUseOfUnallowedKey(DbConnectionStringKeywords.AttachDbFilename);
@@ -2834,6 +2838,11 @@ namespace Microsoft.Data.SqlClient
                 if (connectionOptions.IntegratedSecurity || connectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryIntegrated)
                 {
                     throw SQL.ChangePasswordConflictsWithSSPI();
+                }
+
+                if (connectionOptions.UsesClientCertificate)
+                {
+                    throw SQL.ChangePasswordConflictsWithClientCertificate();
                 }
 
                 if (!string.IsNullOrEmpty(connectionOptions.AttachDBFilename))

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Data.SqlClient
         private static readonly Regex s_connectionStringQuoteOdbcValueRegex = new Regex(ConnectionStringQuoteOdbcValuePattern, RegexOptions.ExplicitCapture | RegexOptions.Compiled);
 
         internal readonly bool _hasPasswordKeyword;
+        internal readonly bool _hasClientKeyPasswordKeyword;
         internal readonly bool _hasUserIdKeyword;
         internal readonly NameValuePair _keyChain;
 
@@ -130,6 +131,9 @@ namespace Microsoft.Data.SqlClient
         private readonly string _userID;
         private readonly string _hostNameInCertificate;
         private readonly string _serverCertificate;
+        private readonly string _clientCertificate;
+        private readonly string _clientKey;
+        private readonly string _clientKeyPassword;
         private readonly string _serverSPN;
         private readonly string _failoverPartnerSPN;
 
@@ -165,6 +169,12 @@ namespace Microsoft.Data.SqlClient
                             DbConnectionStringSynonyms.InitialFileName);
             AddKeywordToMap(DbConnectionStringKeywords.AttestationProtocol);
             AddKeywordToMap(DbConnectionStringKeywords.Authentication);
+            AddKeywordToMap(DbConnectionStringKeywords.ClientCertificate,
+                            DbConnectionStringSynonyms.ClientCertificate);
+            AddKeywordToMap(DbConnectionStringKeywords.ClientKey,
+                            DbConnectionStringSynonyms.ClientKey);
+            AddKeywordToMap(DbConnectionStringKeywords.ClientKeyPassword,
+                            DbConnectionStringSynonyms.ClientKeyPassword);
             AddKeywordToMap(DbConnectionStringKeywords.ColumnEncryptionSetting,
                             DbConnectionStringSynonyms.ColumnEncryption);
             AddKeywordToMap(DbConnectionStringKeywords.CommandTimeout);
@@ -254,6 +264,7 @@ namespace Microsoft.Data.SqlClient
                 _keyChain = ParseInternal(_parsetable, _usersConnectionString, true, s_keywordMap, false);
                 _hasPasswordKeyword = _parsetable.ContainsKey(DbConnectionStringKeywords.Password) ||
                                       _parsetable.ContainsKey(DbConnectionStringSynonyms.Pwd);
+                _hasClientKeyPasswordKeyword = _parsetable.ContainsKey(DbConnectionStringKeywords.ClientKeyPassword);
                 _hasUserIdKeyword = _parsetable.ContainsKey(DbConnectionStringKeywords.UserId) ||
                                     _parsetable.ContainsKey(DbConnectionStringSynonyms.Uid);
             }
@@ -306,6 +317,9 @@ namespace Microsoft.Data.SqlClient
             _ipAddressPreference = ConvertValueToIPAddressPreference();
             _hostNameInCertificate = ConvertValueToString(DbConnectionStringKeywords.HostNameInCertificate, DbConnectionStringDefaults.HostNameInCertificate);
             _serverCertificate = ConvertValueToString(DbConnectionStringKeywords.ServerCertificate, DbConnectionStringDefaults.ServerCertificate);
+            _clientCertificate = ConvertValueToString(DbConnectionStringKeywords.ClientCertificate, DbConnectionStringDefaults.ClientCertificate);
+            _clientKey = ConvertValueToString(DbConnectionStringKeywords.ClientKey, DbConnectionStringDefaults.ClientKey);
+            _clientKeyPassword = ConvertValueToString(DbConnectionStringKeywords.ClientKeyPassword, DbConnectionStringDefaults.ClientKeyPassword);
             _serverSPN = ConvertValueToString(DbConnectionStringKeywords.ServerSpn, DbConnectionStringDefaults.ServerSpn);
             _failoverPartnerSPN = ConvertValueToString(DbConnectionStringKeywords.FailoverPartnerSpn, DbConnectionStringDefaults.FailoverPartnerSpn);
 
@@ -561,6 +575,30 @@ namespace Microsoft.Data.SqlClient
             {
                 throw SQL.NonInteractiveWithPassword(DbConnectionStringUtilities.ActiveDirectoryWorkloadIdentityString);
             }
+
+            if (string.IsNullOrEmpty(_clientCertificate))
+            {
+                if (ContainsKey(DbConnectionStringKeywords.ClientKey))
+                {
+                    throw ADP.MissingConnectionOptionValue(DbConnectionStringKeywords.ClientKey, DbConnectionStringKeywords.ClientCertificate);
+                }
+
+                if (_hasClientKeyPasswordKeyword)
+                {
+                    throw ADP.MissingConnectionOptionValue(DbConnectionStringKeywords.ClientKeyPassword, DbConnectionStringKeywords.ClientCertificate);
+                }
+            }
+            else if (string.IsNullOrEmpty(_clientKey) && !IsPkcs12Certificate(_clientCertificate))
+            {
+                throw ADP.MissingConnectionOptionValue(DbConnectionStringKeywords.ClientCertificate, DbConnectionStringKeywords.ClientKey);
+            }
+            else if (_hasUserIdKeyword ||
+                     _hasPasswordKeyword ||
+                     _integratedSecurity ||
+                     ContainsKey(DbConnectionStringKeywords.Authentication))
+            {
+                throw SQL.ClientCertificateAuthenticationConflict();
+            }
         }
 
         // This c-tor is used to create SSE and user instance connection strings when user instance is set to true
@@ -572,6 +610,7 @@ namespace Microsoft.Data.SqlClient
             _parsetable = connectionOptions._parsetable;
             _keyChain = connectionOptions._keyChain;
             _hasPasswordKeyword = connectionOptions._hasPasswordKeyword;
+            _hasClientKeyPasswordKeyword = connectionOptions._hasClientKeyPasswordKeyword;
             _hasUserIdKeyword = connectionOptions._hasUserIdKeyword;
             _integratedSecurity = connectionOptions._integratedSecurity;
             _encrypt = connectionOptions._encrypt;
@@ -623,6 +662,10 @@ namespace Microsoft.Data.SqlClient
             _serverSPN = connectionOptions._serverSPN;
             _failoverPartnerSPN = connectionOptions._failoverPartnerSPN;
             _hostNameInCertificate = connectionOptions._hostNameInCertificate;
+            _serverCertificate = connectionOptions._serverCertificate;
+            _clientCertificate = connectionOptions._clientCertificate;
+            _clientKey = connectionOptions._clientKey;
+            _clientKeyPassword = connectionOptions._clientKeyPassword;
 #if NETFRAMEWORK
             _connectionReset = connectionOptions._connectionReset;
             _transparentNetworkIPResolution = connectionOptions._transparentNetworkIPResolution;
@@ -649,6 +692,10 @@ namespace Microsoft.Data.SqlClient
         internal string HostNameInCertificate => _hostNameInCertificate;
         internal bool TrustServerCertificate => _trustServerCertificate;
         public string ServerCertificate => _serverCertificate;
+        internal string ClientCertificate => _clientCertificate;
+        internal string ClientKey => _clientKey;
+        internal string ClientKeyPassword => _clientKeyPassword;
+        internal bool UsesClientCertificate => !string.IsNullOrEmpty(_clientCertificate);
         internal bool Enlist => _enlist;
         internal bool MARS => _mars;
         internal bool MultiSubnetFailover => _multiSubnetFailover;
@@ -1141,14 +1188,16 @@ namespace Microsoft.Data.SqlClient
         private string UsersConnectionString(bool hidePassword, bool forceHidePassword)
         {
             string connectionString = _usersConnectionString;
-            if (_hasPasswordKeyword && (forceHidePassword || (hidePassword && !HasPersistablePassword)))
+            if (HasSensitiveInfoKeyword && (forceHidePassword || (hidePassword && !HasPersistablePassword)))
             {
-                ReplacePasswordPwd(out connectionString, false);
+                ReplaceSensitiveValues(out connectionString, false);
             }
             return connectionString ?? string.Empty;
         }
 
-        internal bool HasPersistablePassword => _hasPasswordKeyword
+        internal bool HasSensitiveInfoKeyword => _hasPasswordKeyword || _hasClientKeyPasswordKeyword;
+
+        internal bool HasPersistablePassword => HasSensitiveInfoKeyword
             ? ConvertValueToBoolean(DbConnectionStringKeywords.PersistSecurityInfo, DbConnectionStringDefaults.PersistSecurityInfo)
             : true; // no password means persistable password so we don't have to munge
 
@@ -1536,7 +1585,7 @@ namespace Microsoft.Data.SqlClient
             return keychain;
         }
 
-        internal NameValuePair ReplacePasswordPwd(out string constr, bool fakePassword)
+        internal NameValuePair ReplaceSensitiveValues(out string constr, bool fakePassword)
         {
             bool expanded = false;
             int copyPosition = 0;
@@ -1544,8 +1593,7 @@ namespace Microsoft.Data.SqlClient
             StringBuilder builder = new StringBuilder(_usersConnectionString.Length);
             for (NameValuePair current = _keyChain; current != null; current = current.Next)
             {
-                if (!CompareInsensitiveInvariant(DbConnectionStringKeywords.Password, current.Name) &&
-                    !CompareInsensitiveInvariant(DbConnectionStringSynonyms.Pwd, current.Name))
+                if (!IsSensitiveKeyword(current.Name))
                 {
                     builder.Append(_usersConnectionString, copyPosition, current.Length);
                     if (fakePassword)
@@ -1555,7 +1603,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 else if (fakePassword)
                 {
-                    // replace user password/pwd value with *
+                    // replace the sensitive value with *
                     const string equalstar = "=*;";
                     builder.Append(current.Name).Append(equalstar);
                     next = new NameValuePair(current.Name, "*", current.Name.Length + equalstar.Length);
@@ -1580,9 +1628,21 @@ namespace Microsoft.Data.SqlClient
                 }
                 copyPosition += current.Length;
             }
-            Debug.Assert(expanded, "password/pwd was not removed");
+            Debug.Assert(expanded, "sensitive connection string value was not removed");
             constr = builder.ToString();
             return head;
+        }
+
+        private static bool IsSensitiveKeyword(string keyword) =>
+            CompareInsensitiveInvariant(DbConnectionStringKeywords.Password, keyword) ||
+            CompareInsensitiveInvariant(DbConnectionStringSynonyms.Pwd, keyword) ||
+            CompareInsensitiveInvariant(DbConnectionStringKeywords.ClientKeyPassword, keyword);
+
+        private static bool IsPkcs12Certificate(string certificatePath)
+        {
+            string extension = Path.GetExtension(certificatePath);
+            return extension.Equals(".pfx", StringComparison.OrdinalIgnoreCase) ||
+                   extension.Equals(".p12", StringComparison.OrdinalIgnoreCase);
         }
 
         // SxS notes:

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
@@ -169,16 +169,12 @@ namespace Microsoft.Data.SqlClient
                             DbConnectionStringSynonyms.InitialFileName);
             AddKeywordToMap(DbConnectionStringKeywords.AttestationProtocol);
             AddKeywordToMap(DbConnectionStringKeywords.Authentication);
-#if NET
-            // Client certificate authentication is implemented by managed SNI only, so the keywords
-            // are not recognized on .NET Framework where managed networking is unavailable.
             AddKeywordToMap(DbConnectionStringKeywords.ClientCertificate,
                             DbConnectionStringSynonyms.ClientCertificate);
             AddKeywordToMap(DbConnectionStringKeywords.ClientKey,
                             DbConnectionStringSynonyms.ClientKey);
             AddKeywordToMap(DbConnectionStringKeywords.ClientKeyPassword,
                             DbConnectionStringSynonyms.ClientKeyPassword);
-#endif
             AddKeywordToMap(DbConnectionStringKeywords.ColumnEncryptionSetting,
                             DbConnectionStringSynonyms.ColumnEncryption);
             AddKeywordToMap(DbConnectionStringKeywords.CommandTimeout);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
@@ -169,12 +169,16 @@ namespace Microsoft.Data.SqlClient
                             DbConnectionStringSynonyms.InitialFileName);
             AddKeywordToMap(DbConnectionStringKeywords.AttestationProtocol);
             AddKeywordToMap(DbConnectionStringKeywords.Authentication);
+#if NET
+            // Client certificate authentication is implemented by managed SNI only, so the keywords
+            // are not recognized on .NET Framework where managed networking is unavailable.
             AddKeywordToMap(DbConnectionStringKeywords.ClientCertificate,
                             DbConnectionStringSynonyms.ClientCertificate);
             AddKeywordToMap(DbConnectionStringKeywords.ClientKey,
                             DbConnectionStringSynonyms.ClientKey);
             AddKeywordToMap(DbConnectionStringKeywords.ClientKeyPassword,
                             DbConnectionStringSynonyms.ClientKeyPassword);
+#endif
             AddKeywordToMap(DbConnectionStringKeywords.ColumnEncryptionSetting,
                             DbConnectionStringSynonyms.ColumnEncryption);
             AddKeywordToMap(DbConnectionStringKeywords.CommandTimeout);
@@ -588,14 +592,10 @@ namespace Microsoft.Data.SqlClient
                     throw ADP.MissingConnectionOptionValue(DbConnectionStringKeywords.ClientKeyPassword, DbConnectionStringKeywords.ClientCertificate);
                 }
             }
-            else if (string.IsNullOrEmpty(_clientKey) && !IsPkcs12Certificate(_clientCertificate))
-            {
-                throw ADP.MissingConnectionOptionValue(DbConnectionStringKeywords.ClientCertificate, DbConnectionStringKeywords.ClientKey);
-            }
-            else if (_hasUserIdKeyword ||
-                     _hasPasswordKeyword ||
+            else if (!string.IsNullOrEmpty(_userID) ||
+                     !string.IsNullOrEmpty(_password) ||
                      _integratedSecurity ||
-                     ContainsKey(DbConnectionStringKeywords.Authentication))
+                     Authentication != SqlAuthenticationMethod.NotSpecified)
             {
                 throw SQL.ClientCertificateAuthenticationConflict();
             }
@@ -662,7 +662,6 @@ namespace Microsoft.Data.SqlClient
             _serverSPN = connectionOptions._serverSPN;
             _failoverPartnerSPN = connectionOptions._failoverPartnerSPN;
             _hostNameInCertificate = connectionOptions._hostNameInCertificate;
-            _serverCertificate = connectionOptions._serverCertificate;
             _clientCertificate = connectionOptions._clientCertificate;
             _clientKey = connectionOptions._clientKey;
             _clientKeyPassword = connectionOptions._clientKeyPassword;
@@ -1637,13 +1636,6 @@ namespace Microsoft.Data.SqlClient
             CompareInsensitiveInvariant(DbConnectionStringKeywords.Password, keyword) ||
             CompareInsensitiveInvariant(DbConnectionStringSynonyms.Pwd, keyword) ||
             CompareInsensitiveInvariant(DbConnectionStringKeywords.ClientKeyPassword, keyword);
-
-        private static bool IsPkcs12Certificate(string certificatePath)
-        {
-            string extension = Path.GetExtension(certificatePath);
-            return extension.Equals(".pfx", StringComparison.OrdinalIgnoreCase) ||
-                   extension.Equals(".p12", StringComparison.OrdinalIgnoreCase);
-        }
 
         // SxS notes:
         // * this method queries "DataDirectory" value from the current AppDomain.

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionStringBuilder.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionStringBuilder.cs
@@ -48,6 +48,9 @@ namespace Microsoft.Data.SqlClient
             Encrypt,
             HostNameInCertificate,
             ServerCertificate,
+            ClientCertificate,
+            ClientKey,
+            ClientKeyPassword,
             TrustServerCertificate,
             LoadBalanceTimeout,
             IdleTimeout,
@@ -111,6 +114,9 @@ namespace Microsoft.Data.SqlClient
         private SqlConnectionEncryptOption _encrypt = DbConnectionStringDefaults.Encrypt;
         private string _hostNameInCertificate = DbConnectionStringDefaults.HostNameInCertificate;
         private string _serverCertificate = DbConnectionStringDefaults.ServerCertificate;
+        private string _clientCertificate = DbConnectionStringDefaults.ClientCertificate;
+        private string _clientKey = DbConnectionStringDefaults.ClientKey;
+        private string _clientKeyPassword = DbConnectionStringDefaults.ClientKeyPassword;
         private bool _trustServerCertificate = DbConnectionStringDefaults.TrustServerCertificate;
         private bool _enlist = DbConnectionStringDefaults.Enlist;
         private bool _integratedSecurity = DbConnectionStringDefaults.IntegratedSecurity;
@@ -152,6 +158,9 @@ namespace Microsoft.Data.SqlClient
             validKeywords[(int)Keywords.Encrypt] = DbConnectionStringKeywords.Encrypt;
             validKeywords[(int)Keywords.HostNameInCertificate] = DbConnectionStringKeywords.HostNameInCertificate;
             validKeywords[(int)Keywords.ServerCertificate] = DbConnectionStringKeywords.ServerCertificate;
+            validKeywords[(int)Keywords.ClientCertificate] = DbConnectionStringKeywords.ClientCertificate;
+            validKeywords[(int)Keywords.ClientKey] = DbConnectionStringKeywords.ClientKey;
+            validKeywords[(int)Keywords.ClientKeyPassword] = DbConnectionStringKeywords.ClientKeyPassword;
             validKeywords[(int)Keywords.Enlist] = DbConnectionStringKeywords.Enlist;
             validKeywords[(int)Keywords.FailoverPartner] = DbConnectionStringKeywords.FailoverPartner;
             validKeywords[(int)Keywords.InitialCatalog] = DbConnectionStringKeywords.InitialCatalog;
@@ -212,6 +221,9 @@ namespace Microsoft.Data.SqlClient
                 { DbConnectionStringKeywords.FailoverPartner, Keywords.FailoverPartner },
                 { DbConnectionStringKeywords.HostNameInCertificate, Keywords.HostNameInCertificate },
                 { DbConnectionStringKeywords.ServerCertificate, Keywords.ServerCertificate },
+                { DbConnectionStringKeywords.ClientCertificate, Keywords.ClientCertificate },
+                { DbConnectionStringKeywords.ClientKey, Keywords.ClientKey },
+                { DbConnectionStringKeywords.ClientKeyPassword, Keywords.ClientKeyPassword },
                 { DbConnectionStringKeywords.InitialCatalog, Keywords.InitialCatalog },
                 { DbConnectionStringKeywords.IntegratedSecurity, Keywords.IntegratedSecurity },
                 { DbConnectionStringKeywords.LoadBalanceTimeout, Keywords.LoadBalanceTimeout },
@@ -255,6 +267,9 @@ namespace Microsoft.Data.SqlClient
                 { DbConnectionStringSynonyms.ExtendedProperties, Keywords.AttachDBFilename },
                 { DbConnectionStringSynonyms.HostNameInCertificate, Keywords.HostNameInCertificate },
                 { DbConnectionStringSynonyms.ServerCertificate, Keywords.ServerCertificate },
+                { DbConnectionStringSynonyms.ClientCertificate, Keywords.ClientCertificate },
+                { DbConnectionStringSynonyms.ClientKey, Keywords.ClientKey },
+                { DbConnectionStringSynonyms.ClientKeyPassword, Keywords.ClientKeyPassword },
                 { DbConnectionStringSynonyms.InitialFileName, Keywords.AttachDBFilename },
                 { DbConnectionStringSynonyms.ConnectionTimeout, Keywords.ConnectTimeout },
                 { DbConnectionStringSynonyms.ConnectRetryCount, Keywords.ConnectRetryCount },
@@ -343,6 +358,12 @@ namespace Microsoft.Data.SqlClient
                     return HostNameInCertificate;
                 case Keywords.ServerCertificate:
                     return ServerCertificate;
+                case Keywords.ClientCertificate:
+                    return ClientCertificate;
+                case Keywords.ClientKey:
+                    return ClientKey;
+                case Keywords.ClientKeyPassword:
+                    return ClientKeyPassword;
                 case Keywords.Enlist:
                     return Enlist;
                 case Keywords.FailoverPartner:
@@ -471,6 +492,15 @@ namespace Microsoft.Data.SqlClient
                     break;
                 case Keywords.ServerCertificate:
                     _serverCertificate = DbConnectionStringDefaults.ServerCertificate;
+                    break;
+                case Keywords.ClientCertificate:
+                    _clientCertificate = DbConnectionStringDefaults.ClientCertificate;
+                    break;
+                case Keywords.ClientKey:
+                    _clientKey = DbConnectionStringDefaults.ClientKey;
+                    break;
+                case Keywords.ClientKeyPassword:
+                    _clientKeyPassword = DbConnectionStringDefaults.ClientKeyPassword;
                     break;
                 case Keywords.Enlist:
                     _enlist = DbConnectionStringDefaults.Enlist;
@@ -1031,6 +1061,15 @@ namespace Microsoft.Data.SqlClient
                         case Keywords.ServerCertificate:
                             ServerCertificate = ConvertToString(value);
                             break;
+                        case Keywords.ClientCertificate:
+                            ClientCertificate = ConvertToString(value);
+                            break;
+                        case Keywords.ClientKey:
+                            ClientKey = ConvertToString(value);
+                            break;
+                        case Keywords.ClientKeyPassword:
+                            ClientKeyPassword = ConvertToString(value);
+                            break;
                         case Keywords.TrustServerCertificate:
                             TrustServerCertificate = ConvertToBoolean(value);
                             break;
@@ -1276,6 +1315,52 @@ namespace Microsoft.Data.SqlClient
             {
                 SetValue(DbConnectionStringKeywords.ServerCertificate, value);
                 _serverCertificate = value;
+            }
+        }
+
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/ClientCertificate/*' />
+        [DisplayName(DbConnectionStringKeywords.ClientCertificate)]
+        [ResCategory(nameof(Strings.DataCategory_Security))]
+        [ResDescription(nameof(Strings.DbConnectionString_ClientCertificate))]
+        [RefreshProperties(RefreshProperties.All)]
+        public string ClientCertificate
+        {
+            get => _clientCertificate;
+            set
+            {
+                SetValue(DbConnectionStringKeywords.ClientCertificate, value);
+                _clientCertificate = value;
+            }
+        }
+
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/ClientKey/*' />
+        [DisplayName(DbConnectionStringKeywords.ClientKey)]
+        [ResCategory(nameof(Strings.DataCategory_Security))]
+        [ResDescription(nameof(Strings.DbConnectionString_ClientKey))]
+        [RefreshProperties(RefreshProperties.All)]
+        public string ClientKey
+        {
+            get => _clientKey;
+            set
+            {
+                SetValue(DbConnectionStringKeywords.ClientKey, value);
+                _clientKey = value;
+            }
+        }
+
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/ClientKeyPassword/*' />
+        [DisplayName(DbConnectionStringKeywords.ClientKeyPassword)]
+        [PasswordPropertyText(true)]
+        [ResCategory(nameof(Strings.DataCategory_Security))]
+        [ResDescription(nameof(Strings.DbConnectionString_ClientKeyPassword))]
+        [RefreshProperties(RefreshProperties.All)]
+        public string ClientKeyPassword
+        {
+            get => _clientKeyPassword;
+            set
+            {
+                SetValue(DbConnectionStringKeywords.ClientKeyPassword, value);
+                _clientKeyPassword = value;
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionStringBuilder.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionStringBuilder.cs
@@ -1367,9 +1367,9 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/ClientKeyPassword/*' />
         [DisplayName(DbConnectionStringKeywords.ClientKeyPassword)]
-        [PasswordPropertyText(true)]
         [ResCategory(nameof(Strings.DataCategory_Security))]
         [ResDescription(nameof(Strings.DbConnectionString_ClientKeyPassword))]
+        [PasswordPropertyText(true)]
         [RefreshProperties(RefreshProperties.All)]
         public string ClientKeyPassword
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionStringBuilder.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionStringBuilder.cs
@@ -48,11 +48,9 @@ namespace Microsoft.Data.SqlClient
             Encrypt,
             HostNameInCertificate,
             ServerCertificate,
-#if NET
             ClientCertificate,
             ClientKey,
             ClientKeyPassword,
-#endif
             TrustServerCertificate,
             LoadBalanceTimeout,
             IdleTimeout,
@@ -116,11 +114,9 @@ namespace Microsoft.Data.SqlClient
         private SqlConnectionEncryptOption _encrypt = DbConnectionStringDefaults.Encrypt;
         private string _hostNameInCertificate = DbConnectionStringDefaults.HostNameInCertificate;
         private string _serverCertificate = DbConnectionStringDefaults.ServerCertificate;
-#if NET
         private string _clientCertificate = DbConnectionStringDefaults.ClientCertificate;
         private string _clientKey = DbConnectionStringDefaults.ClientKey;
         private string _clientKeyPassword = DbConnectionStringDefaults.ClientKeyPassword;
-#endif
         private bool _trustServerCertificate = DbConnectionStringDefaults.TrustServerCertificate;
         private bool _enlist = DbConnectionStringDefaults.Enlist;
         private bool _integratedSecurity = DbConnectionStringDefaults.IntegratedSecurity;
@@ -162,11 +158,9 @@ namespace Microsoft.Data.SqlClient
             validKeywords[(int)Keywords.Encrypt] = DbConnectionStringKeywords.Encrypt;
             validKeywords[(int)Keywords.HostNameInCertificate] = DbConnectionStringKeywords.HostNameInCertificate;
             validKeywords[(int)Keywords.ServerCertificate] = DbConnectionStringKeywords.ServerCertificate;
-#if NET
             validKeywords[(int)Keywords.ClientCertificate] = DbConnectionStringKeywords.ClientCertificate;
             validKeywords[(int)Keywords.ClientKey] = DbConnectionStringKeywords.ClientKey;
             validKeywords[(int)Keywords.ClientKeyPassword] = DbConnectionStringKeywords.ClientKeyPassword;
-#endif
             validKeywords[(int)Keywords.Enlist] = DbConnectionStringKeywords.Enlist;
             validKeywords[(int)Keywords.FailoverPartner] = DbConnectionStringKeywords.FailoverPartner;
             validKeywords[(int)Keywords.InitialCatalog] = DbConnectionStringKeywords.InitialCatalog;
@@ -227,11 +221,9 @@ namespace Microsoft.Data.SqlClient
                 { DbConnectionStringKeywords.FailoverPartner, Keywords.FailoverPartner },
                 { DbConnectionStringKeywords.HostNameInCertificate, Keywords.HostNameInCertificate },
                 { DbConnectionStringKeywords.ServerCertificate, Keywords.ServerCertificate },
-#if NET
                 { DbConnectionStringKeywords.ClientCertificate, Keywords.ClientCertificate },
                 { DbConnectionStringKeywords.ClientKey, Keywords.ClientKey },
                 { DbConnectionStringKeywords.ClientKeyPassword, Keywords.ClientKeyPassword },
-#endif
                 { DbConnectionStringKeywords.InitialCatalog, Keywords.InitialCatalog },
                 { DbConnectionStringKeywords.IntegratedSecurity, Keywords.IntegratedSecurity },
                 { DbConnectionStringKeywords.LoadBalanceTimeout, Keywords.LoadBalanceTimeout },
@@ -275,11 +267,9 @@ namespace Microsoft.Data.SqlClient
                 { DbConnectionStringSynonyms.ExtendedProperties, Keywords.AttachDBFilename },
                 { DbConnectionStringSynonyms.HostNameInCertificate, Keywords.HostNameInCertificate },
                 { DbConnectionStringSynonyms.ServerCertificate, Keywords.ServerCertificate },
-#if NET
                 { DbConnectionStringSynonyms.ClientCertificate, Keywords.ClientCertificate },
                 { DbConnectionStringSynonyms.ClientKey, Keywords.ClientKey },
                 { DbConnectionStringSynonyms.ClientKeyPassword, Keywords.ClientKeyPassword },
-#endif
                 { DbConnectionStringSynonyms.InitialFileName, Keywords.AttachDBFilename },
                 { DbConnectionStringSynonyms.ConnectionTimeout, Keywords.ConnectTimeout },
                 { DbConnectionStringSynonyms.ConnectRetryCount, Keywords.ConnectRetryCount },
@@ -368,14 +358,12 @@ namespace Microsoft.Data.SqlClient
                     return HostNameInCertificate;
                 case Keywords.ServerCertificate:
                     return ServerCertificate;
-#if NET
                 case Keywords.ClientCertificate:
                     return ClientCertificate;
                 case Keywords.ClientKey:
                     return ClientKey;
                 case Keywords.ClientKeyPassword:
                     return ClientKeyPassword;
-#endif
                 case Keywords.Enlist:
                     return Enlist;
                 case Keywords.FailoverPartner:
@@ -505,7 +493,6 @@ namespace Microsoft.Data.SqlClient
                 case Keywords.ServerCertificate:
                     _serverCertificate = DbConnectionStringDefaults.ServerCertificate;
                     break;
-#if NET
                 case Keywords.ClientCertificate:
                     _clientCertificate = DbConnectionStringDefaults.ClientCertificate;
                     break;
@@ -515,7 +502,6 @@ namespace Microsoft.Data.SqlClient
                 case Keywords.ClientKeyPassword:
                     _clientKeyPassword = DbConnectionStringDefaults.ClientKeyPassword;
                     break;
-#endif
                 case Keywords.Enlist:
                     _enlist = DbConnectionStringDefaults.Enlist;
                     break;
@@ -1075,7 +1061,6 @@ namespace Microsoft.Data.SqlClient
                         case Keywords.ServerCertificate:
                             ServerCertificate = ConvertToString(value);
                             break;
-#if NET
                         case Keywords.ClientCertificate:
                             ClientCertificate = ConvertToString(value);
                             break;
@@ -1085,7 +1070,6 @@ namespace Microsoft.Data.SqlClient
                         case Keywords.ClientKeyPassword:
                             ClientKeyPassword = ConvertToString(value);
                             break;
-#endif
                         case Keywords.TrustServerCertificate:
                             TrustServerCertificate = ConvertToBoolean(value);
                             break;
@@ -1334,7 +1318,6 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-#if NET
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/ClientCertificate/*' />
         [DisplayName(DbConnectionStringKeywords.ClientCertificate)]
         [ResCategory(nameof(Strings.DataCategory_Security))]
@@ -1380,7 +1363,6 @@ namespace Microsoft.Data.SqlClient
                 _clientKeyPassword = value;
             }
         }
-#endif
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/ColumnEncryptionSetting/*' />
         [DisplayName(DbConnectionStringKeywords.ColumnEncryptionSetting)]

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionStringBuilder.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionStringBuilder.cs
@@ -48,9 +48,11 @@ namespace Microsoft.Data.SqlClient
             Encrypt,
             HostNameInCertificate,
             ServerCertificate,
+#if NET
             ClientCertificate,
             ClientKey,
             ClientKeyPassword,
+#endif
             TrustServerCertificate,
             LoadBalanceTimeout,
             IdleTimeout,
@@ -114,9 +116,11 @@ namespace Microsoft.Data.SqlClient
         private SqlConnectionEncryptOption _encrypt = DbConnectionStringDefaults.Encrypt;
         private string _hostNameInCertificate = DbConnectionStringDefaults.HostNameInCertificate;
         private string _serverCertificate = DbConnectionStringDefaults.ServerCertificate;
+#if NET
         private string _clientCertificate = DbConnectionStringDefaults.ClientCertificate;
         private string _clientKey = DbConnectionStringDefaults.ClientKey;
         private string _clientKeyPassword = DbConnectionStringDefaults.ClientKeyPassword;
+#endif
         private bool _trustServerCertificate = DbConnectionStringDefaults.TrustServerCertificate;
         private bool _enlist = DbConnectionStringDefaults.Enlist;
         private bool _integratedSecurity = DbConnectionStringDefaults.IntegratedSecurity;
@@ -158,9 +162,11 @@ namespace Microsoft.Data.SqlClient
             validKeywords[(int)Keywords.Encrypt] = DbConnectionStringKeywords.Encrypt;
             validKeywords[(int)Keywords.HostNameInCertificate] = DbConnectionStringKeywords.HostNameInCertificate;
             validKeywords[(int)Keywords.ServerCertificate] = DbConnectionStringKeywords.ServerCertificate;
+#if NET
             validKeywords[(int)Keywords.ClientCertificate] = DbConnectionStringKeywords.ClientCertificate;
             validKeywords[(int)Keywords.ClientKey] = DbConnectionStringKeywords.ClientKey;
             validKeywords[(int)Keywords.ClientKeyPassword] = DbConnectionStringKeywords.ClientKeyPassword;
+#endif
             validKeywords[(int)Keywords.Enlist] = DbConnectionStringKeywords.Enlist;
             validKeywords[(int)Keywords.FailoverPartner] = DbConnectionStringKeywords.FailoverPartner;
             validKeywords[(int)Keywords.InitialCatalog] = DbConnectionStringKeywords.InitialCatalog;
@@ -221,9 +227,11 @@ namespace Microsoft.Data.SqlClient
                 { DbConnectionStringKeywords.FailoverPartner, Keywords.FailoverPartner },
                 { DbConnectionStringKeywords.HostNameInCertificate, Keywords.HostNameInCertificate },
                 { DbConnectionStringKeywords.ServerCertificate, Keywords.ServerCertificate },
+#if NET
                 { DbConnectionStringKeywords.ClientCertificate, Keywords.ClientCertificate },
                 { DbConnectionStringKeywords.ClientKey, Keywords.ClientKey },
                 { DbConnectionStringKeywords.ClientKeyPassword, Keywords.ClientKeyPassword },
+#endif
                 { DbConnectionStringKeywords.InitialCatalog, Keywords.InitialCatalog },
                 { DbConnectionStringKeywords.IntegratedSecurity, Keywords.IntegratedSecurity },
                 { DbConnectionStringKeywords.LoadBalanceTimeout, Keywords.LoadBalanceTimeout },
@@ -267,9 +275,11 @@ namespace Microsoft.Data.SqlClient
                 { DbConnectionStringSynonyms.ExtendedProperties, Keywords.AttachDBFilename },
                 { DbConnectionStringSynonyms.HostNameInCertificate, Keywords.HostNameInCertificate },
                 { DbConnectionStringSynonyms.ServerCertificate, Keywords.ServerCertificate },
+#if NET
                 { DbConnectionStringSynonyms.ClientCertificate, Keywords.ClientCertificate },
                 { DbConnectionStringSynonyms.ClientKey, Keywords.ClientKey },
                 { DbConnectionStringSynonyms.ClientKeyPassword, Keywords.ClientKeyPassword },
+#endif
                 { DbConnectionStringSynonyms.InitialFileName, Keywords.AttachDBFilename },
                 { DbConnectionStringSynonyms.ConnectionTimeout, Keywords.ConnectTimeout },
                 { DbConnectionStringSynonyms.ConnectRetryCount, Keywords.ConnectRetryCount },
@@ -358,12 +368,14 @@ namespace Microsoft.Data.SqlClient
                     return HostNameInCertificate;
                 case Keywords.ServerCertificate:
                     return ServerCertificate;
+#if NET
                 case Keywords.ClientCertificate:
                     return ClientCertificate;
                 case Keywords.ClientKey:
                     return ClientKey;
                 case Keywords.ClientKeyPassword:
                     return ClientKeyPassword;
+#endif
                 case Keywords.Enlist:
                     return Enlist;
                 case Keywords.FailoverPartner:
@@ -493,6 +505,7 @@ namespace Microsoft.Data.SqlClient
                 case Keywords.ServerCertificate:
                     _serverCertificate = DbConnectionStringDefaults.ServerCertificate;
                     break;
+#if NET
                 case Keywords.ClientCertificate:
                     _clientCertificate = DbConnectionStringDefaults.ClientCertificate;
                     break;
@@ -502,6 +515,7 @@ namespace Microsoft.Data.SqlClient
                 case Keywords.ClientKeyPassword:
                     _clientKeyPassword = DbConnectionStringDefaults.ClientKeyPassword;
                     break;
+#endif
                 case Keywords.Enlist:
                     _enlist = DbConnectionStringDefaults.Enlist;
                     break;
@@ -1061,6 +1075,7 @@ namespace Microsoft.Data.SqlClient
                         case Keywords.ServerCertificate:
                             ServerCertificate = ConvertToString(value);
                             break;
+#if NET
                         case Keywords.ClientCertificate:
                             ClientCertificate = ConvertToString(value);
                             break;
@@ -1070,6 +1085,7 @@ namespace Microsoft.Data.SqlClient
                         case Keywords.ClientKeyPassword:
                             ClientKeyPassword = ConvertToString(value);
                             break;
+#endif
                         case Keywords.TrustServerCertificate:
                             TrustServerCertificate = ConvertToBoolean(value);
                             break;
@@ -1318,6 +1334,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+#if NET
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/ClientCertificate/*' />
         [DisplayName(DbConnectionStringKeywords.ClientCertificate)]
         [ResCategory(nameof(Strings.DataCategory_Security))]
@@ -1363,6 +1380,7 @@ namespace Microsoft.Data.SqlClient
                 _clientKeyPassword = value;
             }
         }
+#endif
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/ColumnEncryptionSetting/*' />
         [DisplayName(DbConnectionStringKeywords.ColumnEncryptionSetting)]

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -102,6 +102,10 @@ namespace Microsoft.Data.SqlClient
         {
             return ADP.Argument(StringsHelper.GetString(Strings.SQL_AuthenticationAndIntegratedSecurity));
         }
+        internal static Exception ClientCertificateAuthenticationConflict()
+        {
+            return ADP.InvalidMixedArgumentOfClientCertificateAuthentication();
+        }
         internal static Exception IntegratedWithPassword()
         {
             return ADP.Argument(StringsHelper.GetString(Strings.SQL_IntegratedWithPassword));
@@ -2150,4 +2154,3 @@ namespace Microsoft.Data.SqlClient
         }
     }
 }
-

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -106,10 +106,6 @@ namespace Microsoft.Data.SqlClient
         {
             return ADP.InvalidMixedArgumentOfClientCertificateAuthentication();
         }
-        internal static Exception ChangePasswordConflictsWithClientCertificate()
-        {
-            return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_ChangePasswordConflictsWithClientCertificate));
-        }
         internal static Exception IntegratedWithPassword()
         {
             return ADP.Argument(StringsHelper.GetString(Strings.SQL_IntegratedWithPassword));
@@ -203,6 +199,10 @@ namespace Microsoft.Data.SqlClient
         internal static Exception ChangePasswordConflictsWithSSPI()
         {
             return ADP.Argument(StringsHelper.GetString(Strings.SQL_ChangePasswordConflictsWithSSPI));
+        }
+        internal static Exception ChangePasswordConflictsWithClientCertificate()
+        {
+            return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_ChangePasswordConflictsWithClientCertificate));
         }
         internal static Exception UnknownSysTxIsolationLevel(System.Transactions.IsolationLevel isolationLevel)
         {
@@ -2158,3 +2158,4 @@ namespace Microsoft.Data.SqlClient
         }
     }
 }
+

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -106,6 +106,10 @@ namespace Microsoft.Data.SqlClient
         {
             return ADP.InvalidMixedArgumentOfClientCertificateAuthentication();
         }
+        internal static Exception ChangePasswordConflictsWithClientCertificate()
+        {
+            return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_ChangePasswordConflictsWithClientCertificate));
+        }
         internal static Exception IntegratedWithPassword()
         {
             return ADP.Argument(StringsHelper.GetString(Strings.SQL_IntegratedWithPassword));

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -420,7 +420,7 @@ namespace Microsoft.Data.SqlClient
             {
                 SqlClientEventSource.Log.TryTraceEvent("TdsParser.Connect | SEC | Connection Object Id {0}, Authentication Mode: {1}", _connHandler.ObjectID,
                     useClientCertificate
-                        ? nameof(SqlConnectionStringBuilder.ClientCertificate)
+                        ? DbConnectionStringKeywords.ClientCertificate
                         : authType == SqlAuthenticationMethod.NotSpecified ? SqlAuthenticationMethod.SqlPassword.ToString() : authType.ToString());
             }
 
@@ -1006,11 +1006,6 @@ namespace Microsoft.Data.SqlClient
                 info |= TdsEnums.SNI_SSL_IGNORE_CHANNEL_BINDINGS;
             }
 
-            if (!string.IsNullOrEmpty(clientCertificate))
-            {
-                info &= ~TdsEnums.SNI_SSL_USE_SCHANNEL_CACHE;
-            }
-
             error = _physicalStateObj.EnableSsl(
                 ref info,
                 encrypt == SqlConnectionEncryptOption.Strict,
@@ -1281,6 +1276,28 @@ namespace Microsoft.Data.SqlClient
             }
 
             EncryptionOptions negotiatedEncryptionOption = _encryptionOption & EncryptionOptions.OPTIONS_MASK;
+
+            // Client certificate authentication completes during the TLS handshake. With TLS-first
+            // (Strict) encryption the handshake already ran before PRELOGIN. Otherwise the negotiated
+            // encryption level must still include a handshake; without one the certificate would never
+            // be presented and the login would silently degrade to an empty, anonymous LOGIN7 record.
+            if ((_encryptionOption & EncryptionOptions.CLIENT_CERT) != 0 &&
+                !tlsFirst &&
+                negotiatedEncryptionOption != EncryptionOptions.ON &&
+                negotiatedEncryptionOption != EncryptionOptions.LOGIN)
+            {
+                _physicalStateObj.AddError(new SqlError(
+                    TdsEnums.ENCRYPTION_NOT_SUPPORTED,
+                    (byte)0x00,
+                    TdsEnums.FATAL_ERROR_CLASS,
+                    _server,
+                    StringsHelper.GetString(Strings.SQL_ClientCertificateRequiresEncryption),
+                    "",
+                    0));
+                _physicalStateObj.Dispose();
+                ThrowExceptionAndWarning(_physicalStateObj);
+            }
+
             if (negotiatedEncryptionOption == EncryptionOptions.ON ||
                 negotiatedEncryptionOption == EncryptionOptions.LOGIN)
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -994,6 +994,15 @@ namespace Microsoft.Data.SqlClient
                 info |= TdsEnums.SNI_SSL_IGNORE_CHANNEL_BINDINGS;
             }
 
+            if (!string.IsNullOrEmpty(clientCertificate))
+            {
+                // A client certificate produces a connection-specific credential, so the shared
+                // Schannel credential cache cannot be used. Native SNI skips acquiring credentials
+                // altogether when SNI_SSL_USE_SCHANNEL_CACHE is set, which would reuse a cached
+                // credential that carries no certificate and never present one to the server.
+                info &= ~TdsEnums.SNI_SSL_USE_SCHANNEL_CACHE;
+            }
+
             try
             {
                 error = _physicalStateObj.EnableSsl(

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -994,13 +994,34 @@ namespace Microsoft.Data.SqlClient
                 info |= TdsEnums.SNI_SSL_IGNORE_CHANNEL_BINDINGS;
             }
 
-            error = _physicalStateObj.EnableSsl(
-                ref info,
-                encrypt == SqlConnectionEncryptOption.Strict,
-                serverCertificateFilename,
-                clientCertificate,
-                clientKey,
-                clientKeyPassword);
+            try
+            {
+                error = _physicalStateObj.EnableSsl(
+                    ref info,
+                    encrypt == SqlConnectionEncryptOption.Strict,
+                    serverCertificateFilename,
+                    clientCertificate,
+                    clientKey,
+                    clientKeyPassword);
+            }
+            catch (AuthenticationException e)
+            {
+                // Native SNI loads the client certificate in managed code, so a certificate failure
+                // arrives as an exception rather than an SNI error code. Managed SNI converts the
+                // same failure into an SNI error, so report it here to keep both paths reporting a
+                // SqlException that wraps the original AuthenticationException.
+                _physicalStateObj.AddError(new SqlError(
+                    infoNumber: 0,
+                    errorState: 0,
+                    errorClass: TdsEnums.FATAL_ERROR_CLASS,
+                    server: _server,
+                    errorMessage: e.Message,
+                    procedure: string.Empty,
+                    lineNumber: 0,
+                    exception: e));
+                _physicalStateObj.Dispose();
+                ThrowExceptionAndWarning(_physicalStateObj);
+            }
 
             if (error != TdsEnums.SNI_SUCCESS)
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -383,18 +383,6 @@ namespace Microsoft.Data.SqlClient
             string clientKeyPassword = connectionOptions.ClientKeyPassword;
             bool useClientCertificate = connectionOptions.UsesClientCertificate;
 
-            if (useClientCertificate)
-            {
-#if NET
-                if (!LocalAppContextSwitches.UseManagedNetworking)
-                {
-                    throw new PlatformNotSupportedException(StringsHelper.GetString(Strings.SQL_ClientCertificateRequiresManagedSni));
-                }
-#else
-                throw new PlatformNotSupportedException(StringsHelper.GetString(Strings.SQL_ClientCertificateRequiresManagedSni));
-#endif
-            }
-
             if (_state != TdsParserState.Closed)
             {
                 Debug.Fail("TdsParser.Connect called on non-closed connection!");

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -378,6 +378,22 @@ namespace Microsoft.Data.SqlClient
             SqlAuthenticationMethod authType = connectionOptions.Authentication;
             string hostNameInCertificate = connectionOptions.HostNameInCertificate;
             string serverCertificateFilename = connectionOptions.ServerCertificate;
+            string clientCertificate = connectionOptions.ClientCertificate;
+            string clientKey = connectionOptions.ClientKey;
+            string clientKeyPassword = connectionOptions.ClientKeyPassword;
+            bool useClientCertificate = connectionOptions.UsesClientCertificate;
+
+            if (useClientCertificate)
+            {
+#if NET
+                if (!LocalAppContextSwitches.UseManagedNetworking)
+                {
+                    throw new PlatformNotSupportedException(StringsHelper.GetString(Strings.SQL_ClientCertificateRequiresManagedSni));
+                }
+#else
+                throw new PlatformNotSupportedException(StringsHelper.GetString(Strings.SQL_ClientCertificateRequiresManagedSni));
+#endif
+            }
 
             if (_state != TdsParserState.Closed)
             {
@@ -403,7 +419,9 @@ namespace Microsoft.Data.SqlClient
             else
             {
                 SqlClientEventSource.Log.TryTraceEvent("TdsParser.Connect | SEC | Connection Object Id {0}, Authentication Mode: {1}", _connHandler.ObjectID,
-                    authType == SqlAuthenticationMethod.NotSpecified ? SqlAuthenticationMethod.SqlPassword.ToString() : authType.ToString());
+                    useClientCertificate
+                        ? nameof(SqlConnectionStringBuilder.ClientCertificate)
+                        : authType == SqlAuthenticationMethod.NotSpecified ? SqlAuthenticationMethod.SqlPassword.ToString() : authType.ToString());
             }
 
             // Encryption is not supported on SQL Local DB - disable it if they have only specified Mandatory
@@ -545,7 +563,7 @@ namespace Microsoft.Data.SqlClient
             if (!ClientOSEncryptionSupport)
             {
                 //If encryption is required, an error will be thrown.
-                if (encrypt != SqlConnectionEncryptOption.Optional)
+                if (useClientCertificate || encrypt != SqlConnectionEncryptOption.Optional)
                 {
                     _physicalStateObj.AddError(new SqlError(TdsEnums.ENCRYPTION_NOT_SUPPORTED, (byte)0x00, TdsEnums.FATAL_ERROR_CLASS, _server, SQLMessage.EncryptionNotSupportedByClient(), "", 0));
                     _physicalStateObj.Dispose();
@@ -556,7 +574,14 @@ namespace Microsoft.Data.SqlClient
 
             // UNDONE - send "" for instance now, need to fix later
             SqlClientEventSource.Log.TryTraceEvent("<sc.TdsParser.Connect|SEC> Sending prelogin handshake");
-            SendPreLoginHandshake(instanceName, encrypt, integratedSecurity, serverCertificateFilename);
+            SendPreLoginHandshake(
+                instanceName,
+                encrypt,
+                integratedSecurity,
+                serverCertificateFilename,
+                clientCertificate,
+                clientKey,
+                clientKeyPassword);
 
             _connHandler.TimeoutErrorInternal.EndPhase(SqlConnectionTimeoutErrorPhase.SendPreLoginHandshake);
             _connHandler.TimeoutErrorInternal.SetAndBeginPhase(SqlConnectionTimeoutErrorPhase.ConsumePreLoginHandshake);
@@ -570,7 +595,10 @@ namespace Microsoft.Data.SqlClient
                 out marsCapable,
                 out _connHandler._fedAuthRequired,
                 isTlsFirst,
-                serverCertificateFilename);
+                serverCertificateFilename,
+                clientCertificate,
+                clientKey,
+                clientKeyPassword);
 
             if (status == PreLoginHandshakeStatus.InstanceFailure)
             {
@@ -616,7 +644,14 @@ namespace Microsoft.Data.SqlClient
                     _physicalStateObj.AssignPendingDNSInfo(serverInfo.UserProtocol, FQDNforDNSCache, ref _connHandler.pendingSQLDNSObject);
                 }
 
-                SendPreLoginHandshake(instanceName, encrypt, integratedSecurity, serverCertificateFilename);
+                SendPreLoginHandshake(
+                    instanceName,
+                    encrypt,
+                    integratedSecurity,
+                    serverCertificateFilename,
+                    clientCertificate,
+                    clientKey,
+                    clientKeyPassword);
                 status = ConsumePreLoginHandshake(
                     encrypt,
                     trustServerCert,
@@ -624,7 +659,10 @@ namespace Microsoft.Data.SqlClient
                     out marsCapable,
                     out _connHandler._fedAuthRequired,
                     isTlsFirst,
-                    serverCertificateFilename);
+                    serverCertificateFilename,
+                    clientCertificate,
+                    clientKey,
+                    clientKeyPassword);
 
                 if (status == PreLoginHandshakeStatus.InstanceFailure)
                 {
@@ -653,7 +691,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void RemoveEncryption()
         {
-            Debug.Assert(_encryptionOption == EncryptionOptions.LOGIN, "Invalid encryption option state");
+            Debug.Assert((_encryptionOption & EncryptionOptions.OPTIONS_MASK) == EncryptionOptions.LOGIN, "Invalid encryption option state");
 
             uint error = _physicalStateObj.DisableSsl();
 
@@ -761,14 +799,24 @@ namespace Microsoft.Data.SqlClient
             byte[] instanceName,
             SqlConnectionEncryptOption encrypt,
             bool integratedSecurity,
-            string serverCertificateFilename)
+            string serverCertificateFilename,
+            string clientCertificate,
+            string clientKey,
+            string clientKeyPassword)
         {
             if (encrypt == SqlConnectionEncryptOption.Strict)
             {
                 //Always validate the certificate when in strict encryption mode
                 uint info = TdsEnums.SNI_SSL_VALIDATE_CERTIFICATE | TdsEnums.SNI_SSL_USE_SCHANNEL_CACHE | TdsEnums.SNI_SSL_SEND_ALPN_EXTENSION;
 
-                EnableSsl(info, encrypt, integratedSecurity, serverCertificateFilename);
+                EnableSsl(
+                    info,
+                    encrypt,
+                    integratedSecurity,
+                    serverCertificateFilename,
+                    clientCertificate,
+                    clientKey,
+                    clientKeyPassword);
 
                 // Since encryption has already been negotiated, we need to set encryption not supported in
                 // prelogin so that we don't try to negotiate encryption again during ConsumePreLoginHandshake.
@@ -827,7 +875,7 @@ namespace Microsoft.Data.SqlClient
                         break;
 
                     case (int)PreLoginOptions.ENCRYPT:
-                        if (_encryptionOption == EncryptionOptions.NOT_SUP)
+                        if ((_encryptionOption & EncryptionOptions.OPTIONS_MASK) == EncryptionOptions.NOT_SUP)
                         {
                             //If OS doesn't support encryption and encryption is not required, inform server "not supported" by client.
                             payload[payloadLength] = (byte)EncryptionOptions.NOT_SUP;
@@ -845,6 +893,12 @@ namespace Microsoft.Data.SqlClient
                                 payload[payloadLength] = (byte)EncryptionOptions.OFF;
                                 _encryptionOption = EncryptionOptions.OFF;
                             }
+                        }
+
+                        if (!string.IsNullOrEmpty(clientCertificate))
+                        {
+                            payload[payloadLength] |= (byte)EncryptionOptions.CLIENT_CERT;
+                            _encryptionOption |= EncryptionOptions.CLIENT_CERT;
                         }
 
                         payloadLength += 1;
@@ -933,7 +987,14 @@ namespace Microsoft.Data.SqlClient
             _physicalStateObj.WritePacket(TdsEnums.HARDFLUSH);
         }
 
-        private void EnableSsl(uint info, SqlConnectionEncryptOption encrypt, bool integratedSecurity, string serverCertificateFilename)
+        private void EnableSsl(
+            uint info,
+            SqlConnectionEncryptOption encrypt,
+            bool integratedSecurity,
+            string serverCertificateFilename,
+            string clientCertificate,
+            string clientKey,
+            string clientKeyPassword)
         {
             uint error = 0;
 
@@ -945,10 +1006,18 @@ namespace Microsoft.Data.SqlClient
                 info |= TdsEnums.SNI_SSL_IGNORE_CHANNEL_BINDINGS;
             }
 
-#if NETFRAMEWORK
-            Debug.Assert((_encryptionOption & EncryptionOptions.CLIENT_CERT) == 0, "Client certificate authentication support has been removed");
-#endif
-            error = _physicalStateObj.EnableSsl(ref info, encrypt == SqlConnectionEncryptOption.Strict, serverCertificateFilename);
+            if (!string.IsNullOrEmpty(clientCertificate))
+            {
+                info &= ~TdsEnums.SNI_SSL_USE_SCHANNEL_CACHE;
+            }
+
+            error = _physicalStateObj.EnableSsl(
+                ref info,
+                encrypt == SqlConnectionEncryptOption.Strict,
+                serverCertificateFilename,
+                clientCertificate,
+                clientKey,
+                clientKeyPassword);
 
             if (error != TdsEnums.SNI_SUCCESS)
             {
@@ -1000,7 +1069,10 @@ namespace Microsoft.Data.SqlClient
             out bool marsCapable,
             out bool fedAuthRequired,
             bool tlsFirst,
-            string serverCertificateFilename)
+            string serverCertificateFilename,
+            string clientCertificate,
+            string clientKey,
+            string clientKeyPassword)
         {
             // Assign default values
             marsCapable = _fMARS;
@@ -1090,18 +1162,19 @@ namespace Microsoft.Data.SqlClient
                         // Any response other than NOT_SUP means the server supports encryption.
                         serverSupportsEncryption = serverOption != EncryptionOptions.NOT_SUP;
 
-                        switch (_encryptionOption)
+                        EncryptionOptions clientCertificateOption = _encryptionOption & EncryptionOptions.CLIENT_CERT;
+                        switch (_encryptionOption & EncryptionOptions.OPTIONS_MASK)
                         {
                             case (EncryptionOptions.OFF):
                                 if (serverOption == EncryptionOptions.OFF)
                                 {
                                     // Only encrypt login.
-                                    _encryptionOption = EncryptionOptions.LOGIN;
+                                    _encryptionOption = EncryptionOptions.LOGIN | clientCertificateOption;
                                 }
                                 else if (serverOption == EncryptionOptions.REQ)
                                 {
                                     // Encrypt all.
-                                    _encryptionOption = EncryptionOptions.ON;
+                                    _encryptionOption = EncryptionOptions.ON | clientCertificateOption;
                                 }
                                 // NOT_SUP: No encryption.
                                 break;
@@ -1207,8 +1280,9 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            if (_encryptionOption == EncryptionOptions.ON ||
-                _encryptionOption == EncryptionOptions.LOGIN)
+            EncryptionOptions negotiatedEncryptionOption = _encryptionOption & EncryptionOptions.OPTIONS_MASK;
+            if (negotiatedEncryptionOption == EncryptionOptions.ON ||
+                negotiatedEncryptionOption == EncryptionOptions.LOGIN)
             {
                 if (!serverSupportsEncryption)
                 {
@@ -1218,13 +1292,20 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 // Validate Certificate if Trust Server Certificate=false and Encryption forced (EncryptionOptions.ON) from Server.
-                bool shouldValidateServerCert = (_encryptionOption == EncryptionOptions.ON && !trustServerCert) ||
+                bool shouldValidateServerCert = (negotiatedEncryptionOption == EncryptionOptions.ON && !trustServerCert) ||
                     ((_connHandler._accessTokenInBytes != null || _connHandler._accessTokenCallback != null) && !trustServerCert);
 
                 uint info = (shouldValidateServerCert ? TdsEnums.SNI_SSL_VALIDATE_CERTIFICATE : 0)
                     | TdsEnums.SNI_SSL_USE_SCHANNEL_CACHE;
 
-                EnableSsl(info, encrypt, integratedSecurity, serverCertificateFilename);
+                EnableSsl(
+                    info,
+                    encrypt,
+                    integratedSecurity,
+                    serverCertificateFilename,
+                    clientCertificate,
+                    clientKey,
+                    clientKeyPassword);
             }
 
             return PreLoginHandshakeStatus.Successful;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
@@ -33,8 +33,8 @@ namespace Microsoft.Data.SqlClient
         OPTIONS_MASK = 0x3f,
 #if NETFRAMEWORK
         CTAIP = 0x40,
-        CLIENT_CERT = 0x80,
 #endif
+        CLIENT_CERT = 0x80,
     }
 
     internal enum PreLoginHandshakeStatus

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -570,7 +570,13 @@ namespace Microsoft.Data.SqlClient
             string hostNameInCertificate,
             string serverCertificateFilename);
 
-        internal abstract uint EnableSsl(ref uint info, bool tlsFirst, string serverCertificateFilename);
+        internal abstract uint EnableSsl(
+            ref uint info,
+            bool tlsFirst,
+            string serverCertificateFilename,
+            string clientCertificate,
+            string clientKey,
+            string clientKeyPassword);
 
         internal abstract uint CheckConnection();
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.netcore.cs
@@ -373,13 +373,19 @@ namespace Microsoft.Data.SqlClient.ManagedSni
 
         internal override uint PostReadAsyncForMars(TdsParserStateObject physicalStateObject) => TdsEnums.SNI_SUCCESS_IO_PENDING;
 
-        internal override uint EnableSsl(ref uint info, bool tlsFirst, string serverCertificateFilename)
+        internal override uint EnableSsl(
+            ref uint info,
+            bool tlsFirst,
+            string serverCertificateFilename,
+            string clientCertificate,
+            string clientKey,
+            string clientKeyPassword)
         {
             SniHandle sessionHandle = GetSessionSNIHandleHandleOrThrow();
             try
             {
                 SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.EnableSsl | Info | Session Id {0}", sessionHandle.ConnectionId);
-                return sessionHandle.EnableSsl(info);
+                return sessionHandle.EnableSsl(info, clientCertificate, clientKey, clientKeyPassword);
             }
             catch (Exception e)
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -9,6 +9,8 @@ using System.Net;
 using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Threading.Tasks;
+using Interop.Windows;
+using Interop.Windows.Crypt32;
 using Interop.Windows.Sni;
 using Microsoft.Data.Common;
 using Microsoft.Data.ProviderBase;
@@ -29,6 +31,13 @@ namespace Microsoft.Data.SqlClient
         private readonly Dictionary<IntPtr, SNIPacket> _pendingWritePackets = new Dictionary<IntPtr, SNIPacket>(); // Stores write packets that have been sent to SNI, but have not yet finished writing (i.e. we are waiting for SNI's callback)
 
         private SqlClientCertificateContext _clientCertificateContext = null; // client certificate presented during the TLS handshake, released on dispose
+
+        private SqlClientCertificateDelegate _clientCertificateCallback = null; // rooted so native SNI can call back into managed code
+
+        // An all-zero SHA-1 hash, used to drive native SNI's certificate lookup straight to the
+        // fallback callback. Certificate authentication is only enabled when this identifier is set,
+        // and no certificate can hash to this value, so the store searches always miss.
+        private const string UnmatchableCertificateId = "0000000000000000000000000000000000000000";
 
         internal TdsParserStateObjectNative(TdsParser parser, TdsParserStateObject physicalConnection, bool async)
             : base(parser, physicalConnection, async)
@@ -277,6 +286,7 @@ namespace Microsoft.Data.SqlClient
 
             _clientCertificateContext?.Dispose();
             _clientCertificateContext = null;
+            _clientCertificateCallback = null;
         }
 
         protected override void FreeGcHandle(int remaining, bool release)
@@ -468,19 +478,90 @@ namespace Microsoft.Data.SqlClient
                 clientKeyPassword);
             _clientCertificateContext = certificateContext;
 
+            // SNI selects a client certificate by identifier rather than by certificate context: it
+            // searches the LocalMachine and CurrentUser personal stores, and only calls the fallback
+            // callback when neither store holds a match. The configured file is the only authoritative
+            // source for this connection, so pass an identifier that cannot match a stored certificate
+            // and let the callback supply the certificate loaded from disk. Passing the real thumbprint
+            // would instead let a same-thumbprint store entry win, which fails when that entry was
+            // imported without its private key.
+            _clientCertificateCallback = ProvideClientCertificate;
+            authInfo.certId = UnmatchableCertificateId;
+            authInfo.certHash = true;
+            authInfo.clientCertificateCallbackContext = IntPtr.Zero;
+            authInfo.clientCertificateCallback = _clientCertificateCallback;
+
             try
             {
-                // SNI copies the certificate with CertDuplicateCertificateContext while adding the
-                // provider. X509Certificate2.Handle does not keep its certificate alive, so the
-                // managed object must be rooted across the call.
-                authInfo.certContext = certificateContext.Certificate.Handle;
-
                 // Add SSL (Encryption) SNI provider.
                 return SniNativeWrapper.SniAddProvider(Handle, Provider.SSL_PROV, ref authInfo);
             }
             finally
             {
+                // The callback runs while the provider is being added, and neither the delegate nor
+                // the certificate is reachable from the marshalled struct once the call returns.
                 GC.KeepAlive(certificateContext);
+                GC.KeepAlive(_clientCertificateCallback);
+            }
+        }
+
+        /// <summary>
+        /// Supplies the certificate loaded from disk when SNI cannot find <paramref name="certId" />
+        /// in the LocalMachine or CurrentUser personal store.
+        /// </summary>
+        /// <param name="callbackContext">Unused; the certificate is held by this state object.</param>
+        /// <param name="certHash">Whether <paramref name="certId" /> is a SHA-1 hash.</param>
+        /// <param name="certId">The certificate identifier that the store lookup failed to resolve.</param>
+        /// <param name="certContext">Receives the certificate context that SNI takes ownership of.</param>
+        /// <param name="keyContainerFlags">Receives zero, because no temporary key container is created.</param>
+        /// <param name="keyContainerLength">The capacity of <paramref name="keyContainer" />.</param>
+        /// <param name="keyContainer">Left empty, because no temporary key container is created.</param>
+        /// <returns>A Windows error code, where zero indicates success.</returns>
+        private uint ProvideClientCertificate(
+            IntPtr callbackContext,
+            bool certHash,
+            string certId,
+            out IntPtr certContext,
+            out uint keyContainerFlags,
+            uint keyContainerLength,
+            IntPtr keyContainer)
+        {
+            certContext = IntPtr.Zero;
+            keyContainerFlags = 0;
+
+            // This runs as a callback from native code, where an escaping exception would tear down
+            // the process instead of failing the connection.
+            try
+            {
+                SqlClientCertificateContext certificateContext = _clientCertificateContext;
+                if (certificateContext is null)
+                {
+                    return SystemErrors.ERROR_FILE_NOT_FOUND;
+                }
+
+                // SNI releases the returned context with CertFreeCertificateContext, so hand it a
+                // duplicate and leave the managed certificate's own handle intact.
+                IntPtr duplicate = Crypt32.CertDuplicateCertificateContext(
+                    certificateContext.Certificate.Handle);
+                GC.KeepAlive(certificateContext);
+
+                if (duplicate == IntPtr.Zero)
+                {
+                    uint error = (uint)Marshal.GetLastWin32Error();
+                    return error == SystemErrors.ERROR_SUCCESS
+                        ? (uint)SystemErrors.ERROR_FILE_NOT_FOUND
+                        : error;
+                }
+
+                certContext = duplicate;
+                return SystemErrors.ERROR_SUCCESS;
+            }
+            catch (Exception e)
+            {
+                SqlClientEventSource.Log.TryTraceEvent(
+                    "<sc.TdsParserStateObjectNative.ProvideClientCertificate|ERR> {0}",
+                    e.Message);
+                return SystemErrors.ERROR_FILE_NOT_FOUND;
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Data.SqlClient
 
         private readonly Dictionary<IntPtr, SNIPacket> _pendingWritePackets = new Dictionary<IntPtr, SNIPacket>(); // Stores write packets that have been sent to SNI, but have not yet finished writing (i.e. we are waiting for SNI's callback)
 
+        private SqlClientCertificateContext _clientCertificateContext = null; // client certificate presented during the TLS handshake, released on dispose
+
         internal TdsParserStateObjectNative(TdsParser parser, TdsParserStateObject physicalConnection, bool async)
             : base(parser, physicalConnection, async)
         {
@@ -272,6 +274,9 @@ namespace Microsoft.Data.SqlClient
             }
 
             DisposePacketCache();
+
+            _clientCertificateContext?.Dispose();
+            _clientCertificateContext = null;
         }
 
         protected override void FreeGcHandle(int remaining, bool release)
@@ -442,15 +447,22 @@ namespace Microsoft.Data.SqlClient
             string clientKey,
             string clientKeyPassword)
         {
-            if (!string.IsNullOrEmpty(clientCertificate))
-            {
-                throw new PlatformNotSupportedException(StringsHelper.GetString(Strings.SQL_ClientCertificateRequiresManagedSni));
-            }
-
             AuthProviderInfo authInfo = new AuthProviderInfo();
             authInfo.flags = info;
             authInfo.tlsFirst = tlsFirst;
             authInfo.serverCertFileName = string.IsNullOrEmpty(serverCertificateFilename) ? null : serverCertificateFilename;
+
+            if (!string.IsNullOrEmpty(clientCertificate))
+            {
+                // SNI reads the certificate through AuthProviderInfo.certContext and duplicates it
+                // with CertDuplicateCertificateContext, so this object must stay alive for the
+                // duration of the call and is released when the state object is disposed.
+                _clientCertificateContext = SqlClientCertificateLoader.Load(
+                    clientCertificate,
+                    clientKey,
+                    clientKeyPassword);
+                authInfo.certContext = _clientCertificateContext.Certificate.Handle;
+            }
 
             // Add SSL (Encryption) SNI provider.
             return SniNativeWrapper.SniAddProvider(Handle, Provider.SSL_PROV, ref authInfo);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -452,20 +452,36 @@ namespace Microsoft.Data.SqlClient
             authInfo.tlsFirst = tlsFirst;
             authInfo.serverCertFileName = string.IsNullOrEmpty(serverCertificateFilename) ? null : serverCertificateFilename;
 
-            if (!string.IsNullOrEmpty(clientCertificate))
+            if (string.IsNullOrEmpty(clientCertificate))
             {
-                // SNI reads the certificate through AuthProviderInfo.certContext and duplicates it
-                // with CertDuplicateCertificateContext, so this object must stay alive for the
-                // duration of the call and is released when the state object is disposed.
-                _clientCertificateContext = SqlClientCertificateLoader.Load(
-                    clientCertificate,
-                    clientKey,
-                    clientKeyPassword);
-                authInfo.certContext = _clientCertificateContext.Certificate.Handle;
+                // Add SSL (Encryption) SNI provider.
+                return SniNativeWrapper.SniAddProvider(Handle, Provider.SSL_PROV, ref authInfo);
             }
 
-            // Add SSL (Encryption) SNI provider.
-            return SniNativeWrapper.SniAddProvider(Handle, Provider.SSL_PROV, ref authInfo);
+            // A previous attempt on this state object may have left a certificate behind.
+            _clientCertificateContext?.Dispose();
+            _clientCertificateContext = null;
+
+            SqlClientCertificateContext certificateContext = SqlClientCertificateLoader.Load(
+                clientCertificate,
+                clientKey,
+                clientKeyPassword);
+            _clientCertificateContext = certificateContext;
+
+            try
+            {
+                // SNI copies the certificate with CertDuplicateCertificateContext while adding the
+                // provider. X509Certificate2.Handle does not keep its certificate alive, so the
+                // managed object must be rooted across the call.
+                authInfo.certContext = certificateContext.Certificate.Handle;
+
+                // Add SSL (Encryption) SNI provider.
+                return SniNativeWrapper.SniAddProvider(Handle, Provider.SSL_PROV, ref authInfo);
+            }
+            finally
+            {
+                GC.KeepAlive(certificateContext);
+            }
         }
 
         internal override uint SetConnectionBufferSize(ref uint unsignedPacketSize)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -434,8 +434,19 @@ namespace Microsoft.Data.SqlClient
             return error;
         }
 
-        internal override uint EnableSsl(ref uint info, bool tlsFirst, string serverCertificateFilename)
+        internal override uint EnableSsl(
+            ref uint info,
+            bool tlsFirst,
+            string serverCertificateFilename,
+            string clientCertificate,
+            string clientKey,
+            string clientKeyPassword)
         {
+            if (!string.IsNullOrEmpty(clientCertificate))
+            {
+                throw new PlatformNotSupportedException(StringsHelper.GetString(Strings.SQL_ClientCertificateRequiresManagedSni));
+            }
+
             AuthProviderInfo authInfo = new AuthProviderInfo();
             authInfo.flags = info;
             authInfo.tlsFirst = tlsFirst;

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
@@ -2887,11 +2887,47 @@ namespace System {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Client Key supports only RSA PKCS#1 or PKCS#8 private keys. Use a PFX or P12 certificate for other key algorithms..
+        ///   Looks up a localized string similar to Client Key supports only RSA private keys. Use a PFX or P12 certificate for other key algorithms..
         /// </summary>
         internal static string SQL_ClientCertificateUnsupportedKeyAlgorithm {
             get {
                 return ResourceManager.GetString("SQL_ClientCertificateUnsupportedKeyAlgorithm", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Password-protected PKCS#1 private keys are not supported. Convert the key to encrypted PKCS#8, or use a PFX or P12 certificate..
+        /// </summary>
+        internal static string SQL_ClientCertificateEncryptedPkcs1NotSupported {
+            get {
+                return ResourceManager.GetString("SQL_ClientCertificateEncryptedPkcs1NotSupported", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The ODBC 'file:' path syntax is not supported. Specify the certificate and key file paths directly..
+        /// </summary>
+        internal static string SQL_ClientCertificateOdbcPathSyntax {
+            get {
+                return ResourceManager.GetString("SQL_ClientCertificateOdbcPathSyntax", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Client certificate authentication requires an encrypted connection, but the server did not negotiate encryption..
+        /// </summary>
+        internal static string SQL_ClientCertificateRequiresEncryption {
+            get {
+                return ResourceManager.GetString("SQL_ClientCertificateRequiresEncryption", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to ChangePassword cannot be used with client certificate authentication..
+        /// </summary>
+        internal static string SQL_ChangePasswordConflictsWithClientCertificate {
+            get {
+                return ResourceManager.GetString("SQL_ChangePasswordConflictsWithClientCertificate", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
@@ -2851,15 +2851,6 @@ namespace System {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Client certificate authentication requires managed networking and is not supported by native SNI or .NET Framework..
-        /// </summary>
-        internal static string SQL_ClientCertificateRequiresManagedSni {
-            get {
-                return ResourceManager.GetString("SQL_ClientCertificateRequiresManagedSni", resourceCulture);
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to The client certificate or private key could not be loaded..
         /// </summary>
         internal static string SQL_ClientCertificateLoadFailed {
@@ -2919,6 +2910,15 @@ namespace System {
         internal static string SQL_ClientKeyWithPkcs12Certificate {
             get {
                 return ResourceManager.GetString("SQL_ClientKeyWithPkcs12Certificate", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Client Key is not supported on .NET Framework. Supply the client certificate as a PKCS#12 (PFX or P12) file, which contains its own private key, or target .NET..
+        /// </summary>
+        internal static string SQL_ClientKeyRequiresNetCore {
+            get {
+                return ResourceManager.GetString("SQL_ClientKeyRequiresNetCore", resourceCulture);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
@@ -518,6 +518,15 @@ namespace System {
                 return ResourceManager.GetString("ADP_InvalidMixedUsageOfSecureCredentialAndIntegratedSecurity", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Client certificate authentication cannot be combined with User ID, Password, Integrated Security, Authentication, Credential, AccessToken, AccessTokenCallback, or SspiContextProvider..
+        /// </summary>
+        internal static string ADP_InvalidMixedUsageOfClientCertificateAuthentication {
+            get {
+                return ResourceManager.GetString("ADP_InvalidMixedUsageOfClientCertificateAuthentication", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to {0} &quot;{1}&quot;..
@@ -1299,6 +1308,33 @@ namespace System {
         internal static string DbConnectionString_Authentication {
             get {
                 return ResourceManager.GetString("DbConnectionString_Authentication", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The path to the client certificate used for SQL Server on Linux loopback authentication..
+        /// </summary>
+        internal static string DbConnectionString_ClientCertificate {
+            get {
+                return ResourceManager.GetString("DbConnectionString_ClientCertificate", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The path to the private key for the client certificate..
+        /// </summary>
+        internal static string DbConnectionString_ClientKey {
+            get {
+                return ResourceManager.GetString("DbConnectionString_ClientKey", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The password used to access the client certificate or private key..
+        /// </summary>
+        internal static string DbConnectionString_ClientKeyPassword {
+            get {
+                return ResourceManager.GetString("DbConnectionString_ClientKeyPassword", resourceCulture);
             }
         }
         
@@ -2811,6 +2847,51 @@ namespace System {
         internal static string SQL_AuthenticationAndIntegratedSecurity {
             get {
                 return ResourceManager.GetString("SQL_AuthenticationAndIntegratedSecurity", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Client certificate authentication requires managed networking and is not supported by native SNI or .NET Framework..
+        /// </summary>
+        internal static string SQL_ClientCertificateRequiresManagedSni {
+            get {
+                return ResourceManager.GetString("SQL_ClientCertificateRequiresManagedSni", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The client certificate or private key could not be loaded..
+        /// </summary>
+        internal static string SQL_ClientCertificateLoadFailed {
+            get {
+                return ResourceManager.GetString("SQL_ClientCertificateLoadFailed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The client certificate does not have an associated private key..
+        /// </summary>
+        internal static string SQL_ClientCertificateMissingPrivateKey {
+            get {
+                return ResourceManager.GetString("SQL_ClientCertificateMissingPrivateKey", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The client certificate is not currently valid..
+        /// </summary>
+        internal static string SQL_ClientCertificateNotValid {
+            get {
+                return ResourceManager.GetString("SQL_ClientCertificateNotValid", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Client Key supports only RSA PKCS#1 or PKCS#8 private keys. Use a PFX or P12 certificate for other key algorithms..
+        /// </summary>
+        internal static string SQL_ClientCertificateUnsupportedKeyAlgorithm {
+            get {
+                return ResourceManager.GetString("SQL_ClientCertificateUnsupportedKeyAlgorithm", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
@@ -2914,6 +2914,15 @@ namespace System {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Client Key cannot be used with a PKCS#12 (PFX or P12) certificate because the certificate already contains its private key. Remove Client Key, or supply the certificate in PEM or DER format..
+        /// </summary>
+        internal static string SQL_ClientKeyWithPkcs12Certificate {
+            get {
+                return ResourceManager.GetString("SQL_ClientKeyWithPkcs12Certificate", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Client certificate authentication requires an encrypted connection, but the server did not negotiate encryption..
         /// </summary>
         internal static string SQL_ClientCertificateRequiresEncryption {

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
@@ -213,6 +213,9 @@
   <data name="ADP_InvalidMixedUsageOfSecureCredentialAndIntegratedSecurity" xml:space="preserve">
     <value>Cannot use Credential with Integrated Security connection string keyword.</value>
   </data>
+  <data name="ADP_InvalidMixedUsageOfClientCertificateAuthentication" xml:space="preserve">
+    <value>Client certificate authentication cannot be combined with User ID, Password, Integrated Security, Authentication, Credential, AccessToken, AccessTokenCallback, or SspiContextProvider.</value>
+  </data>
   <data name="ADP_InvalidMixedUsageOfAccessTokenAndUserIDPassword" xml:space="preserve">
     <value>Cannot set the AccessToken property if 'UserID', 'UID', 'Password', or 'PWD' has been specified in connection string.</value>
   </data>
@@ -521,6 +524,21 @@
   </data>
   <data name="SQL_AuthenticationAndIntegratedSecurity" xml:space="preserve">
     <value>Cannot use 'Authentication' with 'Integrated Security'.</value>
+  </data>
+  <data name="SQL_ClientCertificateRequiresManagedSni" xml:space="preserve">
+    <value>Client certificate authentication requires managed networking and is not supported by native SNI or .NET Framework.</value>
+  </data>
+  <data name="SQL_ClientCertificateLoadFailed" xml:space="preserve">
+    <value>The client certificate or private key could not be loaded.</value>
+  </data>
+  <data name="SQL_ClientCertificateMissingPrivateKey" xml:space="preserve">
+    <value>The client certificate does not have an associated private key.</value>
+  </data>
+  <data name="SQL_ClientCertificateNotValid" xml:space="preserve">
+    <value>The client certificate is not currently valid.</value>
+  </data>
+  <data name="SQL_ClientCertificateUnsupportedKeyAlgorithm" xml:space="preserve">
+    <value>Client Key supports only RSA PKCS#1 or PKCS#8 private keys. Use a PFX or P12 certificate for other key algorithms.</value>
   </data>
   <data name="SQL_IntegratedWithPassword" xml:space="preserve">
     <value>Cannot use 'Authentication=Active Directory Integrated' with 'Password' or 'PWD' connection string keywords.</value>
@@ -1028,6 +1046,15 @@
   </data>
   <data name="DbConnectionString_Authentication" xml:space="preserve">
     <value>Specifies the method of authenticating with SQL Server.</value>
+  </data>
+  <data name="DbConnectionString_ClientCertificate" xml:space="preserve">
+    <value>The path to the client certificate used for SQL Server on Linux loopback authentication.</value>
+  </data>
+  <data name="DbConnectionString_ClientKey" xml:space="preserve">
+    <value>The path to the private key for the client certificate.</value>
+  </data>
+  <data name="DbConnectionString_ClientKeyPassword" xml:space="preserve">
+    <value>The password used to access the client certificate or private key.</value>
   </data>
   <data name="SqlConnection_AccessToken" xml:space="preserve">
     <value>Access token to use for authentication.</value>

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
@@ -525,9 +525,6 @@
   <data name="SQL_AuthenticationAndIntegratedSecurity" xml:space="preserve">
     <value>Cannot use 'Authentication' with 'Integrated Security'.</value>
   </data>
-  <data name="SQL_ClientCertificateRequiresManagedSni" xml:space="preserve">
-    <value>Client certificate authentication requires managed networking and is not supported by native SNI or .NET Framework.</value>
-  </data>
   <data name="SQL_ClientCertificateLoadFailed" xml:space="preserve">
     <value>The client certificate or private key could not be loaded.</value>
   </data>
@@ -548,6 +545,9 @@
   </data>
   <data name="SQL_ClientKeyWithPkcs12Certificate" xml:space="preserve">
     <value>Client Key cannot be used with a PKCS#12 (PFX or P12) certificate because the certificate already contains its private key. Remove Client Key, or supply the certificate in PEM or DER format.</value>
+  </data>
+  <data name="SQL_ClientKeyRequiresNetCore" xml:space="preserve">
+    <value>Client Key is not supported on .NET Framework. Supply the client certificate as a PKCS#12 (PFX or P12) file, which contains its own private key, or target .NET.</value>
   </data>
   <data name="SQL_ClientCertificateRequiresEncryption" xml:space="preserve">
     <value>Client certificate authentication requires an encrypted connection, but the server did not negotiate encryption.</value>

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
@@ -538,7 +538,19 @@
     <value>The client certificate is not currently valid.</value>
   </data>
   <data name="SQL_ClientCertificateUnsupportedKeyAlgorithm" xml:space="preserve">
-    <value>Client Key supports only RSA PKCS#1 or PKCS#8 private keys. Use a PFX or P12 certificate for other key algorithms.</value>
+    <value>Client Key supports only RSA private keys. Use a PFX or P12 certificate for other key algorithms.</value>
+  </data>
+  <data name="SQL_ClientCertificateEncryptedPkcs1NotSupported" xml:space="preserve">
+    <value>Password-protected PKCS#1 private keys are not supported. Convert the key to encrypted PKCS#8, or use a PFX or P12 certificate.</value>
+  </data>
+  <data name="SQL_ClientCertificateOdbcPathSyntax" xml:space="preserve">
+    <value>The ODBC 'file:' path syntax is not supported. Specify the certificate and key file paths directly.</value>
+  </data>
+  <data name="SQL_ClientCertificateRequiresEncryption" xml:space="preserve">
+    <value>Client certificate authentication requires an encrypted connection, but the server did not negotiate encryption.</value>
+  </data>
+  <data name="SQL_ChangePasswordConflictsWithClientCertificate" xml:space="preserve">
+    <value>ChangePassword cannot be used with client certificate authentication.</value>
   </data>
   <data name="SQL_IntegratedWithPassword" xml:space="preserve">
     <value>Cannot use 'Authentication=Active Directory Integrated' with 'Password' or 'PWD' connection string keywords.</value>

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
@@ -546,6 +546,9 @@
   <data name="SQL_ClientCertificateOdbcPathSyntax" xml:space="preserve">
     <value>The ODBC 'file:' path syntax is not supported. Specify the certificate and key file paths directly.</value>
   </data>
+  <data name="SQL_ClientKeyWithPkcs12Certificate" xml:space="preserve">
+    <value>Client Key cannot be used with a PKCS#12 (PFX or P12) certificate because the certificate already contains its private key. Remove Client Key, or supply the certificate in PEM or DER format.</value>
+  </data>
   <data name="SQL_ClientCertificateRequiresEncryption" xml:space="preserve">
     <value>Client certificate authentication requires an encrypted connection, but the server did not negotiate encryption.</value>
   </data>

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
@@ -103,12 +103,14 @@ namespace Microsoft.Data.SqlClient.Tests
         [InlineData("HostNameInCertificate = tds.test.com")]
         [InlineData("Server Certificate = c:\\test.cer")]
         [InlineData("ServerCertificate = c:\\test.cer")]
+#if NET
         [InlineData("Client Certificate = c:\\client.pfx")]
         [InlineData("ClientCertificate = c:\\client.pfx")]
         [InlineData("Client Certificate = c:\\client.pem;Client Key = c:\\client.key")]
         [InlineData("ClientCertificate = c:\\client.pem;ClientKey = c:\\client.key")]
         [InlineData("Client Certificate = c:\\client.pfx;Client Key Password = <pwd>")]
         [InlineData("ClientCertificate = c:\\client.pfx;ClientKeyPassword = <pwd>")]
+#endif
         [InlineData("Server SPN = server1")]
         [InlineData("ServerSPN = server2")]
         [InlineData("Failover Partner SPN = server3")]
@@ -446,6 +448,7 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Equal(testhostname, builder.HostNameInCertificate);
         }
 
+#if NET
         /// <summary>
         /// Verifies that client certificate authentication options round-trip through strongly typed builder properties.
         /// </summary>
@@ -466,6 +469,46 @@ namespace Microsoft.Data.SqlClient.Tests
                 "Client Certificate=client.pem;Client Key=client.key;Client Key Password=<pwd>",
                 builder.ConnectionString);
         }
+
+        /// <summary>
+        /// Verifies that clearing the builder removes the client certificate options.
+        /// </summary>
+        [Fact]
+        public void ClientCertificateOptions_Clear()
+        {
+            SqlConnectionStringBuilder builder = new()
+            {
+                ClientCertificate = "client.pem",
+                ClientKey = "client.key",
+                ClientKeyPassword = "<pwd>"
+            };
+
+            builder.Clear();
+
+            Assert.Equal(string.Empty, builder.ClientCertificate);
+            Assert.Equal(string.Empty, builder.ClientKey);
+            Assert.Equal(string.Empty, builder.ClientKeyPassword);
+            Assert.Equal(string.Empty, builder.ConnectionString);
+        }
+#else
+        /// <summary>
+        /// Verifies that the client certificate keywords are not recognized on .NET Framework,
+        /// where managed networking (and therefore certificate authentication) is unavailable.
+        /// </summary>
+        [Theory]
+        [InlineData("Client Certificate")]
+        [InlineData("ClientCertificate")]
+        [InlineData("Client Key")]
+        [InlineData("ClientKey")]
+        [InlineData("Client Key Password")]
+        [InlineData("ClientKeyPassword")]
+        public void ClientCertificateOptions_NotSupportedOnNetFx(string keyword)
+        {
+            SqlConnectionStringBuilder builder = new();
+
+            Assert.Throws<ArgumentException>(() => builder[keyword] = "value");
+        }
+#endif
 
         [Fact]
         public void ConnectionBuilderEncryptBackwardsCompatibility()

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
@@ -103,14 +103,12 @@ namespace Microsoft.Data.SqlClient.Tests
         [InlineData("HostNameInCertificate = tds.test.com")]
         [InlineData("Server Certificate = c:\\test.cer")]
         [InlineData("ServerCertificate = c:\\test.cer")]
-#if NET
         [InlineData("Client Certificate = c:\\client.pfx")]
         [InlineData("ClientCertificate = c:\\client.pfx")]
         [InlineData("Client Certificate = c:\\client.pem;Client Key = c:\\client.key")]
         [InlineData("ClientCertificate = c:\\client.pem;ClientKey = c:\\client.key")]
         [InlineData("Client Certificate = c:\\client.pfx;Client Key Password = <pwd>")]
         [InlineData("ClientCertificate = c:\\client.pfx;ClientKeyPassword = <pwd>")]
-#endif
         [InlineData("Server SPN = server1")]
         [InlineData("ServerSPN = server2")]
         [InlineData("Failover Partner SPN = server3")]
@@ -448,7 +446,6 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Equal(testhostname, builder.HostNameInCertificate);
         }
 
-#if NET
         /// <summary>
         /// Verifies that client certificate authentication options round-trip through strongly typed builder properties.
         /// </summary>
@@ -490,25 +487,6 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Equal(string.Empty, builder.ClientKeyPassword);
             Assert.Equal(string.Empty, builder.ConnectionString);
         }
-#else
-        /// <summary>
-        /// Verifies that the client certificate keywords are not recognized on .NET Framework,
-        /// where managed networking (and therefore certificate authentication) is unavailable.
-        /// </summary>
-        [Theory]
-        [InlineData("Client Certificate")]
-        [InlineData("ClientCertificate")]
-        [InlineData("Client Key")]
-        [InlineData("ClientKey")]
-        [InlineData("Client Key Password")]
-        [InlineData("ClientKeyPassword")]
-        public void ClientCertificateOptions_NotSupportedOnNetFx(string keyword)
-        {
-            SqlConnectionStringBuilder builder = new();
-
-            Assert.Throws<ArgumentException>(() => builder[keyword] = "value");
-        }
-#endif
 
         [Fact]
         public void ConnectionBuilderEncryptBackwardsCompatibility()

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
@@ -103,6 +103,12 @@ namespace Microsoft.Data.SqlClient.Tests
         [InlineData("HostNameInCertificate = tds.test.com")]
         [InlineData("Server Certificate = c:\\test.cer")]
         [InlineData("ServerCertificate = c:\\test.cer")]
+        [InlineData("Client Certificate = c:\\client.pfx")]
+        [InlineData("ClientCertificate = c:\\client.pfx")]
+        [InlineData("Client Certificate = c:\\client.pem;Client Key = c:\\client.key")]
+        [InlineData("ClientCertificate = c:\\client.pem;ClientKey = c:\\client.key")]
+        [InlineData("Client Certificate = c:\\client.pfx;Client Key Password = <pwd>")]
+        [InlineData("ClientCertificate = c:\\client.pfx;ClientKeyPassword = <pwd>")]
         [InlineData("Server SPN = server1")]
         [InlineData("ServerSPN = server2")]
         [InlineData("Failover Partner SPN = server3")]
@@ -438,6 +444,27 @@ namespace Microsoft.Data.SqlClient.Tests
                 HostNameInCertificate = testhostname
             };
             Assert.Equal(testhostname, builder.HostNameInCertificate);
+        }
+
+        /// <summary>
+        /// Verifies that client certificate authentication options round-trip through strongly typed builder properties.
+        /// </summary>
+        [Fact]
+        public void ClientCertificateOptions_RoundTrip()
+        {
+            SqlConnectionStringBuilder builder = new()
+            {
+                ClientCertificate = "client.pem",
+                ClientKey = "client.key",
+                ClientKeyPassword = "<pwd>"
+            };
+
+            Assert.Equal("client.pem", builder.ClientCertificate);
+            Assert.Equal("client.key", builder.ClientKey);
+            Assert.Equal("<pwd>", builder.ClientKeyPassword);
+            Assert.Equal(
+                "Client Certificate=client.pem;Client Key=client.key;Client Key Password=<pwd>",
+                builder.ConnectionString);
         }
 
         [Fact]

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Data;
 using System.Collections.Generic;
+using System.Security;
 using Xunit;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -70,6 +71,44 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Equal(ConnectionState.Closed, cn.State);
             Assert.False(cn.StatisticsEnabled);
             Assert.True(string.Compare(Environment.MachineName, cn.WorkstationId, StringComparison.OrdinalIgnoreCase) == 0);
+        }
+
+        /// <summary>
+        /// Verifies that client certificate authentication cannot be combined with a <see cref="SqlCredential"/>.
+        /// </summary>
+        [Fact]
+        public void ClientCertificate_WithCredential_Throws()
+        {
+            using SecureString password = new();
+            password.AppendChar('x');
+            password.MakeReadOnly();
+            SqlCredential credential = new("user", password);
+
+            Assert.Throws<ArgumentException>(
+                () => new SqlConnection("ClientCertificate=client.pfx", credential));
+        }
+
+        /// <summary>
+        /// Verifies that client certificate authentication cannot be combined with an access token.
+        /// </summary>
+        [Fact]
+        public void ClientCertificate_WithAccessToken_Throws()
+        {
+            using SqlConnection connection = new("ClientCertificate=client.pfx");
+
+            Assert.Throws<InvalidOperationException>(() => connection.AccessToken = "token");
+        }
+
+        /// <summary>
+        /// Verifies that client certificate authentication cannot be combined with an access-token callback.
+        /// </summary>
+        [Fact]
+        public void ClientCertificate_WithAccessTokenCallback_Throws()
+        {
+            using SqlConnection connection = new("ClientCertificate=client.pfx");
+
+            Assert.Throws<InvalidOperationException>(
+                () => connection.AccessTokenCallback = (_, _) => throw new NotImplementedException());
         }
 
         [Fact]
@@ -944,6 +983,8 @@ namespace Microsoft.Data.SqlClient.Tests
         [InlineData("HostNameInCertificate=tds.test.com")]
         [InlineData("Server Certificate=c:\\test.cer")]
         [InlineData("ServerCertificate=c:\\test.cer")]
+        [InlineData("Client Certificate=c:\\client.pfx")]
+        [InlineData("ClientCertificate=c:\\client.pfx")]
         [InlineData("Enlist=false")]
         [InlineData("Enlist=true")]
         [InlineData("Integrated Security=true")]

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
@@ -73,7 +73,6 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.True(string.Compare(Environment.MachineName, cn.WorkstationId, StringComparison.OrdinalIgnoreCase) == 0);
         }
 
-#if NET
         /// <summary>
         /// Verifies that client certificate authentication cannot be combined with a <see cref="SqlCredential"/>.
         /// </summary>
@@ -139,7 +138,6 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Throws<InvalidOperationException>(
                 () => SqlConnection.ChangePassword("ClientCertificate=client.pfx", credential, newPassword));
         }
-#endif
 
         [Fact]
         public void Constructor2_ConnectionString_Invalid()
@@ -1013,10 +1011,8 @@ namespace Microsoft.Data.SqlClient.Tests
         [InlineData("HostNameInCertificate=tds.test.com")]
         [InlineData("Server Certificate=c:\\test.cer")]
         [InlineData("ServerCertificate=c:\\test.cer")]
-#if NET
         [InlineData("Client Certificate=c:\\client.pfx")]
         [InlineData("ClientCertificate=c:\\client.pfx")]
-#endif
         [InlineData("Enlist=false")]
         [InlineData("Enlist=true")]
         [InlineData("Integrated Security=true")]

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.True(string.Compare(Environment.MachineName, cn.WorkstationId, StringComparison.OrdinalIgnoreCase) == 0);
         }
 
+#if NET
         /// <summary>
         /// Verifies that client certificate authentication cannot be combined with a <see cref="SqlCredential"/>.
         /// </summary>
@@ -110,6 +111,35 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Throws<InvalidOperationException>(
                 () => connection.AccessTokenCallback = (_, _) => throw new NotImplementedException());
         }
+
+        /// <summary>
+        /// Verifies that a password change cannot be requested for a certificate-authenticated connection.
+        /// </summary>
+        [Fact]
+        public void ClientCertificate_ChangePassword_Throws()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => SqlConnection.ChangePassword("ClientCertificate=client.pfx", "newPassword"));
+        }
+
+        /// <summary>
+        /// Verifies that a secure password change cannot be requested for a certificate-authenticated connection.
+        /// </summary>
+        [Fact]
+        public void ClientCertificate_ChangePasswordWithCredential_Throws()
+        {
+            using SecureString password = new();
+            password.AppendChar('x');
+            password.MakeReadOnly();
+            using SecureString newPassword = new();
+            newPassword.AppendChar('y');
+            newPassword.MakeReadOnly();
+            SqlCredential credential = new("user", password);
+
+            Assert.Throws<InvalidOperationException>(
+                () => SqlConnection.ChangePassword("ClientCertificate=client.pfx", credential, newPassword));
+        }
+#endif
 
         [Fact]
         public void Constructor2_ConnectionString_Invalid()
@@ -983,8 +1013,10 @@ namespace Microsoft.Data.SqlClient.Tests
         [InlineData("HostNameInCertificate=tds.test.com")]
         [InlineData("Server Certificate=c:\\test.cer")]
         [InlineData("ServerCertificate=c:\\test.cer")]
+#if NET
         [InlineData("Client Certificate=c:\\client.pfx")]
         [InlineData("ClientCertificate=c:\\client.pfx")]
+#endif
         [InlineData("Enlist=false")]
         [InlineData("Enlist=true")]
         [InlineData("Integrated Security=true")]

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/ManagedSni/SniPacketTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/ManagedSni/SniPacketTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.ManagedSni
             {
             }
 
-            public override uint EnableSsl(uint options) => TdsEnums.SNI_SUCCESS;
+            public override uint EnableSsl(uint options, string clientCertificate, string clientKey, string clientKeyPassword) => TdsEnums.SNI_SUCCESS;
 
             public override SniPacket RentPacket(int headerSize, int dataSize)
             {

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/ManagedSni/SqlClientCertificateLoaderTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/ManagedSni/SqlClientCertificateLoaderTests.cs
@@ -301,6 +301,145 @@ namespace Microsoft.Data.SqlClient.UnitTests.ManagedSni
         }
 
         /// <summary>
+        /// Verifies that the container format is detected from the file contents rather than the
+        /// file extension, so a PKCS#12 bundle loads regardless of how it is named.
+        /// </summary>
+        /// <param name="fileName">The certificate file name under test.</param>
+        [Theory]
+        [InlineData("client.pem")]
+        [InlineData("client.cer")]
+        [InlineData("client")]
+        public void Load_Pkcs12WithNonPkcs12Extension_ReturnsCertificateWithPrivateKey(string fileName)
+        {
+            Directory.CreateDirectory(_temporaryDirectory);
+            string certificatePath = Path.Combine(_temporaryDirectory, fileName);
+
+            using X509Certificate2 source = CreateCertificate(
+                DateTimeOffset.UtcNow.AddMinutes(-5),
+                DateTimeOffset.UtcNow.AddMinutes(5));
+            File.WriteAllBytes(certificatePath, source.Export(X509ContentType.Pkcs12, Password));
+
+            using SqlClientCertificateContext loaded =
+                SqlClientCertificateLoader.Load(certificatePath, null, Password);
+
+            Assert.True(loaded.Certificate.HasPrivateKey);
+            Assert.Equal(source.Thumbprint, loaded.Certificate.Thumbprint);
+        }
+
+        /// <summary>
+        /// Verifies that a PEM certificate named with a PKCS#12 extension is still combined with a
+        /// detached private key rather than being rejected on the basis of its name.
+        /// </summary>
+        [Fact]
+        public void Load_PemWithPkcs12Extension_ReturnsCertificateWithPrivateKey()
+        {
+            Directory.CreateDirectory(_temporaryDirectory);
+            string certificatePath = Path.Combine(_temporaryDirectory, "client.pfx");
+            string keyPath = Path.Combine(_temporaryDirectory, "client.key");
+
+            using RSA key = RSA.Create(2048);
+            CertificateRequest request = new(
+                "CN=SqlClient Test",
+                key,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+            using X509Certificate2 source = request.CreateSelfSigned(
+                DateTimeOffset.UtcNow.AddMinutes(-5),
+                DateTimeOffset.UtcNow.AddMinutes(5));
+            File.WriteAllText(certificatePath, source.ExportCertificatePem());
+            File.WriteAllText(keyPath, key.ExportPkcs8PrivateKeyPem());
+
+            using SqlClientCertificateContext loaded =
+                SqlClientCertificateLoader.Load(certificatePath, keyPath, keyPassword: null);
+
+            Assert.True(loaded.Certificate.HasPrivateKey);
+            Assert.Equal(source.Thumbprint, loaded.Certificate.Thumbprint);
+        }
+
+        /// <summary>
+        /// Verifies that the ODBC driver's <c>file:</c> path syntax is rejected with a specific error.
+        /// </summary>
+        [Fact]
+        public void Load_OdbcStylePath_ThrowsAuthenticationException()
+        {
+            Directory.CreateDirectory(_temporaryDirectory);
+            string certificatePath = Path.Combine(_temporaryDirectory, "client.pfx");
+
+            using X509Certificate2 source = CreateCertificate(
+                DateTimeOffset.UtcNow.AddMinutes(-5),
+                DateTimeOffset.UtcNow.AddMinutes(5));
+            File.WriteAllBytes(certificatePath, source.Export(X509ContentType.Pkcs12, Password));
+
+            AuthenticationException exception = Assert.Throws<AuthenticationException>(
+                () => SqlClientCertificateLoader.Load($"file:{certificatePath}", null, Password));
+            Assert.Contains("file:", exception.Message, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Verifies that traditional (PKCS#1) encrypted private keys report an actionable error
+        /// rather than a generic load failure.
+        /// </summary>
+        [Fact]
+        public void Load_EncryptedPkcs1Key_ThrowsAuthenticationException()
+        {
+            Directory.CreateDirectory(_temporaryDirectory);
+            string certificatePath = Path.Combine(_temporaryDirectory, "client.pem");
+            string keyPath = Path.Combine(_temporaryDirectory, "client.key");
+
+            using X509Certificate2 source = CreateCertificate(
+                DateTimeOffset.UtcNow.AddMinutes(-5),
+                DateTimeOffset.UtcNow.AddMinutes(5));
+            File.WriteAllText(certificatePath, source.ExportCertificatePem());
+            File.WriteAllText(
+                keyPath,
+                "-----BEGIN RSA PRIVATE KEY-----\n" +
+                "Proc-Type: 4,ENCRYPTED\n" +
+                "DEK-Info: AES-256-CBC,0123456789ABCDEF0123456789ABCDEF\n" +
+                "\n" +
+                "AA==\n" +
+                "-----END RSA PRIVATE KEY-----");
+
+            AuthenticationException exception = Assert.Throws<AuthenticationException>(
+                () => SqlClientCertificateLoader.Load(certificatePath, keyPath, Password));
+            Assert.Contains("PKCS#8", exception.Message, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Verifies that the end-entity certificate is selected from a PKCS#12 bundle even when an
+        /// issuer certificate in the same bundle also carries a private key.
+        /// </summary>
+        [Fact]
+        public void Load_Pkcs12WithMultiplePrivateKeys_SelectsLeafCertificate()
+        {
+            Directory.CreateDirectory(_temporaryDirectory);
+            string certificatePath = Path.Combine(_temporaryDirectory, "chain.pfx");
+
+            CreateCertificateChain(
+                out X509Certificate2 leafCertificate,
+                out X509Certificate2 intermediateCertificate);
+            using (leafCertificate)
+            using (intermediateCertificate)
+            {
+                // Order the intermediate first so that a positional heuristic would select the wrong
+                // certificate. Both entries carry private keys.
+                X509Certificate2Collection bundle = new()
+                {
+                    intermediateCertificate,
+                    leafCertificate
+                };
+                byte[] bundleBytes = bundle.Export(X509ContentType.Pkcs12, Password)
+                    ?? throw new InvalidOperationException("The PKCS#12 bundle could not be exported.");
+                File.WriteAllBytes(certificatePath, bundleBytes);
+
+                using SqlClientCertificateContext loaded =
+                    SqlClientCertificateLoader.Load(certificatePath, null, Password);
+
+                Assert.Equal(leafCertificate.Thumbprint, loaded.Certificate.Thumbprint);
+                Assert.True(loaded.Certificate.HasPrivateKey);
+            }
+        }
+
+        /// <summary>
         /// Creates a self-signed certificate with the requested validity period.
         /// </summary>
         /// <param name="notBefore">The beginning of the validity period.</param>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/ManagedSni/SqlClientCertificateLoaderTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/ManagedSni/SqlClientCertificateLoaderTests.cs
@@ -1,0 +1,414 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NET
+
+using System;
+using System.IO;
+using System.Security.Authentication;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Data.SqlClient.ManagedSni;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests.ManagedSni
+{
+    /// <summary>
+    /// Tests loading client certificates and their private keys without persisting key material.
+    /// </summary>
+    public sealed class SqlClientCertificateLoaderTests : IDisposable
+    {
+        private const string Password = "<pwd>";
+        private readonly string _temporaryDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"SqlClientCertificateLoaderTests-{Guid.NewGuid():N}");
+
+        /// <summary>
+        /// Removes certificate files created by each test.
+        /// </summary>
+        public void Dispose()
+        {
+            if (Directory.Exists(_temporaryDirectory))
+            {
+                Directory.Delete(_temporaryDirectory, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that an encrypted PFX is loaded with its private key.
+        /// </summary>
+        [Fact]
+        public void Load_EncryptedPfx_ReturnsCertificateWithPrivateKey()
+        {
+            Directory.CreateDirectory(_temporaryDirectory);
+            string certificatePath = Path.Combine(_temporaryDirectory, "client.pfx");
+
+            using X509Certificate2 source = CreateCertificate(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddMinutes(5));
+            File.WriteAllBytes(certificatePath, source.Export(X509ContentType.Pkcs12, Password));
+
+            using SqlClientCertificateContext loaded = SqlClientCertificateLoader.Load(certificatePath, null, Password);
+
+            Assert.True(loaded.Certificate.HasPrivateKey);
+            Assert.Equal(source.Thumbprint, loaded.Certificate.Thumbprint);
+        }
+
+        /// <summary>
+        /// Verifies that a PEM certificate and encrypted PKCS#8 key are combined successfully.
+        /// </summary>
+        [Fact]
+        public void Load_PemCertificateAndEncryptedKey_ReturnsCertificateWithPrivateKey()
+        {
+            Directory.CreateDirectory(_temporaryDirectory);
+            string certificatePath = Path.Combine(_temporaryDirectory, "client.pem");
+            string keyPath = Path.Combine(_temporaryDirectory, "client.key");
+
+            using RSA key = RSA.Create(2048);
+            CertificateRequest request = new("CN=SqlClient Test", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            using X509Certificate2 source = request.CreateSelfSigned(
+                DateTimeOffset.UtcNow.AddMinutes(-5),
+                DateTimeOffset.UtcNow.AddMinutes(5));
+            File.WriteAllText(certificatePath, source.ExportCertificatePem());
+            File.WriteAllText(
+                keyPath,
+                key.ExportEncryptedPkcs8PrivateKeyPem(
+                    Password,
+                    new PbeParameters(PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA256, 10_000)));
+
+            using SqlClientCertificateContext loaded = SqlClientCertificateLoader.Load(certificatePath, keyPath, Password);
+
+            Assert.True(loaded.Certificate.HasPrivateKey);
+            Assert.Equal(source.Thumbprint, loaded.Certificate.Thumbprint);
+        }
+
+        /// <summary>
+        /// Verifies that intermediate certificates in a PEM bundle are retained for the TLS client chain.
+        /// </summary>
+        [Fact]
+        public void Load_PemCertificateChain_RetainsIntermediateCertificate()
+        {
+            Directory.CreateDirectory(_temporaryDirectory);
+            string certificatePath = Path.Combine(_temporaryDirectory, "client-chain.pem");
+            string keyPath = Path.Combine(_temporaryDirectory, "client.key");
+
+            CreateCertificateChain(
+                out X509Certificate2 leafCertificate,
+                out X509Certificate2 intermediateCertificate);
+            using (leafCertificate)
+            using (intermediateCertificate)
+            using (RSA leafKey = leafCertificate.GetRSAPrivateKey()
+                ?? throw new InvalidOperationException("The test leaf certificate must have a private key."))
+            {
+                File.WriteAllText(
+                    certificatePath,
+                    leafCertificate.ExportCertificatePem() +
+                    Environment.NewLine +
+                    intermediateCertificate.ExportCertificatePem());
+                File.WriteAllText(keyPath, leafKey.ExportPkcs8PrivateKeyPem());
+
+                using SqlClientCertificateContext loaded =
+                    SqlClientCertificateLoader.Load(certificatePath, keyPath, keyPassword: null);
+
+                Assert.Equal(leafCertificate.Thumbprint, loaded.Certificate.Thumbprint);
+                Assert.Equal(1, loaded.AdditionalCertificateCount);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that intermediate certificates in a PFX bundle are retained for the TLS client chain.
+        /// </summary>
+        [Fact]
+        public void Load_PfxCertificateChain_RetainsIntermediateCertificate()
+        {
+            Directory.CreateDirectory(_temporaryDirectory);
+            string certificatePath = Path.Combine(_temporaryDirectory, "client-chain.pfx");
+
+            CreateCertificateChain(
+                out X509Certificate2 leafCertificate,
+                out X509Certificate2 intermediateCertificate);
+            using (leafCertificate)
+            using (intermediateCertificate)
+            {
+                X509Certificate2Collection bundle = new();
+                bundle.Add(leafCertificate);
+                bundle.Add(intermediateCertificate);
+                byte[] pkcs12 = bundle.Export(X509ContentType.Pkcs12, Password)
+                    ?? throw new InvalidOperationException("The test PKCS#12 bundle could not be exported.");
+                try
+                {
+                    File.WriteAllBytes(certificatePath, pkcs12);
+                }
+                finally
+                {
+                    CryptographicOperations.ZeroMemory(pkcs12);
+                }
+
+                using SqlClientCertificateContext loaded =
+                    SqlClientCertificateLoader.Load(certificatePath, keyPath: null, keyPassword: Password);
+
+                Assert.Equal(leafCertificate.Thumbprint, loaded.Certificate.Thumbprint);
+                Assert.Equal(1, loaded.AdditionalCertificateCount);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that a PFX certificate can use an ECDSA private key.
+        /// </summary>
+        [Fact]
+        public void Load_EcdsaPfx_ReturnsCertificateWithPrivateKey()
+        {
+            Directory.CreateDirectory(_temporaryDirectory);
+            string certificatePath = Path.Combine(_temporaryDirectory, "client-ecdsa.pfx");
+
+            using ECDsa key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+            CertificateRequest request = new("CN=SqlClient ECDSA", key, HashAlgorithmName.SHA256);
+            using X509Certificate2 source = request.CreateSelfSigned(
+                DateTimeOffset.UtcNow.AddMinutes(-5),
+                DateTimeOffset.UtcNow.AddMinutes(5));
+            File.WriteAllBytes(certificatePath, source.Export(X509ContentType.Pkcs12, Password));
+
+            using SqlClientCertificateContext loaded =
+                SqlClientCertificateLoader.Load(certificatePath, keyPath: null, keyPassword: Password);
+            using ECDsa loadedKey = loaded.Certificate.GetECDsaPrivateKey()
+                ?? throw new InvalidOperationException("The loaded ECDSA certificate must have a private key.");
+
+            Assert.NotNull(loadedKey);
+            Assert.Equal(source.Thumbprint, loaded.Certificate.Thumbprint);
+        }
+
+        /// <summary>
+        /// Verifies that detached ECDSA keys fail with the documented RSA-only error.
+        /// </summary>
+        /// <param name="useSec1">Whether to encode the key in SEC1 rather than PKCS#8 format.</param>
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Load_EcdsaPemAndKey_ThrowsUnsupportedAlgorithm(bool useSec1)
+        {
+            Directory.CreateDirectory(_temporaryDirectory);
+            string certificatePath = Path.Combine(_temporaryDirectory, "client-ecdsa.pem");
+            string keyPath = Path.Combine(_temporaryDirectory, "client-ecdsa.key");
+
+            CreateCertificateChain(
+                out X509Certificate2 unusedRsaLeafCertificate,
+                out X509Certificate2 intermediateCertificate);
+            using (unusedRsaLeafCertificate)
+            using (intermediateCertificate)
+            using (ECDsa key = ECDsa.Create(ECCurve.NamedCurves.nistP256))
+            {
+                CertificateRequest request = new("CN=SqlClient ECDSA", key, HashAlgorithmName.SHA256);
+                using RSA issuerKey = intermediateCertificate.GetRSAPrivateKey()
+                    ?? throw new InvalidOperationException("The intermediate certificate must have an RSA private key.");
+                using X509Certificate2 publicCertificate = request.Create(
+                    intermediateCertificate.SubjectName,
+                    X509SignatureGenerator.CreateForRSA(issuerKey, RSASignaturePadding.Pkcs1),
+                    DateTimeOffset.UtcNow.AddMinutes(-5),
+                    DateTimeOffset.UtcNow.AddMinutes(5),
+                    CreateSerialNumber());
+                using X509Certificate2 source = publicCertificate.CopyWithPrivateKey(key);
+                File.WriteAllText(
+                    certificatePath,
+                    source.ExportCertificatePem() +
+                    Environment.NewLine +
+                    intermediateCertificate.ExportCertificatePem());
+                File.WriteAllText(
+                    keyPath,
+                    useSec1 ? key.ExportECPrivateKeyPem() : key.ExportPkcs8PrivateKeyPem());
+
+                AuthenticationException exception = Assert.Throws<AuthenticationException>(
+                    () => SqlClientCertificateLoader.Load(certificatePath, keyPath, keyPassword: null));
+                Assert.Contains("RSA", exception.Message, StringComparison.Ordinal);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that an incorrect private-key password is reported as an authentication failure.
+        /// </summary>
+        [Fact]
+        public void Load_IncorrectPassword_ThrowsAuthenticationException()
+        {
+            Directory.CreateDirectory(_temporaryDirectory);
+            string certificatePath = Path.Combine(_temporaryDirectory, "client.pfx");
+
+            using X509Certificate2 source = CreateCertificate(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddMinutes(5));
+            File.WriteAllBytes(certificatePath, source.Export(X509ContentType.Pkcs12, Password));
+
+            Assert.Throws<AuthenticationException>(
+                () => SqlClientCertificateLoader.Load(certificatePath, null, "incorrect"));
+        }
+
+        /// <summary>
+        /// Verifies that an unreadable private-key path is reported as an authentication failure.
+        /// </summary>
+        [Fact]
+        public void Load_MissingPrivateKey_ThrowsAuthenticationException()
+        {
+            Directory.CreateDirectory(_temporaryDirectory);
+            string certificatePath = Path.Combine(_temporaryDirectory, "client.pem");
+            string missingKeyPath = Path.Combine(_temporaryDirectory, "missing.key");
+
+            using X509Certificate2 source = CreateCertificate(
+                DateTimeOffset.UtcNow.AddMinutes(-5),
+                DateTimeOffset.UtcNow.AddMinutes(5));
+            File.WriteAllText(certificatePath, source.ExportCertificatePem());
+
+            Assert.Throws<AuthenticationException>(
+                () => SqlClientCertificateLoader.Load(certificatePath, missingKeyPath, keyPassword: null));
+        }
+
+        /// <summary>
+        /// Verifies that an unsupported PEM key label is normalized to a certificate-load failure.
+        /// </summary>
+        [Fact]
+        public void Load_UnsupportedPemKey_ThrowsAuthenticationException()
+        {
+            Directory.CreateDirectory(_temporaryDirectory);
+            string certificatePath = Path.Combine(_temporaryDirectory, "client.pem");
+            string keyPath = Path.Combine(_temporaryDirectory, "client.key");
+
+            using X509Certificate2 source = CreateCertificate(
+                DateTimeOffset.UtcNow.AddMinutes(-5),
+                DateTimeOffset.UtcNow.AddMinutes(5));
+            File.WriteAllText(certificatePath, source.ExportCertificatePem());
+            File.WriteAllText(
+                keyPath,
+                "-----BEGIN DSA PRIVATE KEY-----\nAA==\n-----END DSA PRIVATE KEY-----");
+
+            AuthenticationException exception = Assert.Throws<AuthenticationException>(
+                () => SqlClientCertificateLoader.Load(certificatePath, keyPath, keyPassword: null));
+            Assert.Contains(
+                "could not be loaded",
+                exception.Message,
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Verifies that an expired certificate is rejected before the TLS handshake.
+        /// </summary>
+        [Fact]
+        public void Load_ExpiredCertificate_ThrowsAuthenticationException()
+        {
+            Directory.CreateDirectory(_temporaryDirectory);
+            string certificatePath = Path.Combine(_temporaryDirectory, "client.pfx");
+
+            using X509Certificate2 source = CreateCertificate(
+                DateTimeOffset.UtcNow.AddMinutes(-10),
+                DateTimeOffset.UtcNow.AddMinutes(-5));
+            File.WriteAllBytes(certificatePath, source.Export(X509ContentType.Pkcs12, Password));
+
+            Assert.Throws<AuthenticationException>(
+                () => SqlClientCertificateLoader.Load(certificatePath, null, Password));
+        }
+
+        /// <summary>
+        /// Creates a self-signed certificate with the requested validity period.
+        /// </summary>
+        /// <param name="notBefore">The beginning of the validity period.</param>
+        /// <param name="notAfter">The end of the validity period.</param>
+        /// <returns>A certificate containing its private key.</returns>
+        private static X509Certificate2 CreateCertificate(DateTimeOffset notBefore, DateTimeOffset notAfter)
+        {
+            using RSA key = RSA.Create(2048);
+            CertificateRequest request = new("CN=SqlClient Test", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            return request.CreateSelfSigned(notBefore, notAfter);
+        }
+
+        /// <summary>
+        /// Creates a certificate request for a certificate authority or TLS client leaf.
+        /// </summary>
+        /// <param name="subjectName">The request subject.</param>
+        /// <param name="key">The request's private key.</param>
+        /// <param name="isCertificateAuthority">Whether the request represents a certificate authority.</param>
+        /// <returns>The configured certificate request.</returns>
+        private static CertificateRequest CreateCertificateRequest(
+            string subjectName,
+            RSA key,
+            bool isCertificateAuthority)
+        {
+            CertificateRequest request = new(
+                subjectName,
+                key,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+            request.CertificateExtensions.Add(
+                new X509BasicConstraintsExtension(
+                    certificateAuthority: isCertificateAuthority,
+                    hasPathLengthConstraint: false,
+                    pathLengthConstraint: 0,
+                    critical: true));
+            request.CertificateExtensions.Add(
+                new X509KeyUsageExtension(
+                    isCertificateAuthority
+                        ? X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign
+                        : X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment,
+                    critical: true));
+            if (!isCertificateAuthority)
+            {
+                request.CertificateExtensions.Add(
+                    new X509EnhancedKeyUsageExtension(
+                        new OidCollection { new("1.3.6.1.5.5.7.3.2") },
+                        critical: true));
+            }
+
+            return request;
+        }
+
+        /// <summary>
+        /// Creates a client leaf certificate and its issuing intermediate certificate.
+        /// </summary>
+        /// <param name="leafCertificate">Receives the client certificate with its private key.</param>
+        /// <param name="intermediateCertificate">Receives the issuing intermediate with its private key.</param>
+        private static void CreateCertificateChain(
+            out X509Certificate2 leafCertificate,
+            out X509Certificate2 intermediateCertificate)
+        {
+            DateTimeOffset notBefore = DateTimeOffset.UtcNow.AddMinutes(-5);
+            DateTimeOffset notAfter = DateTimeOffset.UtcNow.AddMinutes(5);
+            using RSA rootKey = RSA.Create(2048);
+            CertificateRequest rootRequest = CreateCertificateRequest(
+                "CN=SqlClient Root",
+                rootKey,
+                isCertificateAuthority: true);
+            using X509Certificate2 rootCertificate =
+                rootRequest.CreateSelfSigned(notBefore, notAfter);
+
+            using RSA intermediateKey = RSA.Create(2048);
+            CertificateRequest intermediateRequest = CreateCertificateRequest(
+                "CN=SqlClient Intermediate",
+                intermediateKey,
+                isCertificateAuthority: true);
+            using X509Certificate2 intermediatePublicCertificate = intermediateRequest.Create(
+                rootCertificate,
+                notBefore,
+                notAfter,
+                CreateSerialNumber());
+            intermediateCertificate =
+                intermediatePublicCertificate.CopyWithPrivateKey(intermediateKey);
+
+            using RSA leafKey = RSA.Create(2048);
+            CertificateRequest leafRequest = CreateCertificateRequest(
+                "CN=SqlClient Leaf",
+                leafKey,
+                isCertificateAuthority: false);
+            using X509Certificate2 leafPublicCertificate = leafRequest.Create(
+                intermediateCertificate,
+                notBefore,
+                notAfter,
+                CreateSerialNumber());
+            leafCertificate = leafPublicCertificate.CopyWithPrivateKey(leafKey);
+        }
+
+        /// <summary>
+        /// Creates a positive random serial number for a test certificate.
+        /// </summary>
+        /// <returns>A random sixteen-byte serial number.</returns>
+        private static byte[] CreateSerialNumber()
+        {
+            byte[] serialNumber = RandomNumberGenerator.GetBytes(16);
+            serialNumber[0] &= 0x7F;
+            return serialNumber;
+        }
+    }
+}
+
+#endif

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/ManagedSni/SqlClientCertificateLoaderTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/ManagedSni/SqlClientCertificateLoaderTests.cs
@@ -357,6 +357,34 @@ namespace Microsoft.Data.SqlClient.UnitTests.ManagedSni
         }
 
         /// <summary>
+        /// Verifies that combining a PKCS#12 certificate with a detached private key reports the
+        /// misconfiguration explicitly rather than as an unspecified certificate-load failure.
+        /// </summary>
+        [Fact]
+        public void Load_Pkcs12WithDetachedKey_ThrowsAuthenticationException()
+        {
+            Directory.CreateDirectory(_temporaryDirectory);
+            string certificatePath = Path.Combine(_temporaryDirectory, "client.pfx");
+            string keyPath = Path.Combine(_temporaryDirectory, "client.key");
+
+            using RSA key = RSA.Create(2048);
+            CertificateRequest request = new(
+                "CN=SqlClient Test",
+                key,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+            using X509Certificate2 source = request.CreateSelfSigned(
+                DateTimeOffset.UtcNow.AddMinutes(-5),
+                DateTimeOffset.UtcNow.AddMinutes(5));
+            File.WriteAllBytes(certificatePath, source.Export(X509ContentType.Pkcs12, Password));
+            File.WriteAllText(keyPath, key.ExportPkcs8PrivateKeyPem());
+
+            AuthenticationException exception = Assert.Throws<AuthenticationException>(
+                () => SqlClientCertificateLoader.Load(certificatePath, keyPath, Password));
+            Assert.Contains("PKCS#12", exception.Message, StringComparison.Ordinal);
+        }
+
+        /// <summary>
         /// Verifies that the ODBC driver's <c>file:</c> path syntax is rejected with a specific error.
         /// </summary>
         [Fact]

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlClientCertificateLoaderTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlClientCertificateLoaderTests.cs
@@ -9,10 +9,9 @@ using System.IO;
 using System.Security.Authentication;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using Microsoft.Data.SqlClient.ManagedSni;
 using Xunit;
 
-namespace Microsoft.Data.SqlClient.UnitTests.ManagedSni
+namespace Microsoft.Data.SqlClient.UnitTests
 {
     /// <summary>
     /// Tests loading client certificates and their private keys without persisting key material.
@@ -574,6 +573,61 @@ namespace Microsoft.Data.SqlClient.UnitTests.ManagedSni
             byte[] serialNumber = RandomNumberGenerator.GetBytes(16);
             serialNumber[0] &= 0x7F;
             return serialNumber;
+        }
+    }
+}
+
+#else
+
+using System;
+using System.IO;
+using System.Security.Authentication;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests
+{
+    /// <summary>
+    /// Tests the .NET Framework client certificate loader, which supports PKCS#12 containers only.
+    /// </summary>
+    public sealed class SqlClientCertificateLoaderTests
+    {
+        /// <summary>
+        /// Verifies that a detached private key reports the documented .NET Framework limitation
+        /// rather than an unspecified certificate load failure.
+        /// </summary>
+        [Fact]
+        public void Load_DetachedKey_ThrowsNotSupportedOnNetFx()
+        {
+            AuthenticationException exception = Assert.Throws<AuthenticationException>(
+                () => SqlClientCertificateLoader.Load("client.pem", "client.key", keyPassword: null));
+
+            Assert.Contains(".NET Framework", exception.Message, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Verifies that the ODBC driver's <c>file:</c> path syntax is rejected on .NET Framework too.
+        /// </summary>
+        [Fact]
+        public void Load_OdbcStylePath_ThrowsAuthenticationException()
+        {
+            AuthenticationException exception = Assert.Throws<AuthenticationException>(
+                () => SqlClientCertificateLoader.Load("file:client.pfx", null, keyPassword: null));
+
+            Assert.Contains("file:", exception.Message, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Verifies that an unreadable PKCS#12 path is reported as an authentication failure.
+        /// </summary>
+        [Fact]
+        public void Load_MissingCertificate_ThrowsAuthenticationException()
+        {
+            string missingPath = Path.Combine(
+                Path.GetTempPath(),
+                $"SqlClientCertificateLoaderTests-{Guid.NewGuid():N}.pfx");
+
+            Assert.Throws<AuthenticationException>(
+                () => SqlClientCertificateLoader.Load(missingPath, null, keyPassword: null));
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionOptionsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionOptionsTest.cs
@@ -8,6 +8,9 @@ using Xunit;
 
 namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
 {
+    /// <summary>
+    /// Tests immutable connection option parsing and validation.
+    /// </summary>
     public class SqlConnectionOptionsTest : IDisposable
     {
         // Ensure we restore the original app context switch values after each
@@ -104,6 +107,86 @@ namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
             };
 
             Assert.Throws<ArgumentException>(() => new SqlConnectionOptions(builder.ConnectionString));
+        }
+
+        /// <summary>
+        /// Verifies that the client certificate options and no-space aliases map to their canonical values.
+        /// </summary>
+        [Fact]
+        public void ClientCertificateOptions_ParseAliases()
+        {
+            SqlConnectionOptions options = new(
+                "ClientCertificate=client.pem;ClientKey=client.key;ClientKeyPassword=<pwd>");
+
+            Assert.Equal("client.pem", options.ClientCertificate);
+            Assert.Equal("client.key", options.ClientKey);
+            Assert.Equal("<pwd>", options.ClientKeyPassword);
+            Assert.True(options.UsesClientCertificate);
+        }
+
+        /// <summary>
+        /// Verifies that certificate authentication rejects connection-string credential mechanisms.
+        /// </summary>
+        [Theory]
+        [InlineData("ClientCertificate=client.pfx;User ID=user")]
+        [InlineData("ClientCertificate=client.pfx;Password=<pwd>")]
+        [InlineData("ClientCertificate=client.pfx;Integrated Security=true")]
+        [InlineData("ClientCertificate=client.pfx;Authentication=SqlPassword")]
+        [InlineData("ClientCertificate=client.pfx;Authentication=NotSpecified")]
+        public void ClientCertificateOptions_WithOtherAuthentication_Throws(string connectionString)
+        {
+            Assert.Throws<ArgumentException>(() => new SqlConnectionOptions(connectionString));
+        }
+
+        /// <summary>
+        /// Verifies that key material cannot be configured without a client certificate.
+        /// </summary>
+        [Theory]
+        [InlineData("ClientKey=client.key")]
+        [InlineData("ClientKey=")]
+        [InlineData("ClientKeyPassword=<pwd>")]
+        public void ClientCertificateOptions_KeyWithoutCertificate_Throws(string connectionString)
+        {
+            Assert.Throws<ArgumentException>(() => new SqlConnectionOptions(connectionString));
+        }
+
+        /// <summary>
+        /// Verifies that PEM, DER, and CER certificates require a separate private-key file.
+        /// </summary>
+        [Theory]
+        [InlineData("client.pem")]
+        [InlineData("client.der")]
+        [InlineData("client.cer")]
+        public void ClientCertificateOptions_NonPkcs12WithoutKey_Throws(string certificatePath)
+        {
+            Assert.Throws<ArgumentException>(
+                () => new SqlConnectionOptions($"ClientCertificate={certificatePath}"));
+        }
+
+        /// <summary>
+        /// Verifies that client key passwords are removed from returned and trace connection strings by default.
+        /// </summary>
+        [Fact]
+        public void ClientKeyPassword_IsRedacted()
+        {
+            SqlConnectionOptions options = new(
+                "Data Source=server;ClientCertificate=client.pfx;ClientKeyPassword=<pwd>");
+
+            Assert.DoesNotContain("ClientKeyPassword", options.UsersConnectionString(hidePassword: true), StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("<pwd>", options.UsersConnectionStringForTrace(), StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Verifies that Persist Security Info affects the public string but never the trace string.
+        /// </summary>
+        [Fact]
+        public void ClientKeyPassword_PersistSecurityInfo_DoesNotExposeTrace()
+        {
+            SqlConnectionOptions options = new(
+                "ClientCertificate=client.pfx;ClientKeyPassword=<pwd>;Persist Security Info=true");
+
+            Assert.Contains("<pwd>", options.UsersConnectionString(hidePassword: true), StringComparison.Ordinal);
+            Assert.DoesNotContain("<pwd>", options.UsersConnectionStringForTrace(), StringComparison.Ordinal);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionOptionsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionOptionsTest.cs
@@ -109,6 +109,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
             Assert.Throws<ArgumentException>(() => new SqlConnectionOptions(builder.ConnectionString));
         }
 
+#if NET
         /// <summary>
         /// Verifies that the client certificate options and no-space aliases map to their canonical values.
         /// </summary>
@@ -132,10 +133,24 @@ namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
         [InlineData("ClientCertificate=client.pfx;Password=<pwd>")]
         [InlineData("ClientCertificate=client.pfx;Integrated Security=true")]
         [InlineData("ClientCertificate=client.pfx;Authentication=SqlPassword")]
-        [InlineData("ClientCertificate=client.pfx;Authentication=NotSpecified")]
         public void ClientCertificateOptions_WithOtherAuthentication_Throws(string connectionString)
         {
             Assert.Throws<ArgumentException>(() => new SqlConnectionOptions(connectionString));
+        }
+
+        /// <summary>
+        /// Verifies that credential keywords present but empty (or explicitly disabled) do not
+        /// conflict with certificate authentication.
+        /// </summary>
+        [Theory]
+        [InlineData("ClientCertificate=client.pfx;User ID=")]
+        [InlineData("ClientCertificate=client.pfx;Password=")]
+        [InlineData("ClientCertificate=client.pfx;Integrated Security=false")]
+        public void ClientCertificateOptions_EmptyCredentialKeywords_DoNotConflict(string connectionString)
+        {
+            SqlConnectionOptions options = new(connectionString);
+
+            Assert.True(options.UsesClientCertificate);
         }
 
         /// <summary>
@@ -151,16 +166,21 @@ namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
         }
 
         /// <summary>
-        /// Verifies that PEM, DER, and CER certificates require a separate private-key file.
+        /// Verifies that the certificate container format is never inferred from the file extension,
+        /// so a certificate may be supplied without a separate key file regardless of its name.
         /// </summary>
         [Theory]
         [InlineData("client.pem")]
         [InlineData("client.der")]
         [InlineData("client.cer")]
-        public void ClientCertificateOptions_NonPkcs12WithoutKey_Throws(string certificatePath)
+        [InlineData("client.pfx")]
+        [InlineData("client")]
+        public void ClientCertificateOptions_FormatNotInferredFromExtension(string certificatePath)
         {
-            Assert.Throws<ArgumentException>(
-                () => new SqlConnectionOptions($"ClientCertificate={certificatePath}"));
+            SqlConnectionOptions options = new($"ClientCertificate={certificatePath}");
+
+            Assert.Equal(certificatePath, options.ClientCertificate);
+            Assert.True(options.UsesClientCertificate);
         }
 
         /// <summary>
@@ -188,5 +208,22 @@ namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
             Assert.Contains("<pwd>", options.UsersConnectionString(hidePassword: true), StringComparison.Ordinal);
             Assert.DoesNotContain("<pwd>", options.UsersConnectionStringForTrace(), StringComparison.Ordinal);
         }
+#else
+        /// <summary>
+        /// Verifies that the client certificate keywords are not recognized on .NET Framework,
+        /// where managed networking (and therefore certificate authentication) is unavailable.
+        /// </summary>
+        [Theory]
+        [InlineData("ClientCertificate=client.pfx")]
+        [InlineData("Client Certificate=client.pfx")]
+        [InlineData("ClientKey=client.key")]
+        [InlineData("Client Key=client.key")]
+        [InlineData("ClientKeyPassword=<pwd>")]
+        [InlineData("Client Key Password=<pwd>")]
+        public void ClientCertificateOptions_NotSupportedOnNetFx(string connectionString)
+        {
+            Assert.Throws<ArgumentException>(() => new SqlConnectionOptions(connectionString));
+        }
+#endif
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionOptionsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionOptionsTest.cs
@@ -110,7 +110,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
             Assert.Throws<ArgumentException>(() => new SqlConnectionOptions(builder.ConnectionString));
         }
 
-#if NET
         /// <summary>
         /// Verifies that the client certificate options and no-space aliases map to their canonical values.
         /// </summary>
@@ -209,22 +208,5 @@ namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
             Assert.Contains("<pwd>", options.UsersConnectionString(hidePassword: true), StringComparison.Ordinal);
             Assert.DoesNotContain("<pwd>", options.UsersConnectionStringForTrace(), StringComparison.Ordinal);
         }
-#else
-        /// <summary>
-        /// Verifies that the client certificate keywords are not recognized on .NET Framework,
-        /// where managed networking (and therefore certificate authentication) is unavailable.
-        /// </summary>
-        [Theory]
-        [InlineData("ClientCertificate=client.pfx")]
-        [InlineData("Client Certificate=client.pfx")]
-        [InlineData("ClientKey=client.key")]
-        [InlineData("Client Key=client.key")]
-        [InlineData("ClientKeyPassword=<pwd>")]
-        [InlineData("Client Key Password=<pwd>")]
-        public void ClientCertificateOptions_NotSupportedOnNetFx(string connectionString)
-        {
-            Assert.Throws<ArgumentException>(() => new SqlConnectionOptions(connectionString));
-        }
-#endif
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ClientCertificateAuthenticationTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ClientCertificateAuthenticationTests.cs
@@ -1,0 +1,517 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NET
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Security.Authentication;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient.Tests.Common;
+using Microsoft.SqlServer.TDS;
+using Microsoft.SqlServer.TDS.EndPoint;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests;
+
+/// <summary>
+/// Verifies the TDS and TLS behavior used for SQL Server on Linux loopback client-certificate authentication.
+/// </summary>
+[Collection("SimulatedServerTests")]
+public sealed class ClientCertificateAuthenticationTests : IDisposable
+{
+    private const string CertificatePassword = "<pwd>";
+
+    private static readonly byte[] s_preLoginEncryptOnResponse =
+    {
+        0x12, 0x01, 0x00, 0x1A, 0x00, 0x00, 0x01, 0x00,
+        0x00, 0x00, 0x0B, 0x00, 0x06,
+        0x01, 0x00, 0x11, 0x00, 0x01,
+        0xFF,
+        0x11, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x01,
+    };
+
+    private static readonly byte[] s_preLoginEncryptOffResponse =
+    {
+        0x12, 0x01, 0x00, 0x1A, 0x00, 0x00, 0x01, 0x00,
+        0x00, 0x00, 0x0B, 0x00, 0x06,
+        0x01, 0x00, 0x11, 0x00, 0x01,
+        0xFF,
+        0x11, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00,
+    };
+
+    private readonly string _temporaryDirectory = Path.Combine(
+        Path.GetTempPath(),
+        $"SqlClientClientCertificateTests-{Guid.NewGuid():N}");
+
+    /// <summary>
+    /// Removes certificate files created by the test.
+    /// </summary>
+    public void Dispose()
+    {
+        if (Directory.Exists(_temporaryDirectory))
+        {
+            Directory.Delete(_temporaryDirectory, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a certificate-authentication connection advertises the PRELOGIN flag,
+    /// presents the configured certificate, and omits SQL credentials from LOGIN7.
+    /// </summary>
+    /// <param name="encryptionMode">Zero for Optional, one for Mandatory, or two for Strict encryption.</param>
+    /// <param name="async">Whether to open the connection asynchronously.</param>
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(0, true)]
+    [InlineData(1, false)]
+    [InlineData(1, true)]
+    [InlineData(2, false)]
+    [InlineData(2, true)]
+    public async Task Open_WithClientCertificate_SendsCertificateAuthenticationHandshake(int encryptionMode, bool async)
+    {
+        bool strict = encryptionMode == 2;
+        Directory.CreateDirectory(_temporaryDirectory);
+        string clientCertificatePath = Path.Combine(_temporaryDirectory, "client.pfx");
+        string serverCertificatePath = Path.Combine(_temporaryDirectory, "server.cer");
+
+        using X509Certificate2 serverCertificate = CreateCertificate(
+            "CN=localhost",
+            "1.3.6.1.5.5.7.3.1");
+        using X509Certificate2 clientCertificate = CreateCertificate(
+            "CN=SqlClient Loopback",
+            "1.3.6.1.5.5.7.3.2");
+        File.WriteAllBytes(
+            clientCertificatePath,
+            clientCertificate.Export(X509ContentType.Pkcs12, CertificatePassword));
+        File.WriteAllBytes(
+            serverCertificatePath,
+            serverCertificate.Export(X509ContentType.Cert));
+
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        Task<HandshakeResult> serverTask = Task.Run(
+            () => RunServer(listener, serverCertificate, encryptionMode));
+
+        using LocalAppContextSwitchesHelper switches = new();
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            switches.UseManagedNetworking = true;
+        }
+
+        SqlConnectionStringBuilder builder = new()
+        {
+            DataSource = $"127.0.0.1,{port}",
+            Encrypt = encryptionMode switch
+            {
+                0 => SqlConnectionEncryptOption.Optional,
+                1 => SqlConnectionEncryptOption.Mandatory,
+                _ => SqlConnectionEncryptOption.Strict,
+            },
+            TrustServerCertificate = true,
+            ServerCertificate = strict ? serverCertificatePath : string.Empty,
+            ClientCertificate = clientCertificatePath,
+            ClientKeyPassword = CertificatePassword,
+            ConnectTimeout = 5,
+            ConnectRetryCount = 0,
+            Pooling = false,
+        };
+
+        try
+        {
+            using SqlConnection connection = new(builder.ConnectionString);
+            Exception? openException = async
+                ? await Record.ExceptionAsync(() => connection.OpenAsync())
+                : Record.Exception(() => connection.Open());
+
+            HandshakeResult result;
+            try
+            {
+                result = await serverTask;
+            }
+            catch (Exception serverException)
+            {
+                throw new AggregateException(
+                    "The client and simulated server did not complete the certificate-authentication handshake.",
+                    openException,
+                    serverException);
+            }
+
+            Assert.IsType<SqlException>(openException);
+            Assert.True(result.ClientCertificateFlagSet);
+            Assert.Equal(clientCertificate.Thumbprint, result.ClientCertificateThumbprint);
+            Assert.Equal(0, result.UserNameLength);
+            Assert.Equal(0, result.PasswordLength);
+        }
+        finally
+        {
+            listener.Stop();
+            try
+            {
+                serverTask.Wait(TimeSpan.FromSeconds(10));
+            }
+            catch
+            {
+                // The assertions above surface the server failure with its original stack trace.
+            }
+        }
+    }
+
+    /// <summary>
+    /// Verifies that certificate-file failures flow through the TLS authentication error path.
+    /// </summary>
+    [Fact]
+    public void Open_WithMissingClientCertificate_ReportsAuthenticationFailure()
+    {
+        Directory.CreateDirectory(_temporaryDirectory);
+        string missingCertificatePath = Path.Combine(_temporaryDirectory, "missing.pfx");
+
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        Task serverTask = Task.Run(() => CompletePreLoginOnly(listener));
+
+        using LocalAppContextSwitchesHelper switches = new();
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            switches.UseManagedNetworking = true;
+        }
+
+        SqlConnectionStringBuilder builder = new()
+        {
+            DataSource = $"127.0.0.1,{port}",
+            Encrypt = SqlConnectionEncryptOption.Mandatory,
+            TrustServerCertificate = true,
+            ClientCertificate = missingCertificatePath,
+            ConnectTimeout = 5,
+            ConnectRetryCount = 0,
+            Pooling = false,
+        };
+
+        try
+        {
+            using SqlConnection connection = new(builder.ConnectionString);
+            SqlException exception = Assert.Throws<SqlException>(() => connection.Open());
+            AuthenticationException authenticationException =
+                Assert.IsType<AuthenticationException>(exception.InnerException);
+            Assert.Contains(
+                "client certificate or private key could not be loaded",
+                authenticationException.Message,
+                StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            listener.Stop();
+            serverTask.GetAwaiter().GetResult();
+        }
+    }
+
+    /// <summary>
+    /// Completes PRELOGIN and TLS as a server, then inspects the decrypted LOGIN7 packet.
+    /// </summary>
+    /// <param name="listener">The listener accepting the test connection.</param>
+    /// <param name="serverCertificate">The certificate presented by the simulated server.</param>
+    /// <param name="encryptionMode">Zero for Optional, one for Mandatory, or two for Strict encryption.</param>
+    /// <returns>The observed certificate-authentication protocol values.</returns>
+    private static HandshakeResult RunServer(
+        TcpListener listener,
+        X509Certificate2 serverCertificate,
+        int encryptionMode)
+    {
+        using TcpClient client = listener.AcceptTcpClient();
+        client.ReceiveTimeout = 10_000;
+        client.SendTimeout = 10_000;
+        using NetworkStream networkStream = client.GetStream();
+
+        string? clientCertificateThumbprint = null;
+        if (encryptionMode == 2)
+        {
+            using SslStream sslStream = CreateServerSslStream(
+                networkStream,
+                certificate => clientCertificateThumbprint = certificate);
+            AuthenticateServer(sslStream, serverCertificate, useTds8Alpn: true);
+
+            byte[] preLoginPacket = ReadTdsPacket(sslStream);
+            bool clientCertificateFlagSet = HasClientCertificateFlag(preLoginPacket);
+            sslStream.Write(s_preLoginEncryptOnResponse, 0, s_preLoginEncryptOnResponse.Length);
+            sslStream.Flush();
+
+            return ReadLoginResult(
+                sslStream,
+                clientCertificateFlagSet,
+                clientCertificateThumbprint);
+        }
+
+        byte[] classicPreLoginPacket = ReadTdsPacket(networkStream);
+        bool classicClientCertificateFlagSet = HasClientCertificateFlag(classicPreLoginPacket);
+        byte[] preLoginResponse = encryptionMode == 0
+            ? s_preLoginEncryptOffResponse
+            : s_preLoginEncryptOnResponse;
+        networkStream.Write(preLoginResponse, 0, preLoginResponse.Length);
+        networkStream.Flush();
+
+        TDSStream tdsStream = new(networkStream, leaveInnerStreamOpen: true)
+        {
+            PacketSize = 4096,
+        };
+        AutoTDSStream tlsOverTds = new(tdsStream, closeInnerStream: false)
+        {
+            OutgoingMessageType = TDSMessageType.PreLogin,
+        };
+        PlaceholderStream multiplexer = new(tlsOverTds, leaveInnerStreamOpen: true);
+
+        using SslStream classicSslStream = CreateServerSslStream(
+            multiplexer,
+            certificate => clientCertificateThumbprint = certificate);
+        AuthenticateServer(classicSslStream, serverCertificate, useTds8Alpn: false);
+
+        multiplexer.InnerStream = networkStream;
+        return ReadLoginResult(
+            classicSslStream,
+            classicClientCertificateFlagSet,
+            clientCertificateThumbprint);
+    }
+
+    /// <summary>
+    /// Completes PRELOGIN, then waits for the client to close before starting TLS.
+    /// </summary>
+    /// <param name="listener">The listener accepting the test connection.</param>
+    private static void CompletePreLoginOnly(TcpListener listener)
+    {
+        using TcpClient client = listener.AcceptTcpClient();
+        client.ReceiveTimeout = 10_000;
+        client.SendTimeout = 10_000;
+        using NetworkStream networkStream = client.GetStream();
+        ReadTdsPacket(networkStream);
+        networkStream.Write(s_preLoginEncryptOnResponse, 0, s_preLoginEncryptOnResponse.Length);
+        networkStream.Flush();
+
+        try
+        {
+            while (networkStream.ReadByte() >= 0)
+            {
+            }
+        }
+        catch (IOException)
+        {
+            // The expected certificate-loading failure closes the client socket.
+        }
+    }
+
+    /// <summary>
+    /// Creates a server-side TLS stream that accepts and records the client certificate.
+    /// </summary>
+    /// <param name="transport">The TLS transport stream.</param>
+    /// <param name="captureThumbprint">Receives the presented client certificate thumbprint.</param>
+    /// <returns>The configured TLS stream.</returns>
+    private static SslStream CreateServerSslStream(
+        Stream transport,
+        Action<string> captureThumbprint)
+    {
+        return new SslStream(
+            transport,
+            leaveInnerStreamOpen: true,
+            (_, certificate, _, _) =>
+            {
+                if (certificate != null)
+                {
+                    using X509Certificate2 certificate2 = new(certificate);
+                    captureThumbprint(certificate2.Thumbprint);
+                }
+
+                return true;
+            });
+    }
+
+    /// <summary>
+    /// Authenticates the simulated server with optional TDS 8.0 ALPN negotiation.
+    /// </summary>
+    /// <param name="sslStream">The server TLS stream.</param>
+    /// <param name="serverCertificate">The certificate presented by the server.</param>
+    /// <param name="useTds8Alpn">Whether to advertise the TDS 8.0 ALPN protocol.</param>
+    private static void AuthenticateServer(
+        SslStream sslStream,
+        X509Certificate2 serverCertificate,
+        bool useTds8Alpn)
+    {
+        SslServerAuthenticationOptions options = new()
+        {
+            ServerCertificate = serverCertificate,
+            ClientCertificateRequired = true,
+            EnabledSslProtocols = SslProtocols.Tls12,
+            CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
+        };
+        if (useTds8Alpn)
+        {
+            options.ApplicationProtocols = new List<SslApplicationProtocol>
+            {
+                new(Encoding.ASCII.GetBytes("tds/8.0")),
+            };
+        }
+
+        sslStream.AuthenticateAsServer(options);
+    }
+
+    /// <summary>
+    /// Reads the decrypted LOGIN7 packet and returns the observed authentication fields.
+    /// </summary>
+    /// <param name="sslStream">The authenticated TLS stream.</param>
+    /// <param name="clientCertificateFlagSet">Whether PRELOGIN requested certificate authentication.</param>
+    /// <param name="clientCertificateThumbprint">The client certificate thumbprint observed by TLS.</param>
+    /// <returns>The observed certificate-authentication protocol values.</returns>
+    private static HandshakeResult ReadLoginResult(
+        SslStream sslStream,
+        bool clientCertificateFlagSet,
+        string? clientCertificateThumbprint)
+    {
+        byte[] loginPacket = ReadTdsPacket(sslStream);
+        Assert.Equal((byte)TDSMessageType.TDS7Login, loginPacket[0]);
+
+        ReadOnlySpan<byte> loginPayload = loginPacket.AsSpan(8);
+        ushort userNameLength = BinaryPrimitives.ReadUInt16LittleEndian(loginPayload.Slice(42, 2));
+        ushort passwordLength = BinaryPrimitives.ReadUInt16LittleEndian(loginPayload.Slice(46, 2));
+
+        return new HandshakeResult(
+            clientCertificateFlagSet,
+            clientCertificateThumbprint,
+            userNameLength,
+            passwordLength);
+    }
+
+    /// <summary>
+    /// Reports whether the PRELOGIN encryption option contains the client-certificate bit.
+    /// </summary>
+    /// <param name="preLoginPacket">The complete PRELOGIN packet.</param>
+    /// <returns><see langword="true" /> when the client-certificate bit is set.</returns>
+    private static bool HasClientCertificateFlag(byte[] preLoginPacket) =>
+        GetPreLoginEncryptionValue(preLoginPacket) is byte encryptionValue &&
+        (encryptionValue & 0x80) != 0;
+
+    /// <summary>
+    /// Reads one complete TDS packet from a stream.
+    /// </summary>
+    /// <param name="stream">The stream containing the TDS packet.</param>
+    /// <returns>The complete packet, including its eight-byte header.</returns>
+    private static byte[] ReadTdsPacket(Stream stream)
+    {
+        byte[] header = new byte[8];
+        ReadExactly(stream, header);
+        int packetLength = BinaryPrimitives.ReadUInt16BigEndian(header.AsSpan(2, 2));
+        Assert.True(packetLength >= header.Length);
+
+        byte[] packet = new byte[packetLength];
+        Buffer.BlockCopy(header, 0, packet, 0, header.Length);
+        ReadExactly(stream, packet.AsSpan(header.Length));
+        return packet;
+    }
+
+    /// <summary>
+    /// Reads until the destination buffer is full or throws when the peer closes early.
+    /// </summary>
+    /// <param name="stream">The source stream.</param>
+    /// <param name="buffer">The destination buffer.</param>
+    private static void ReadExactly(Stream stream, Span<byte> buffer)
+    {
+        int totalRead = 0;
+        while (totalRead < buffer.Length)
+        {
+            int bytesRead = stream.Read(buffer.Slice(totalRead));
+            if (bytesRead == 0)
+            {
+                throw new EndOfStreamException();
+            }
+
+            totalRead += bytesRead;
+        }
+    }
+
+    /// <summary>
+    /// Extracts the PRELOGIN encryption option from a complete TDS packet.
+    /// </summary>
+    /// <param name="packet">The complete PRELOGIN packet.</param>
+    /// <returns>The encryption byte, or <see langword="null" /> when the option is absent.</returns>
+    private static byte? GetPreLoginEncryptionValue(byte[] packet)
+    {
+        const int headerLength = 8;
+        int optionPosition = headerLength;
+        while (packet[optionPosition] != 0xFF)
+        {
+            byte option = packet[optionPosition];
+            int dataOffset = BinaryPrimitives.ReadUInt16BigEndian(packet.AsSpan(optionPosition + 1, 2));
+            int dataLength = BinaryPrimitives.ReadUInt16BigEndian(packet.AsSpan(optionPosition + 3, 2));
+
+            if (option == 0x01 && dataLength == 1)
+            {
+                return packet[headerLength + dataOffset];
+            }
+
+            optionPosition += 5;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Creates a short-lived self-signed certificate for the requested TLS purpose.
+    /// </summary>
+    /// <param name="subjectName">The certificate subject.</param>
+    /// <param name="enhancedKeyUsageOid">The server- or client-authentication OID.</param>
+    /// <returns>A certificate with an exportable private key.</returns>
+    private static X509Certificate2 CreateCertificate(string subjectName, string enhancedKeyUsageOid)
+    {
+        using RSA key = RSA.Create(2048);
+        CertificateRequest request = new(
+            subjectName,
+            key,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+        OidCollection usages = new() { new Oid(enhancedKeyUsageOid) };
+        request.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(usages, critical: true));
+        request.CertificateExtensions.Add(
+            new X509KeyUsageExtension(
+                X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment,
+                critical: true));
+        using X509Certificate2 ephemeralCertificate = request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddMinutes(-5),
+            DateTimeOffset.UtcNow.AddMinutes(5));
+        byte[] certificateBytes = ephemeralCertificate.Export(X509ContentType.Pkcs12);
+        try
+        {
+#pragma warning disable SYSLIB0057
+            return new X509Certificate2(
+                certificateBytes,
+                (string?)null,
+                X509KeyStorageFlags.UserKeySet | X509KeyStorageFlags.Exportable);
+#pragma warning restore SYSLIB0057
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(certificateBytes);
+        }
+    }
+
+    /// <summary>
+    /// Captures the certificate-authentication values observed by the simulated server.
+    /// </summary>
+    private sealed record HandshakeResult(
+        bool ClientCertificateFlagSet,
+        string? ClientCertificateThumbprint,
+        ushort UserNameLength,
+        ushort PasswordLength);
+}
+
+#endif

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ClientCertificateAuthenticationTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ClientCertificateAuthenticationTests.cs
@@ -52,6 +52,16 @@ public sealed class ClientCertificateAuthenticationTests : IDisposable
         0x00,
     };
 
+    private static readonly byte[] s_preLoginEncryptNotSupportedResponse =
+    {
+        0x12, 0x01, 0x00, 0x1A, 0x00, 0x00, 0x01, 0x00,
+        0x00, 0x00, 0x0B, 0x00, 0x06,
+        0x01, 0x00, 0x11, 0x00, 0x01,
+        0xFF,
+        0x11, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x02,
+    };
+
     private readonly string _temporaryDirectory = Path.Combine(
         Path.GetTempPath(),
         $"SqlClientClientCertificateTests-{Guid.NewGuid():N}");
@@ -183,7 +193,7 @@ public sealed class ClientCertificateAuthenticationTests : IDisposable
         TcpListener listener = new(IPAddress.Loopback, 0);
         listener.Start();
         int port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        Task serverTask = Task.Run(() => CompletePreLoginOnly(listener));
+        Task<byte[]> serverTask = Task.Run(() => CompletePreLoginOnly(listener, s_preLoginEncryptOnResponse));
 
         using LocalAppContextSwitchesHelper switches = new();
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -212,6 +222,66 @@ public sealed class ClientCertificateAuthenticationTests : IDisposable
                 "client certificate or private key could not be loaded",
                 authenticationException.Message,
                 StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            listener.Stop();
+            serverTask.GetAwaiter().GetResult();
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a server which declines encryption fails the connection instead of silently
+    /// sending an empty, anonymous LOGIN7 record that no certificate could ever authenticate.
+    /// </summary>
+    [Fact]
+    public void Open_WhenServerDeclinesEncryption_FailsInsteadOfAnonymousLogin()
+    {
+        Directory.CreateDirectory(_temporaryDirectory);
+        string clientCertificatePath = Path.Combine(_temporaryDirectory, "client.pfx");
+
+        using X509Certificate2 clientCertificate = CreateCertificate(
+            "CN=SqlClient Loopback",
+            "1.3.6.1.5.5.7.3.2");
+        File.WriteAllBytes(
+            clientCertificatePath,
+            clientCertificate.Export(X509ContentType.Pkcs12, CertificatePassword));
+
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        Task<byte[]> serverTask = Task.Run(
+            () => CompletePreLoginOnly(listener, s_preLoginEncryptNotSupportedResponse));
+
+        using LocalAppContextSwitchesHelper switches = new();
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            switches.UseManagedNetworking = true;
+        }
+
+        SqlConnectionStringBuilder builder = new()
+        {
+            DataSource = $"127.0.0.1,{port}",
+            Encrypt = SqlConnectionEncryptOption.Optional,
+            TrustServerCertificate = true,
+            ClientCertificate = clientCertificatePath,
+            ClientKeyPassword = CertificatePassword,
+            ConnectTimeout = 5,
+            ConnectRetryCount = 0,
+            Pooling = false,
+        };
+
+        try
+        {
+            using SqlConnection connection = new(builder.ConnectionString);
+            SqlException exception = Assert.Throws<SqlException>(() => connection.Open());
+            Assert.Contains(
+                "requires an encrypted connection",
+                exception.Message,
+                StringComparison.OrdinalIgnoreCase);
+
+            // The client must close without sending an unauthenticated LOGIN7 record.
+            Assert.Empty(serverTask.GetAwaiter().GetResult());
         }
         finally
         {
@@ -287,29 +357,36 @@ public sealed class ClientCertificateAuthenticationTests : IDisposable
     }
 
     /// <summary>
-    /// Completes PRELOGIN, then waits for the client to close before starting TLS.
+    /// Completes PRELOGIN, then records anything the client sends before closing.
     /// </summary>
     /// <param name="listener">The listener accepting the test connection.</param>
-    private static void CompletePreLoginOnly(TcpListener listener)
+    /// <param name="preLoginResponse">The PRELOGIN response written to the client.</param>
+    /// <returns>The bytes the client sent after the PRELOGIN response.</returns>
+    private static byte[] CompletePreLoginOnly(TcpListener listener, byte[] preLoginResponse)
     {
         using TcpClient client = listener.AcceptTcpClient();
         client.ReceiveTimeout = 10_000;
         client.SendTimeout = 10_000;
         using NetworkStream networkStream = client.GetStream();
         ReadTdsPacket(networkStream);
-        networkStream.Write(s_preLoginEncryptOnResponse, 0, s_preLoginEncryptOnResponse.Length);
+        networkStream.Write(preLoginResponse, 0, preLoginResponse.Length);
         networkStream.Flush();
 
+        using MemoryStream trailingBytes = new();
         try
         {
-            while (networkStream.ReadByte() >= 0)
+            int value;
+            while ((value = networkStream.ReadByte()) >= 0)
             {
+                trailingBytes.WriteByte((byte)value);
             }
         }
         catch (IOException)
         {
-            // The expected certificate-loading failure closes the client socket.
+            // The expected failure closes the client socket.
         }
+
+        return trailingBytes.ToArray();
     }
 
     /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ClientCertificateAuthenticationTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ClientCertificateAuthenticationTests.cs
@@ -172,7 +172,7 @@ public sealed class ClientCertificateAuthenticationTests : IDisposable
             listener.Stop();
             try
             {
-                serverTask.Wait(TimeSpan.FromSeconds(10));
+                await serverTask.WaitAsync(TimeSpan.FromSeconds(10));
             }
             catch
             {
@@ -182,10 +182,14 @@ public sealed class ClientCertificateAuthenticationTests : IDisposable
     }
 
     /// <summary>
-    /// Verifies that certificate-file failures flow through the TLS authentication error path.
+    /// Verifies that certificate-file failures flow through the TLS authentication error path on
+    /// both the synchronous and asynchronous open paths.
     /// </summary>
-    [Fact]
-    public void Open_WithMissingClientCertificate_ReportsAuthenticationFailure()
+    /// <param name="async">Whether to open the connection asynchronously.</param>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Open_WithMissingClientCertificate_ReportsAuthenticationFailure(bool async)
     {
         Directory.CreateDirectory(_temporaryDirectory);
         string missingCertificatePath = Path.Combine(_temporaryDirectory, "missing.pfx");
@@ -215,7 +219,9 @@ public sealed class ClientCertificateAuthenticationTests : IDisposable
         try
         {
             using SqlConnection connection = new(builder.ConnectionString);
-            SqlException exception = Assert.Throws<SqlException>(() => connection.Open());
+            SqlException exception = async
+                ? await Assert.ThrowsAsync<SqlException>(() => connection.OpenAsync())
+                : Assert.Throws<SqlException>(() => connection.Open());
             AuthenticationException authenticationException =
                 Assert.IsType<AuthenticationException>(exception.InnerException);
             Assert.Contains(
@@ -226,7 +232,7 @@ public sealed class ClientCertificateAuthenticationTests : IDisposable
         finally
         {
             listener.Stop();
-            serverTask.GetAwaiter().GetResult();
+            await serverTask;
         }
     }
 
@@ -234,8 +240,11 @@ public sealed class ClientCertificateAuthenticationTests : IDisposable
     /// Verifies that a server which declines encryption fails the connection instead of silently
     /// sending an empty, anonymous LOGIN7 record that no certificate could ever authenticate.
     /// </summary>
-    [Fact]
-    public void Open_WhenServerDeclinesEncryption_FailsInsteadOfAnonymousLogin()
+    /// <param name="async">Whether to open the connection asynchronously.</param>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Open_WhenServerDeclinesEncryption_FailsInsteadOfAnonymousLogin(bool async)
     {
         Directory.CreateDirectory(_temporaryDirectory);
         string clientCertificatePath = Path.Combine(_temporaryDirectory, "client.pfx");
@@ -274,19 +283,21 @@ public sealed class ClientCertificateAuthenticationTests : IDisposable
         try
         {
             using SqlConnection connection = new(builder.ConnectionString);
-            SqlException exception = Assert.Throws<SqlException>(() => connection.Open());
+            SqlException exception = async
+                ? await Assert.ThrowsAsync<SqlException>(() => connection.OpenAsync())
+                : Assert.Throws<SqlException>(() => connection.Open());
             Assert.Contains(
                 "requires an encrypted connection",
                 exception.Message,
                 StringComparison.OrdinalIgnoreCase);
 
             // The client must close without sending an unauthenticated LOGIN7 record.
-            Assert.Empty(serverTask.GetAwaiter().GetResult());
+            Assert.Empty(await serverTask);
         }
         finally
         {
             listener.Stop();
-            serverTask.GetAwaiter().GetResult();
+            await serverTask;
         }
     }
 

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ClientCertificateAuthenticationTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ClientCertificateAuthenticationTests.cs
@@ -90,7 +90,34 @@ public sealed class ClientCertificateAuthenticationTests : IDisposable
     [InlineData(1, true)]
     [InlineData(2, false)]
     [InlineData(2, true)]
-    public async Task Open_WithClientCertificate_SendsCertificateAuthenticationHandshake(int encryptionMode, bool async)
+    public Task Open_WithClientCertificate_SendsCertificateAuthenticationHandshake(int encryptionMode, bool async) =>
+        RunCertificateHandshakeAsync(encryptionMode, async, useManagedSni: true);
+
+    /// <summary>
+    /// Verifies the same handshake over native SNI, which selects the certificate by thumbprint and
+    /// falls back to the managed callback because the certificate is not installed in a store. Native
+    /// SNI is only available on Windows, so this runs there alone.
+    /// </summary>
+    /// <param name="encryptionMode">Zero for Optional, one for Mandatory, or two for Strict encryption.</param>
+    /// <param name="async">Whether to open the connection asynchronously.</param>
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(0, true)]
+    [InlineData(1, false)]
+    [InlineData(1, true)]
+    [InlineData(2, false)]
+    [InlineData(2, true)]
+    public Task Open_WithClientCertificateOverNativeSni_SendsCertificateAuthenticationHandshake(int encryptionMode, bool async)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return Task.CompletedTask;
+        }
+
+        return RunCertificateHandshakeAsync(encryptionMode, async, useManagedSni: false);
+    }
+
+    private async Task RunCertificateHandshakeAsync(int encryptionMode, bool async, bool useManagedSni)
     {
         bool strict = encryptionMode == 2;
         Directory.CreateDirectory(_temporaryDirectory);
@@ -120,7 +147,7 @@ public sealed class ClientCertificateAuthenticationTests : IDisposable
         using LocalAppContextSwitchesHelper switches = new();
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            switches.UseManagedNetworking = true;
+            switches.UseManagedNetworking = useManagedSni;
         }
 
         SqlConnectionStringBuilder builder = new()


### PR DESCRIPTION
## Description

Adds client certificate authentication for SQL Server on Linux loopback connections, matching the documented behavior of the ODBC and JDBC drivers. Supported on every target framework, with both managed and native SNI.

- Adds the `Client Certificate` / `ClientCertificate`, `Client Key` / `ClientKey`, and `Client Key Password` / `ClientKeyPassword` connection-string keywords and the matching `SqlConnectionStringBuilder` properties. Paths are plain file paths, as in the JDBC driver.
- Signals certificate authentication with the TDS PRELOGIN `CLIENT_CERT` (`0x80`) bit and sends LOGIN7 with an empty user name and password. Authentication completes during the TLS handshake, so no new `SqlAuthenticationMethod` value is introduced.
- Managed SNI attaches the certificate to the client `SslStream`. Native SNI supplies it through `SNIAuthProviderInfo.pfnCertificateCallback`, which the shipping SNI binaries already honor; no SNI change is required.
- Determines the certificate container format from the **file contents**, never from the file extension. A PKCS#12 (PFX or P12) file supplies its own private key, including ECDSA. A PEM or DER certificate requires `Client Key`, which accepts unencrypted RSA PKCS#1 and RSA PKCS#8 keys, or encrypted PKCS#8 when `Client Key Password` is set.
- Selects the end-entity certificate from a bundle by content rather than by position.
- Requires an encrypted connection. If the server declines encryption the connection fails instead of silently sending an unauthenticated, anonymous LOGIN7 record. `Encrypt=Optional`, `Mandatory`, and `Strict` are all supported when the server negotiates encryption, on both the sync and async open paths.
- Treats `Client Key Password` as sensitive connection information and always redacts it from tracing, regardless of `Persist Security Info`.
- Rejects conflicting configuration: SQL credentials, integrated security, Microsoft Entra authentication, access tokens, `SqlCredential`, a custom SSPI context provider, and `SqlConnection.ChangePassword`. Conflict detection is value-based, so an empty `User ID=` or `Integrated Security=false` does not conflict.
- Reports actionable errors for the ODBC `file:` path prefix, password-protected PKCS#1 keys, non-RSA detached keys, and a `Client Key` combined with a PKCS#12 certificate. Certificate load failures surface as a `SqlException` on both SNI implementations.

## Design notes

The API shape follows the JDBC driver (`clientCertificate` / `clientKey` / `clientKeyPassword`) rather than the single `Certificate` keyword prototyped in CTAIP, per guidance from the SNI/driver team, to keep the .NET and Java surfaces aligned. The CTAIP form accepts only `subject:` and `sha1:` store lookups and therefore cannot express the Linux loopback file scenario this issue asks for.

**How native SNI is driven.** An earlier revision of this PR assigned the certificate handle to `SNIAuthProviderInfo.pCertContext`. That was wrong, and it failed silently. In the SNI sources that produce the pinned `Microsoft.Data.SqlClient.SNI` 6.0.2 package, `Ssl::AcquireCredentialsForClient` gates solely on `pwszCertId`, and `pCertContext` is an *output* parameter that receives the resolved certificate; the field is never read as an input. SNI resolves a certificate by identifier — searching `LocalMachine\MY`, then `CurrentUser\MY`, and invoking `pfnCertificateCallback` only when both lookups miss.

This PR therefore supplies the certificate through that callback, which is live in the shipping provider. Two consequences are worth calling out:

- The identifier passed to SNI is deliberately **unmatchable** (an all-zero SHA-1) rather than the certificate's real thumbprint. The caller named a file, so the file must be authoritative. Passing the real thumbprint would let a store entry with the same thumbprint win — and that entry may have been imported without its private key, which would break the handshake.
- `TdsParser` previously requested the shared Schannel credential cache on every connection. SNI skips credential acquisition entirely when `SNI_SSL_USE_SCHANNEL_CACHE` is set, so the connection reused a cached credential that carried no certificate. That flag is now cleared when, and only when, a client certificate is configured, since such a credential is connection specific. Connections without a client certificate are unaffected, and managed SNI does not read the flag.

The managed `SqlClientCertificateDelegate` was a one-argument stub left over from the code removed in #2831 and did not match the native callback, so it has been redefined against the real signature. The certificate context handed to SNI is duplicated with `CertDuplicateCertificateContext`, because SNI releases it with `CertFreeCertificateContext`.

## Scope and limitations

- **.NET Framework accepts PKCS#12 only.** `net462` has `X509CertificateLoader` through `Microsoft.Bcl.Cryptography` but not `RSA.ImportFromPem`, `ImportPkcs8PrivateKey`, or `PemEncoding`. Supporting a detached PEM key there would require a hand-written ASN.1 RSA key parser, which is not justified for a scenario whose target host is SQL Server on Linux. A detached `Client Key` therefore throws an error on `net462` that names PKCS#12 as the supported alternative; a PFX or P12 containing the key works on all frameworks.
- **Native SNI presents the leaf certificate only.** The callback returns a single `PCCERT_CONTEXT`, and `SNIAuthProviderInfo` has no field for an issuer chain. This matches the JDBC driver, whose PEM/DER path also builds a single-element chain (`SQLServerCertificateUtils.readPKCS8Certificate` calls `keyStore.setKeyEntry(..., new Certificate[] {clientCertificate})`). Managed SNI presents the full chain, which is a superset. Documented in the API remarks.
- **No Windows certificate store syntax.** The ODBC `subject:` and `sha1:` forms are not accepted; that scaffolding was removed in #2831. The JDBC driver does not support them either, so omitting them is the parity-preserving choice. They remain additive later — native SNI already resolves them through `pwszCertId` / `fCertHash` — but would need new managed-SNI code.
- **Certificate rotation.** The certificate is read when a pooled physical connection is created and cached for that connection's lifetime. Picking up a rotated certificate requires `SqlConnection.ClearPool` or `Pooling=false`.
- **Sample.** `doc/samples/SqlConnection_ClientCertificateAuthentication.cs` is guarded with `#if false` because the Samples project compiles against the released `Microsoft.Data.SqlClient` package, which does not yet expose these properties. The guard should be removed once a package containing them ships.

**Release note:** Added `Client Certificate`, `Client Key`, and `Client Key Password` connection-string support for SQL Server on Linux loopback certificate authentication.

## Issues

Fixes #4551

## Testing

Connection-string and API surface
- Keyword and alias parsing, key-without-certificate validation, credential conflict detection, empty-credential-keyword non-conflict, and confirmation that the container format is not inferred from the file extension.
- `Client Key Password` redaction from both the public connection string and the trace string.
- `SqlConnectionStringBuilder` round-trip and `Clear`.
- Conflicts with `SqlCredential`, `AccessToken`, `AccessTokenCallback`, and both `ChangePassword` overloads.
- On .NET Framework, the keywords parse and round-trip identically to .NET, and a detached `Client Key` produces the documented "requires .NET" error.

Certificate loader
- Encrypted PFX, PEM certificate with an encrypted PKCS#8 key, PEM chain, PFX chain, and ECDSA PFX.
- PKCS#12 content loaded from `.pem`, `.cer`, and extensionless paths, and PEM content loaded from a `.pfx` path, confirming content-based detection.
- Deterministic leaf selection from a PKCS#12 bundle in which an issuer also carries a private key.
- Rejection of detached ECDSA keys (PKCS#8 and SEC1), password-protected PKCS#1 keys, a `Client Key` paired with a PKCS#12 certificate, the ODBC `file:` prefix, expired certificates, incorrect passwords, missing keys, and unsupported PEM key labels.

Simulated TDS/TLS server
- PRELOGIN `0x80`, client certificate presentation, and empty LOGIN7 user name and password across `Optional`, `Mandatory`, and `Strict`, sync and async. The simulated server sets `ClientCertificateRequired` and asserts the exact thumbprint it observed, so the certificate is verified to reach the TLS layer rather than merely being configured.
- **The same matrix is run a second time over native SNI**, which is what caught the `pCertContext` defect described above: those six cases failed with a null observed thumbprint against the previous implementation and pass now. Because the identifier passed to SNI is unmatchable by construction, a passing run proves the certificate arrived through the callback.
- Certificate load failure surfaced as `SqlException` wrapping `AuthenticationException`, sync and async.
- Server declining encryption fails the connection, asserting that no bytes at all are sent after PRELOGIN, sync and async.

Builds and runs
- Full solution build (39 projects), 0 warnings and 0 errors, including the Samples project and the GenAPI-generated "not supported" assemblies. The generated surface contains the new properties for all four target frameworks.

End-to-end against a real SQL Server on Linux

Validated against **SQL Server 2022 (16.0.4265.3) Developer Edition on Ubuntu 22.04**, using a `linux-x64` client built from this branch, running on the SQL Server host.

- **The certificate is presented and the server extracts its identity.** Using the real launchpad-minted satellite credentials — `/var/opt/mssql-extensibility/data/<launchpad-guid>/sqlsatellitecert.pem` and `sqlsatellitekey.pem`, the exact files and formats the extensibility framework produces (PEM certificate plus PKCS#1 PEM key) — the server responded `Login failed for user 'Microsoft Corporation'`. That is the `O` of the satellite certificate's subject, so SQL Server received the certificate, parsed it, and derived the login identity from it. This confirms the certificate reaches the server and that LOGIN7 is interpreted as certificate authentication rather than as an anonymous login. Reproduced on `Encrypt=Optional` and `Encrypt=Mandatory`.
- **A second, independent path gives the same result.** With a SQL-generated certificate (`CREATE CERTIFICATE` / `CREATE LOGIN ... FROM CERTIFICATE`, exported via `BACKUP CERTIFICATE` and converted from PVK to PEM), the server resolved the login as `clientCertAuth` and logged `Error: 18456, State: 1 ... Reason: Infrastructure error occurred`. Certificate-to-login resolution again succeeded; the rejection is the documented behavior that certificate-mapped logins cannot be used for ordinary connections.
- **The error paths behave correctly against a live server**, surfacing `SqlException` wrapping `AuthenticationException` ("The client certificate or private key could not be loaded") for unreadable certificate material.

This exercises **managed SNI**, which is the implementation used in the real scenario, since the target host is Linux.
- Unified product built for Windows (`net462`, `net8.0`, `net9.0`) and Unix (`net8.0`, `net9.0`), plus the reference assemblies.
- Unit tests: `net9.0` 1151 passed / 0 failed; `net462` 1163 passed / 0 failed. The `net462` run is split into two invocations because `SimulatedServerTests` leaves the `net462` test host hanging after all of its tests pass — a pre-existing condition reproduced on an unmodified `origin/main` worktree, unrelated to this change.
- Functional tests run in full and compared against an `origin/main` worktree on the same machine: identical pre-existing failure counts (2 on `net9.0`, 86 on `net462`, all Always Encrypted certificate-store and `SqlDataRecordTest.GetUdt_ReturnsValue` environmental failures). No regressions.

Not yet validated
- **A fully authenticated session was not obtained**, and this is a server-side constraint rather than a driver gap. Two routes were tested directly on the host:
  - *Without SPEES.* A certificate-mapped login (`CREATE CERTIFICATE` + `CREATE LOGIN ... FROM CERTIFICATE`, exported with `BACKUP CERTIFICATE` and converted from PVK to PEM) resolves correctly — the server reports the login by name — but is then rejected with `Error: 18456, State: 1 ... Reason: Infrastructure error occurred`. This was retried **after** installing `mssql-server-extensibility`, enabling `external scripts enabled`, and confirming `mssql-launchpadd` was running, and the result was identical. That matches the documented behavior that logins created from certificates "can't be used to connect to SQL Server": there is no administrator-configurable way to trust an arbitrary client certificate for a login.
  - *With SPEES.* The supported trust anchor is registered by the launchpad per external-script session. Reaching it needs a working R or Python runtime under the launchpad; on SQL Server 2022 the launchpad still binds the legacy `mssql-mlservices` launchers (`libPythonLauncher.so` / `libRLauncher.so`), which are not installable on 2022. Completing this would require a SQL Server 2019 host with the `mssql-mlservices-*` packages.

  In both cases the certificate was transmitted and parsed by the server; the unverified remainder is the **server's authorization decision**, not the driver's presentation of the certificate.
- **`Encrypt=Strict` (TDS 8) was not confirmed against a live server.** It fails on the test host during the TLS handshake — but so does `sqlcmd` with ODBC Driver 18 and `-N s` and no client certificate at all (`TCP Provider: Error code 0x2746`). That isolates it to the server instance's TDS 8 configuration rather than to this change. The Strict path, including `tds/8.0` ALPN, remains covered by the simulated-server tests.
- **`Encrypt=Strict` (TDS 8) was not confirmed against a live server.** It fails on the test host during the TLS handshake — but so does `sqlcmd` with ODBC Driver 18 and `-N s` and no client certificate at all (`TCP Provider: Error code 0x2746`). That isolates it to the server instance's TDS 8 configuration rather than to this change. The Strict path, including `tds/8.0` ALPN, remains covered by the simulated-server tests.

Review
- Reviewed with Claude Sonnet 5, then independently with GPT-5.6 Sol and Claude Opus 5, then GPT-5.6 Luna on the remediation, then a codebase-pattern conformance pass, then GPT-5.6 Luna again on the native SNI work and once more on this fix. All findings were addressed or answered in the review threads.

- [x] Tests added or updated
- [x] Public API changes documented
- [ ] Verified against customer repro (requires a SQL Server on Linux loopback certificate environment)
- [x] Ensure no breaking changes introduced

## Guidelines

- [x] [Contributing](/CONTRIBUTING.md)
- [x] [Code of Conduct](/CODE_OF_CONDUCT.md)
- [x] [Best Practices](/policy/coding-best-practices.md)
- [x] [Coding Style](/policy/coding-style.md)
- [x] [Review Process](/policy/review-process.md)
