### PR TITLE
Fix | Preserve delegated transactions when resetting a pooled connection

### DIFF
--- a/doc/design-notes/4001-delegated-transaction-reset.md
+++ b/doc/design-notes/4001-delegated-transaction-reset.md
@@ -151,43 +151,9 @@ evaluate `false` while `B` is `true`. The guarantee is structural, not empirical
 The condition is a strict **superset** of both prior behaviors. There is no input on
 which it returns `false` where either predecessor returned `true`.
 
-### Why the union, and not something more precise
-
-An earlier attempt checked whether the transaction was still *alive* before preserving
-it — inspecting `TransactionInformation.Status`, mirroring the pattern in
-`DbConnectionInternal.DetachCurrentTransactionIfEnded`. It worked, and it was arguably
-more correct.
-
-It was discarded deliberately, because it **changed the value in the #2970 row**. That
-would have meant relying on tests to prove #2970 had not regressed — and as section 8
-shows, the test suite cannot currently prove that.
-
-A guarantee derived from the shape of the condition is worth more here than a green
-check from tests that do not exercise the line. If the liveness refinement is
-desirable, it should land as its own change, on its own merits, with test coverage
-that actually discriminates.
-
 ---
 
-## 6. The residual risk, stated plainly
-
-The risk in this change is **not** reintroducing #2970. It is the opposite direction:
-this fix preserves in the delegated-root row where #3019 chose not to. If a connection
-were the root of a transaction that had already ended, this would preserve state that
-did not need preserving.
-
-Two reasons that is acceptable:
-
-- **It is not new behavior.** This is precisely what 6.0.5 and every prior release did,
-  in production, for years. This restores known-good behavior rather than introducing
-  untested behavior.
-- **The failure modes are not symmetric.** Under-preserving *destroys a live
-  transaction* and permanently breaks a pooled connection — the bug being fixed.
-  Over-preserving leaves state that is cleaned up when the transaction completes.
-
----
-
-## 7. How the root cause was established
+## 6. How the root cause was established
 
 The cause was **proven at runtime, not inferred**. The driver was temporarily
 instrumented at the reset site and at `DoomThisConnection()`. The captured state at the
@@ -218,7 +184,7 @@ All instrumentation was removed before commit.
 
 ---
 
-## 8. What the existing tests actually verify
+## 7. What the existing tests actually verify
 
 This section is deliberately blunt, because the intuitive answer is wrong.
 
@@ -269,44 +235,7 @@ matrix above and the structural argument in section 5. Those should carry the we
 
 ---
 
-## 9. Why no new automated test ships with this fix
-
-The only known reliable reproduction requires NHibernate.
-
-The bug needs the connection caught in a narrow half-state: still the delegated root,
-but with `EnlistedTransaction` already detached by `DetachCurrentTransactionIfEnded()`
-(called from `DbConnectionInternal.CloseConnection`). NHibernate's `StatelessSession`
-reaches this window because it returns the connection to the pool after **every
-statement**. Hand-written SqlClient code typically holds a connection across statements
-and steps straight over it.
-
-Eight NHibernate-free variants were attempted. Every one landed in a non-reproducing
-state:
-
-| Variant | Shape | Observed |
-|---|---|---|
-| A | c1 open/query/close, c2 open + query | `enlisted=set` — buggy condition accidentally true |
-| B | as A, c2 does nothing | `enlisted=set` |
-| C | c2 does `BeginTransaction()` then query | `enlisted=set` |
-| D | default pool size, c2 forces promotion failure, then `c1.Close()` | `deleg.IsActive=False` — already torn down |
-| E | c1 parked in pool, then `Transaction.Current.Rollback()` | `deleg.IsActive=False` |
-| F | c1 park → reopen → promotion fail → close | `deleg.IsActive=False` |
-| G | c2 from a different pool forces promotion | `deleg.IsActive=False` |
-| H | mirrors NHibernate: park, reopen, local tx inside ambient scope | `enlisted=set` |
-
-Either the connection still held its `EnlistedTransaction` (so the buggy condition
-happened to evaluate `true`), or delegation had already been torn down synchronously.
-Neither reproduces the failure.
-
-This is a genuine coverage gap and is recorded here rather than papered over. Given
-section 8, closing it properly would mean adding a test that *fails* against both
-buggy conditions — which, today, likely requires either an NHibernate-backed manual
-test or a targeted harness that drives a connection into the delegated-root-with-
-detached-enlistment state directly.
-
----
-
-## 10. Related
+## 8. Related
 
 - **#2970** — the issue #3019 was fixing. Fully preserved by this change (section 5).
 - **#2285** — reports the same exception with no reproduction. Plausibly the same root

--- a/doc/design-notes/4001-delegated-transaction-reset.md
+++ b/doc/design-notes/4001-delegated-transaction-reset.md
@@ -19,7 +19,7 @@ what the existing test suite does and does not actually verify.
 This distinction is the crux of the entire bug.
 
 When a connection participates in a `TransactionScope`, it ends up in one of **two
-mutually exclusive** states.
+distinct** states. They overlap, but neither implies the other.
 
 ### Delegated root — "I *own* this transaction"
 
@@ -28,10 +28,26 @@ down to SQL Server rather than paying for a distributed coordinator. The transac
 lives **on** the connection.
 
 - `IsTransactionRoot` → `true`
-- `EnlistedTransaction` → **`null`**
+- `EnlistedTransaction` → set at first, then **cleared** later (see below)
 
-The `null` is not an oversight. There is no external transaction object to point at,
-because the transaction *is here*.
+`IsTransactionRoot` is not a stored flag. It is derived:
+
+```csharp
+internal bool IsTransactionRoot => DelegatedTransaction?.IsActive == true;
+```
+
+Enlistment sets `EnlistedTransaction` unconditionally, so a *freshly* delegated root
+has both. But once the transaction is no longer `Active`,
+`DbConnectionInternal.DetachCurrentTransactionIfEnded` clears `EnlistedTransaction`:
+
+```csharp
+transactionIsDead = enlistedTransaction.TransactionInformation.Status != TransactionStatus.Active;
+if (transactionIsDead) { DetachTransaction(enlistedTransaction, true); }
+```
+
+The delegated transaction, meanwhile, can still report `IsActive == true`. That
+transient **half-state** — root, but no `EnlistedTransaction` — is precisely the state
+issue #4001 reproduces in.
 
 ### Enlisted participant — "I *joined* someone else's transaction"
 
@@ -43,9 +59,10 @@ each connection enlists in it.
 
 ### The trap
 
-These two states never look alike. **A delegated root always has a `null`
-`EnlistedTransaction`.** Any check that tests only one of these fields silently
-misses the other case — and does so with no exception at the point of the mistake.
+Neither field subsumes the other: a delegated root can have a `null`
+`EnlistedTransaction`, and an enlisted participant is never a root. Any check that
+tests only one of these fields silently misses the other case — and does so with no
+exception at the point of the mistake.
 
 ---
 
@@ -96,12 +113,16 @@ internal protected override bool IsNonPoolableTransactionRoot
     => IsTransactionRoot && (!Is2008OrNewer || Pool == null);
 ```
 
-Since `Is2008OrNewer` is true for every supported server, the entire pre-#3019
-condition reduces to:
+Substituting, the pre-#3019 condition was:
 
 ```csharp
-IsTransactionRoot && Pool != null
+IsTransactionRoot && Is2008OrNewer && Pool != null
 ```
+
+The `Is2008OrNewer` term is not vestigial. `AdapterUtil.ValidateTdsVersion` still accepts
+`TdsEnums.SQL2005_VERSION`, and `ConnectionCapabilities.Is2008R2OrNewer` returns `false`
+for it. A pre-2008 server cannot carry a delegated transaction across a reset, so such a
+connection must not be recycled with one attached.
 
 So the two conditions were:
 
@@ -120,13 +141,26 @@ This reframes the fix: the goal is not to undo #3019, it is to finish it.
 
 ## 4. The fix
 
+The predicate is extracted into a helper so it can be tested directly:
+
 ```csharp
-_parser.PrepareResetConnection(
-    Pool is not null &&
-    (IsTransactionRoot || EnlistedTransaction is not null));
+internal static bool ShouldPreserveTransactionOnReset(
+    bool isPooled,
+    bool isTransactionRoot,
+    bool is2008OrNewer,
+    bool hasEnlistedTransaction)
+{
+    if (!isPooled)
+    {
+        return false;
+    }
+
+    return (isTransactionRoot && is2008OrNewer) || hasEnlistedTransaction;
+}
 ```
 
-This is exactly `OLD || NEW`.
+This is exactly `OLD || NEW`, with both prior conditions preserved verbatim — including
+the `Is2008OrNewer` guard that only ever applied to the delegated-root arm.
 
 ---
 
@@ -135,12 +169,13 @@ This is exactly `OLD || NEW`.
 This is the question that matters most, and it is answerable by inspection rather than
 by testing. Every reachable state, for a pooled connection:
 
-| `IsTransactionRoot` | `EnlistedTransaction` | Pre-#3019 | #3019 | **This fix** |
-|:---:|:---:|:---:|:---:|:---:|
-| `false` | `null` | `false` | `false` | `false` |
-| **`true`** | **`null`** | ✅ `true` | ❌ `false` ← **#4001** | ✅ **`true`** |
-| **`false`** | **set** | ❌ `false` ← **#2970** | ✅ `true` | ✅ **`true`** |
-| `true` | set | `true` | `true` | `true` |
+| `IsTransactionRoot` | `Is2008OrNewer` | `EnlistedTransaction` | Pre-#3019 | #3019 | **This fix** |
+|:---:|:---:|:---:|:---:|:---:|:---:|
+| `false` | `true` | `null` | `false` | `false` | `false` |
+| **`true`** | **`true`** | **`null`** | ✅ `true` | ❌ `false` ← **#4001** | ✅ **`true`** |
+| `true` | `false` | `null` | `false` | `false` | `false` |
+| **`false`** | any | **set** | ❌ `false` ← **#2970** | ✅ `true` | ✅ **`true`** |
+| `true` | any | set | see above | `true` | `true` |
 
 Read the **#2970 row**. That is the row PR #3019 was created to fix, and this fix still
 evaluates `true` there. It is untouched.
@@ -148,8 +183,9 @@ evaluates `true` there. It is untouched.
 Reintroducing #2970 would require that cell to flip to `false`, and `A || B` cannot
 evaluate `false` while `B` is `true`. The guarantee is structural, not empirical.
 
-The condition is a strict **superset** of both prior behaviors. There is no input on
-which it returns `false` where either predecessor returned `true`.
+Because each arm reproduces its original predecessor exactly, the condition returns
+`true` wherever either predecessor did, and never returns `false` where one of them
+returned `true`.
 
 ---
 
@@ -230,8 +266,43 @@ to cover #2970 — is tagged `[Trait("Category", "flaky")]` and passes against c
 carries the #2970 bug.
 
 The practical conclusion: **the 9/9 result is evidence of no collateral damage, not
-evidence that the fix works.** The evidence that the fix works is the reproduction
-matrix above and the structural argument in section 5. Those should carry the weight.
+evidence that the fix works.**
+
+### The regression test that was added
+
+An end-to-end reproduction was attempted extensively and abandoned. The `#4001` state
+requires a narrow simultaneity — the transaction's status already non-`Active` (so
+`DetachCurrentTransactionIfEnded` has cleared `EnlistedTransaction`) while
+`DelegatedTransaction.IsActive` is still `true` — and which of two teardown paths in
+`SqlDelegatedTransaction` wins is a race:
+
+- `TransactionEnded` sets `_active = false` and *immediately* calls
+  `DoomThisConnection()`. If this path runs first, the delegate is already inactive
+  before any reset, so the state is never observed.
+- `Rollback`, driven from `TransactionScope.Dispose`, sets `_active = false` *after* the
+  reset. This is the ordering the reporter hit.
+
+Roughly twenty harness variants — varying pool size, pool implementation, promotion
+success, explicit rollback, and parking the delegate in the transacted pool ahead of the
+enlistment — consistently drove the first path. A test built on that race would be
+flaky, which is the same defect `Test_EnlistedTransactionPreservedWhilePooled` already
+demonstrates.
+
+Instead the predicate was extracted into
+`SqlConnectionInternal.ShouldPreserveTransactionOnReset` and pinned directly by
+`SqlConnectionInternalResetTransactionTests`, following the existing precedent of
+`ResolveLoginTimeout` / `SqlConnectionInternalTimeoutTests`. The tests were themselves
+mutation-tested:
+
+| Condition compiled into the helper | Bug it contains | New tests |
+|---|---|---|
+| `hasEnlistedTransaction` (#3019) | **#4001** | ❌ 2 failed |
+| `isTransactionRoot && is2008OrNewer` (pre-#3019) | **#2970** | ❌ 4 failed |
+| Union without the 2008 guard | pre-2008 regression | ❌ 2 failed |
+| The shipped condition | none | ✅ 15 passed |
+
+This satisfies "fails before the change, passes after" for **both** regressions, and
+does so deterministically and without a server.
 
 ---
 

--- a/doc/design-notes/4001-delegated-transaction-reset.md
+++ b/doc/design-notes/4001-delegated-transaction-reset.md
@@ -299,7 +299,7 @@ mutation-tested:
 | `hasEnlistedTransaction` (#3019) | **#4001** | ❌ 2 failed |
 | `isTransactionRoot && is2008OrNewer` (pre-#3019) | **#2970** | ❌ 4 failed |
 | Union without the 2008 guard | pre-2008 regression | ❌ 2 failed |
-| The shipped condition | none | ✅ 15 passed |
+| The shipped condition | none | ✅ 19 passed |
 
 This satisfies "fails before the change, passes after" for **both** regressions, and
 does so deterministically and without a server.

--- a/doc/design-notes/4001-delegated-transaction-reset.md
+++ b/doc/design-notes/4001-delegated-transaction-reset.md
@@ -119,10 +119,22 @@ Substituting, the pre-#3019 condition was:
 IsTransactionRoot && Is2008OrNewer && Pool != null
 ```
 
-The `Is2008OrNewer` term is not vestigial. `AdapterUtil.ValidateTdsVersion` still accepts
-`TdsEnums.SQL2005_VERSION`, and `ConnectionCapabilities.Is2008R2OrNewer` returns `false`
-for it. A pre-2008 server cannot carry a delegated transaction across a reset, so such a
-connection must not be recycled with one attached.
+The `Is2008OrNewer` term is **deliberately not carried forward**, for two reasons.
+
+First, it is outside the support matrix. The term is `false` for exactly one server
+version — SQL Server 2005 — and the driver's supported floor is SQL Server 2012.
+
+Second, and more importantly, **it was never safe on its own.** `IsNonPoolableTransactionRoot`
+had two jobs, not one. Besides suppressing the preserve bit, it also drove pool routing:
+`DbConnectionPool` sent any connection it flagged into *stasis* rather than back into the
+pool. Being parked is what made a plain reset harmless — the connection was never handed
+to another caller. #3019 deleted the property entirely, and today's pools route on
+`EnlistedTransaction` alone. A delegated root with a `null` `EnlistedTransaction` now goes
+straight back to the **general** pool.
+
+Reinstating only the suppression half would therefore reset a live delegated transaction
+*and* hand the connection out again — #4001 exactly, just narrowed to SQL Server 2005.
+Half of a retired safety mechanism is worse than none of it.
 
 So the two conditions were:
 
@@ -147,7 +159,6 @@ The predicate is extracted into a helper so it can be tested directly:
 internal static bool ShouldPreserveTransactionOnReset(
     bool isPooled,
     bool isTransactionRoot,
-    bool is2008OrNewer,
     bool hasEnlistedTransaction)
 {
     if (!isPooled)
@@ -155,12 +166,12 @@ internal static bool ShouldPreserveTransactionOnReset(
         return false;
     }
 
-    return (isTransactionRoot && is2008OrNewer) || hasEnlistedTransaction;
+    return isTransactionRoot || hasEnlistedTransaction;
 }
 ```
 
-This is exactly `OLD || NEW`, with both prior conditions preserved verbatim — including
-the `Is2008OrNewer` guard that only ever applied to the delegated-root arm.
+This is `OLD || NEW`: each arm answers one of the two questions from section 1, so the
+predicate is `true` wherever either predecessor was.
 
 ---
 
@@ -169,13 +180,12 @@ the `Is2008OrNewer` guard that only ever applied to the delegated-root arm.
 This is the question that matters most, and it is answerable by inspection rather than
 by testing. Every reachable state, for a pooled connection:
 
-| `IsTransactionRoot` | `Is2008OrNewer` | `EnlistedTransaction` | Pre-#3019 | #3019 | **This fix** |
-|:---:|:---:|:---:|:---:|:---:|:---:|
-| `false` | `true` | `null` | `false` | `false` | `false` |
-| **`true`** | **`true`** | **`null`** | ✅ `true` | ❌ `false` ← **#4001** | ✅ **`true`** |
-| `true` | `false` | `null` | `false` | `false` | `false` |
-| **`false`** | any | **set** | ❌ `false` ← **#2970** | ✅ `true` | ✅ **`true`** |
-| `true` | any | set | see above | `true` | `true` |
+| `IsTransactionRoot` | `EnlistedTransaction` | Pre-#3019 | #3019 | **This fix** |
+|:---:|:---:|:---:|:---:|:---:|
+| `false` | `null` | `false` | `false` | `false` |
+| **`true`** | **`null`** | ✅ `true` | ❌ `false` ← **#4001** | ✅ **`true`** |
+| **`false`** | **set** | ❌ `false` ← **#2970** | ✅ `true` | ✅ **`true`** |
+| `true` | set | `true` | `true` | `true` |
 
 Read the **#2970 row**. That is the row PR #3019 was created to fix, and this fix still
 evaluates `true` there. It is untouched.
@@ -297,9 +307,8 @@ mutation-tested:
 | Condition compiled into the helper | Bug it contains | New tests |
 |---|---|---|
 | `hasEnlistedTransaction` (#3019) | **#4001** | ❌ 2 failed |
-| `isTransactionRoot && is2008OrNewer` (pre-#3019) | **#2970** | ❌ 4 failed |
-| Union without the 2008 guard | pre-2008 regression | ❌ 2 failed |
-| The shipped condition | none | ✅ 19 passed |
+| `isTransactionRoot` (pre-#3019) | **#2970** | ❌ 2 failed |
+| The shipped condition | none | ✅ 11 passed |
 
 This satisfies "fails before the change, passes after" for **both** regressions, and
 does so deterministically and without a server.

--- a/doc/design-notes/4001-delegated-transaction-reset.md
+++ b/doc/design-notes/4001-delegated-transaction-reset.md
@@ -1,0 +1,313 @@
+# Root cause analysis: #4001 — pooled connection broken after `TransactionScope` rollback
+
+| | |
+|---|---|
+| **Issue** | [#4001](https://github.com/dotnet/SqlClient/issues/4001) |
+| **Regressed by** | [#3019](https://github.com/dotnet/SqlClient/pull/3019) (`0322d44c7`), shipped in 6.1.0 |
+| **Affected** | 6.1.0 → 6.1.6, `main` |
+| **Last good** | 6.0.5 |
+| **Code** | `SqlConnectionInternal.ResetConnection()` |
+
+This note records why the bug happens, why the previous fix caused it, why the new
+condition cannot reintroduce the issue that fix was addressing, and — importantly —
+what the existing test suite does and does not actually verify.
+
+---
+
+## 1. Background: two ways a connection can be "in" a transaction
+
+This distinction is the crux of the entire bug.
+
+When a connection participates in a `TransactionScope`, it ends up in one of **two
+mutually exclusive** states.
+
+### Delegated root — "I *own* this transaction"
+
+Only one connection is involved, so `System.Transactions` delegates the transaction
+down to SQL Server rather than paying for a distributed coordinator. The transaction
+lives **on** the connection.
+
+- `IsTransactionRoot` → `true`
+- `EnlistedTransaction` → **`null`**
+
+The `null` is not an oversight. There is no external transaction object to point at,
+because the transaction *is here*.
+
+### Enlisted participant — "I *joined* someone else's transaction"
+
+Multiple resources are involved, so a coordinator (MSDTC) owns the transaction and
+each connection enlists in it.
+
+- `IsTransactionRoot` → `false`
+- `EnlistedTransaction` → set
+
+### The trap
+
+These two states never look alike. **A delegated root always has a `null`
+`EnlistedTransaction`.** Any check that tests only one of these fields silently
+misses the other case — and does so with no exception at the point of the mistake.
+
+---
+
+## 2. Where the damage occurs
+
+When a connection is closed it returns to the pool and is **reset** — wiped clean for
+the next consumer. If a transaction is still in flight, that reset must *preserve* it.
+The entire decision is one boolean:
+
+```csharp
+_parser.PrepareResetConnection(preserveTransaction);
+```
+
+Pass `false` while a transaction is genuinely live, and the TDS reset destroys the
+server-side transaction **while `System.Transactions` still believes it exists**.
+
+The failure then surfaces later, some distance from the cause:
+
+1. `TransactionScope` disposes and rolls back.
+2. `SqlDelegatedTransaction.Rollback` asks the server to roll back a transaction the
+   server no longer has.
+3. The rollback fails, and SqlClient calls `DoomThisConnection()`.
+4. The physical connection is now permanently marked broken.
+5. With a small pool (the report used `MaxPoolSize=1`) that same doomed connection is
+   immediately handed back out.
+6. The next caller gets:
+
+> `InvalidOperationException: The requested operation cannot be completed because the connection has been broken.`
+
+The exception names the connection, not the reset that ruined it. That distance
+between cause and symptom is what makes this class of bug hard to trace.
+
+---
+
+## 3. What PR #3019 actually changed
+
+The relevant diff from `0322d44c7`:
+
+```diff
+- _parser.PrepareResetConnection(IsTransactionRoot && !IsNonPoolableTransactionRoot);
++ _parser.PrepareResetConnection(EnlistedTransaction is not null && Pool is not null);
+```
+
+The old helper was:
+
+```csharp
+internal protected override bool IsNonPoolableTransactionRoot
+    => IsTransactionRoot && (!Is2008OrNewer || Pool == null);
+```
+
+Since `Is2008OrNewer` is true for every supported server, the entire pre-#3019
+condition reduces to:
+
+```csharp
+IsTransactionRoot && Pool != null
+```
+
+So the two conditions were:
+
+| | Question it asked | Covered | Missed |
+|---|---|---|---|
+| **Pre-#3019** | "Am I the *owner*?" | delegated root | enlisted → **#2970** |
+| **#3019** | "Am I *enlisted*?" | enlisted | delegated root → **#4001** |
+
+**#3019 swapped one case for the other rather than covering both.** It genuinely fixed
+#2970, and it traded it for #4001. Both conditions were half-right; neither was wrong
+about the case it did cover.
+
+This reframes the fix: the goal is not to undo #3019, it is to finish it.
+
+---
+
+## 4. The fix
+
+```csharp
+_parser.PrepareResetConnection(
+    Pool is not null &&
+    (IsTransactionRoot || EnlistedTransaction is not null));
+```
+
+This is exactly `OLD || NEW`.
+
+---
+
+## 5. Why this cannot reintroduce #2970
+
+This is the question that matters most, and it is answerable by inspection rather than
+by testing. Every reachable state, for a pooled connection:
+
+| `IsTransactionRoot` | `EnlistedTransaction` | Pre-#3019 | #3019 | **This fix** |
+|:---:|:---:|:---:|:---:|:---:|
+| `false` | `null` | `false` | `false` | `false` |
+| **`true`** | **`null`** | ✅ `true` | ❌ `false` ← **#4001** | ✅ **`true`** |
+| **`false`** | **set** | ❌ `false` ← **#2970** | ✅ `true` | ✅ **`true`** |
+| `true` | set | `true` | `true` | `true` |
+
+Read the **#2970 row**. That is the row PR #3019 was created to fix, and this fix still
+evaluates `true` there. It is untouched.
+
+Reintroducing #2970 would require that cell to flip to `false`, and `A || B` cannot
+evaluate `false` while `B` is `true`. The guarantee is structural, not empirical.
+
+The condition is a strict **superset** of both prior behaviors. There is no input on
+which it returns `false` where either predecessor returned `true`.
+
+### Why the union, and not something more precise
+
+An earlier attempt checked whether the transaction was still *alive* before preserving
+it — inspecting `TransactionInformation.Status`, mirroring the pattern in
+`DbConnectionInternal.DetachCurrentTransactionIfEnded`. It worked, and it was arguably
+more correct.
+
+It was discarded deliberately, because it **changed the value in the #2970 row**. That
+would have meant relying on tests to prove #2970 had not regressed — and as section 8
+shows, the test suite cannot currently prove that.
+
+A guarantee derived from the shape of the condition is worth more here than a green
+check from tests that do not exercise the line. If the liveness refinement is
+desirable, it should land as its own change, on its own merits, with test coverage
+that actually discriminates.
+
+---
+
+## 6. The residual risk, stated plainly
+
+The risk in this change is **not** reintroducing #2970. It is the opposite direction:
+this fix preserves in the delegated-root row where #3019 chose not to. If a connection
+were the root of a transaction that had already ended, this would preserve state that
+did not need preserving.
+
+Two reasons that is acceptable:
+
+- **It is not new behavior.** This is precisely what 6.0.5 and every prior release did,
+  in production, for years. This restores known-good behavior rather than introducing
+  untested behavior.
+- **The failure modes are not symmetric.** Under-preserving *destroys a live
+  transaction* and permanently breaks a pooled connection — the bug being fixed.
+  Over-preserving leaves state that is cleaned up when the transaction completes.
+
+---
+
+## 7. How the root cause was established
+
+The cause was **proven at runtime, not inferred**. The driver was temporarily
+instrumented at the reset site and at `DoomThisConnection()`. The captured state at the
+critical reset:
+
+```
+[RESET] obj=4  preserve=False  root=False  deleg=null         enlisted=null  pool=set
+[RESET] obj=7  preserve=False  root=False  deleg=null         enlisted=null  pool=set
+[RESET] obj=7  preserve=False  root=True   deleg=active=True  enlisted=null  pool=set   <-- old: true, new: false
+[DOOM]  obj=7
+   at Microsoft.Data.SqlClient.SqlDelegatedTransaction.Rollback(...)
+   at System.Transactions.Transaction.Rollback()
+   at System.Transactions.TransactionScope.InternalDispose()
+   at System.Transactions.TransactionScope.Dispose()
+[FAIL] Bug reproduced
+```
+
+The third reset is the bug caught in the act: `root=True`, `deleg.IsActive=True`,
+`enlisted=null`, and `preserve=False`. A live delegated transaction being discarded.
+
+This mattered, because **the initial hypothesis was wrong.** The first theory was that
+#3019 had made the condition *too broad*, and a narrowing fix was written on that
+basis. It did not work. The instrumentation showed the opposite — #3019 had *narrowed*
+the condition, not widened it — and the fix was rewritten accordingly. Without runtime
+evidence this would have been fixed in the wrong direction.
+
+All instrumentation was removed before commit.
+
+---
+
+## 8. What the existing tests actually verify
+
+This section is deliberately blunt, because the intuitive answer is wrong.
+
+### Bisection
+
+Against the reporter's reproduction (NHibernate 5.5.2, `MaxPoolSize=1`,
+`TransactionScope` with a failed DTC promotion):
+
+**6.0.5 ✅ · 6.1.0 ❌ · 6.1.1 ❌ · 6.1.4 ❌ · `main` ❌**
+
+This places the regression in the 6.1.0 window, consistent with #3019.
+
+### Both pool implementations, both directions
+
+| | without fix | with fix |
+|---|---|---|
+| `WaitHandleDbConnectionPool` (default) | ❌ reproduces | ✅ passes |
+| `ChannelDbConnectionPool` (`UseConnectionPoolV2`) | ❌ reproduces | ✅ passes |
+
+The **left-hand column is the load-bearing one.** It was produced by stashing the fix
+and rebuilding. Without it, a pass on the V2 pool could simply mean V2 never reaches
+this code path, which would prove nothing.
+
+(V2 in released 6.1.4 throws `NotImplementedException`, so only `main` was testable.)
+
+### Mutation testing of the manual suite
+
+`--filter "FullyQualifiedName~TransactionTest"` reports **9/9 passing** with the fix.
+That number is easy to over-read, so the suite was mutation-tested: the condition was
+replaced with each known-buggy variant and the suite re-run.
+
+| Condition compiled in | Bug it contains | Suite result |
+|---|---|---|
+| Pre-#3019 (`IsTransactionRoot && Pool is not null`) | **#2970** | **9/9 passed** |
+| #3019 (`EnlistedTransaction is not null && Pool is not null`) | **#4001** | **9/9 passed** |
+| This fix (union) | none | 9/9 passed |
+
+**The suite passes on all three.** It does not detect either bug, and therefore does
+not guard this line at all in this environment.
+
+`Test_EnlistedTransactionPreservedWhilePooled` — the test added by #3019 specifically
+to cover #2970 — is tagged `[Trait("Category", "flaky")]` and passes against code that
+carries the #2970 bug.
+
+The practical conclusion: **the 9/9 result is evidence of no collateral damage, not
+evidence that the fix works.** The evidence that the fix works is the reproduction
+matrix above and the structural argument in section 5. Those should carry the weight.
+
+---
+
+## 9. Why no new automated test ships with this fix
+
+The only known reliable reproduction requires NHibernate.
+
+The bug needs the connection caught in a narrow half-state: still the delegated root,
+but with `EnlistedTransaction` already detached by `DetachCurrentTransactionIfEnded()`
+(called from `DbConnectionInternal.CloseConnection`). NHibernate's `StatelessSession`
+reaches this window because it returns the connection to the pool after **every
+statement**. Hand-written SqlClient code typically holds a connection across statements
+and steps straight over it.
+
+Eight NHibernate-free variants were attempted. Every one landed in a non-reproducing
+state:
+
+| Variant | Shape | Observed |
+|---|---|---|
+| A | c1 open/query/close, c2 open + query | `enlisted=set` — buggy condition accidentally true |
+| B | as A, c2 does nothing | `enlisted=set` |
+| C | c2 does `BeginTransaction()` then query | `enlisted=set` |
+| D | default pool size, c2 forces promotion failure, then `c1.Close()` | `deleg.IsActive=False` — already torn down |
+| E | c1 parked in pool, then `Transaction.Current.Rollback()` | `deleg.IsActive=False` |
+| F | c1 park → reopen → promotion fail → close | `deleg.IsActive=False` |
+| G | c2 from a different pool forces promotion | `deleg.IsActive=False` |
+| H | mirrors NHibernate: park, reopen, local tx inside ambient scope | `enlisted=set` |
+
+Either the connection still held its `EnlistedTransaction` (so the buggy condition
+happened to evaluate `true`), or delegation had already been torn down synchronously.
+Neither reproduces the failure.
+
+This is a genuine coverage gap and is recorded here rather than papered over. Given
+section 8, closing it properly would mean adding a test that *fails* against both
+buggy conditions — which, today, likely requires either an NHibernate-backed manual
+test or a targeted harness that drives a connection into the delegated-root-with-
+detached-enlistment state directly.
+
+---
+
+## 10. Related
+
+- **#2970** — the issue #3019 was fixing. Fully preserved by this change (section 5).
+- **#2285** — reports the same exception with no reproduction. Plausibly the same root
+  cause, though unconfirmed.

--- a/doc/design-notes/4001-delegated-transaction-reset.md
+++ b/doc/design-notes/4001-delegated-transaction-reset.md
@@ -306,9 +306,9 @@ mutation-tested:
 
 | Condition compiled into the helper | Bug it contains | New tests |
 |---|---|---|
-| `hasEnlistedTransaction` (#3019) | **#4001** | ❌ 2 failed |
-| `isTransactionRoot` (pre-#3019) | **#2970** | ❌ 2 failed |
-| The shipped condition | none | ✅ 11 passed |
+| `hasEnlistedTransaction` (#3019) | **#4001** | ❌ 1 failed |
+| `isTransactionRoot` (pre-#3019) | **#2970** | ❌ 1 failed |
+| The shipped condition | none | ✅ 8 passed |
 
 This satisfies "fails before the change, passes after" for **both** regressions, and
 does so deterministically and without a server.

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -3973,28 +3973,82 @@ namespace Microsoft.Data.SqlClient.Connection
 
             if (_fResetConnection)
             {
-                // Pooled connections that are enlisted in a transaction must have their transaction
-                // preserved when resetting the connection state. Otherwise, future uses of the connection
-                // from the pool will execute outside the transaction, in auto-commit mode.
-                // https://github.com/dotnet/SqlClient/issues/2970
-                //
-                // Two distinct cases must be covered:
-                //  - This connection is the root of a delegated transaction. The transaction has been
-                //    delegated to (and lives on) this connection, so it has no EnlistedTransaction.
-                //  - This connection merely enlisted in someone else's transaction, in which case
-                //    EnlistedTransaction is set but the connection is not the root.
-                // Checking only EnlistedTransaction misses the first case and resets the server side
-                // transaction out from under System.Transactions, which later breaks the connection
-                // while it is being recycled through the pool.
-                // https://github.com/dotnet/SqlClient/issues/4001
-                _parser.PrepareResetConnection(
-                    Pool is not null &&
-                    (IsTransactionRoot || EnlistedTransaction is not null));
+                // Pooled connections that are tied to a transaction must have that transaction
+                // preserved when resetting the connection state. Otherwise, future uses of the
+                // connection from the pool will execute outside the transaction, in auto-commit
+                // mode. See ShouldPreserveTransactionOnReset for the full rationale.
+                _parser.PrepareResetConnection(ShouldPreserveTransactionOnReset(
+                    isPooled: Pool is not null,
+                    isTransactionRoot: IsTransactionRoot,
+                    is2008OrNewer: Is2008OrNewer,
+                    hasEnlistedTransaction: EnlistedTransaction is not null));
 
                 // Reset dictionary values, since calling reset will not send us env_changes.
                 CurrentDatabase = _originalDatabase;
                 _currentLanguage = _originalLanguage;
             }
+        }
+
+        /// <summary>
+        /// Decides whether a connection reset must preserve the server side transaction, i.e.
+        /// whether <c>ST_RESET_CONNECTION_PRESERVE_TRANSACTION</c> should be sent instead of a
+        /// plain <c>ST_RESET_CONNECTION</c>.
+        /// </summary>
+        /// <param name="isPooled">Whether this connection belongs to a pool.</param>
+        /// <param name="isTransactionRoot">
+        /// Whether this connection is the root of a delegated transaction, i.e.
+        /// <see cref="IsTransactionRoot"/>.
+        /// </param>
+        /// <param name="is2008OrNewer">
+        /// Whether the server is SQL Server 2008 or newer. Older servers cannot preserve a
+        /// delegated transaction across a reset, so such connections must not be recycled with
+        /// the transaction still attached.
+        /// </param>
+        /// <param name="hasEnlistedTransaction">
+        /// Whether this connection has a non-null <see cref="DbConnectionInternal.EnlistedTransaction"/>.
+        /// </param>
+        /// <remarks>
+        /// <para>
+        /// A pooled connection can be tied to a transaction in two independent ways, and both
+        /// must be preserved across a reset:
+        /// </para>
+        /// <list type="bullet">
+        /// <item>
+        /// It is the <b>root of a delegated transaction</b>: the transaction was delegated to
+        /// this connection, so it lives on the server session this connection owns. Missing this
+        /// case resets the server side transaction out from under System.Transactions, which
+        /// later breaks the connection while it is being recycled through the pool.
+        /// See https://github.com/dotnet/SqlClient/issues/4001.
+        /// </item>
+        /// <item>
+        /// It has <b>enlisted in a transaction</b>, so <c>EnlistedTransaction</c> is set. Missing
+        /// this case causes subsequent uses of the connection to run outside the transaction, in
+        /// auto-commit mode. See https://github.com/dotnet/SqlClient/issues/2970.
+        /// </item>
+        /// </list>
+        /// <para>
+        /// These two conditions overlap but neither implies the other. A freshly delegated root
+        /// has both flags set, because enlistment sets <c>EnlistedTransaction</c> unconditionally.
+        /// However, once the transaction is no longer <c>Active</c>,
+        /// <c>DetachCurrentTransactionIfEnded</c> clears <c>EnlistedTransaction</c> while the
+        /// delegated transaction can still report itself as active. That transient half-state is
+        /// root-only, and it is exactly the state issue #4001 reproduces in.
+        /// </para>
+        /// </remarks>
+        internal static bool ShouldPreserveTransactionOnReset(
+            bool isPooled,
+            bool isTransactionRoot,
+            bool is2008OrNewer,
+            bool hasEnlistedTransaction)
+        {
+            // A connection with no pool is not recycled, so there is nothing to preserve for.
+            if (!isPooled)
+            {
+                return false;
+            }
+
+            // Delegated transaction roots can only be preserved on 2008+ servers.
+            return (isTransactionRoot && is2008OrNewer) || hasEnlistedTransaction;
         }
 
         private void ResolveExtendedServerName(ServerInfo serverInfo, bool aliasLookup, SqlConnectionOptions options)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -3977,7 +3977,19 @@ namespace Microsoft.Data.SqlClient.Connection
                 // preserved when resetting the connection state. Otherwise, future uses of the connection
                 // from the pool will execute outside the transaction, in auto-commit mode.
                 // https://github.com/dotnet/SqlClient/issues/2970
-                _parser.PrepareResetConnection(EnlistedTransaction is not null && Pool is not null);
+                //
+                // Two distinct cases must be covered:
+                //  - This connection is the root of a delegated transaction. The transaction has been
+                //    delegated to (and lives on) this connection, so it has no EnlistedTransaction.
+                //  - This connection merely enlisted in someone else's transaction, in which case
+                //    EnlistedTransaction is set but the connection is not the root.
+                // Checking only EnlistedTransaction misses the first case and resets the server side
+                // transaction out from under System.Transactions, which later breaks the connection
+                // while it is being recycled through the pool.
+                // https://github.com/dotnet/SqlClient/issues/4001
+                _parser.PrepareResetConnection(
+                    Pool is not null &&
+                    (IsTransactionRoot || EnlistedTransaction is not null));
 
                 // Reset dictionary values, since calling reset will not send us env_changes.
                 CurrentDatabase = _originalDatabase;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -3935,7 +3935,19 @@ namespace Microsoft.Data.SqlClient.Connection
                 // preserved when resetting the connection state. Otherwise, future uses of the connection
                 // from the pool will execute outside the transaction, in auto-commit mode.
                 // https://github.com/dotnet/SqlClient/issues/2970
-                _parser.PrepareResetConnection(EnlistedTransaction is not null && Pool is not null);
+                //
+                // Two distinct cases must be covered:
+                //  - This connection is the root of a delegated transaction. The transaction has been
+                //    delegated to (and lives on) this connection, so it has no EnlistedTransaction.
+                //  - This connection merely enlisted in someone else's transaction, in which case
+                //    EnlistedTransaction is set but the connection is not the root.
+                // Checking only EnlistedTransaction misses the first case and resets the server side
+                // transaction out from under System.Transactions, which later breaks the connection
+                // while it is being recycled through the pool.
+                // https://github.com/dotnet/SqlClient/issues/4001
+                _parser.PrepareResetConnection(
+                    Pool is not null &&
+                    (IsTransactionRoot || EnlistedTransaction is not null));
 
                 // Reset dictionary values, since calling reset will not send us env_changes.
                 CurrentDatabase = _originalDatabase;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -3990,7 +3990,7 @@ namespace Microsoft.Data.SqlClient.Connection
         }
 
         /// <summary>
-        /// Decides whether a connection reset must preserve the server side transaction, i.e.
+        /// Decides whether a connection reset must preserve the server-side transaction, i.e.
         /// whether <c>ST_RESET_CONNECTION_PRESERVE_TRANSACTION</c> should be sent instead of a
         /// plain <c>ST_RESET_CONNECTION</c>.
         /// </summary>
@@ -4016,7 +4016,7 @@ namespace Microsoft.Data.SqlClient.Connection
         /// <item>
         /// It is the <b>root of a delegated transaction</b>: the transaction was delegated to
         /// this connection, so it lives on the server session this connection owns. Missing this
-        /// case resets the server side transaction out from under System.Transactions, which
+        /// case resets the server-side transaction out from under System.Transactions, which
         /// later breaks the connection while it is being recycled through the pool.
         /// See https://github.com/dotnet/SqlClient/issues/4001.
         /// </item>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -3980,7 +3980,6 @@ namespace Microsoft.Data.SqlClient.Connection
                 _parser.PrepareResetConnection(ShouldPreserveTransactionOnReset(
                     isPooled: Pool is not null,
                     isTransactionRoot: IsTransactionRoot,
-                    is2008OrNewer: Is2008OrNewer,
                     hasEnlistedTransaction: EnlistedTransaction is not null));
 
                 // Reset dictionary values, since calling reset will not send us env_changes.
@@ -3998,11 +3997,6 @@ namespace Microsoft.Data.SqlClient.Connection
         /// <param name="isTransactionRoot">
         /// Whether this connection is the root of a delegated transaction, i.e.
         /// <see cref="IsTransactionRoot"/>.
-        /// </param>
-        /// <param name="is2008OrNewer">
-        /// Whether the server is SQL Server 2008 or newer. Older servers cannot preserve a
-        /// delegated transaction across a reset, so such connections must not be recycled with
-        /// the transaction still attached.
         /// </param>
         /// <param name="hasEnlistedTransaction">
         /// Whether this connection has a non-null <see cref="DbConnectionInternal.EnlistedTransaction"/>.
@@ -4034,11 +4028,20 @@ namespace Microsoft.Data.SqlClient.Connection
         /// delegated transaction can still report itself as active. That transient half-state is
         /// root-only, and it is exactly the state issue #4001 reproduces in.
         /// </para>
+        /// <para>
+        /// There is deliberately no server-version guard here. Before
+        /// https://github.com/dotnet/SqlClient/pull/3019, a delegated root on a pre-2008 server
+        /// was excluded via <c>IsNonPoolableTransactionRoot</c>, but that property also routed
+        /// such connections into stasis rather than back into the pool, which is what made
+        /// suppressing the preserve bit safe. #3019 removed the property, and neither pool puts a
+        /// poolable root into stasis today, so a version guard would now return the connection to
+        /// the general pool with its transaction silently reset. That is issue #4001 again.
+        /// SQL Server 2005 is also outside the supported matrix.
+        /// </para>
         /// </remarks>
         internal static bool ShouldPreserveTransactionOnReset(
             bool isPooled,
             bool isTransactionRoot,
-            bool is2008OrNewer,
             bool hasEnlistedTransaction)
         {
             // A connection with no pool is not recycled, so there is nothing to preserve for.
@@ -4047,8 +4050,7 @@ namespace Microsoft.Data.SqlClient.Connection
                 return false;
             }
 
-            // Delegated transaction roots can only be preserved on 2008+ servers.
-            return (isTransactionRoot && is2008OrNewer) || hasEnlistedTransaction;
+            return isTransactionRoot || hasEnlistedTransaction;
         }
 
         private void ResolveExtendedServerName(ServerInfo serverInfo, bool aliasLookup, SqlConnectionOptions options)

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionInternalResetTransactionTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionInternalResetTransactionTests.cs
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Data.SqlClient.Connection;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests;
+
+/// <summary>
+/// Verifies <see cref="SqlConnectionInternal.ShouldPreserveTransactionOnReset"/>, which decides
+/// whether a pooled connection is reset with <c>ST_RESET_CONNECTION_PRESERVE_TRANSACTION</c>
+/// rather than a plain <c>ST_RESET_CONNECTION</c>.
+///
+/// Getting this predicate wrong has caused two separate regressions, in opposite directions:
+/// <list type="bullet">
+///   <item>
+///   Testing only <c>IsTransactionRoot</c> misses connections that merely enlisted in someone
+///   else's transaction, so they are reset and subsequently run in auto-commit mode
+///   (https://github.com/dotnet/SqlClient/issues/2970).
+///   </item>
+///   <item>
+///   Testing only <c>EnlistedTransaction</c> misses delegated transaction roots, whose
+///   server side transaction is then reset out from under System.Transactions, corrupting the
+///   connection as it is recycled through the pool
+///   (https://github.com/dotnet/SqlClient/issues/4001).
+///   </item>
+/// </list>
+///
+/// Both conditions must therefore be honored. Asserting against the extracted predicate covers
+/// every combination deterministically, including state combinations that are transient and
+/// racy to stage against a live server.
+/// </summary>
+public class SqlConnectionInternalResetTransactionTests
+{
+    /// <summary>
+    /// Exhaustively pins the predicate over every combination of its four inputs.
+    ///
+    /// The expectations encode three rules:
+    /// <list type="number">
+    ///   <item>An unpooled connection is never recycled, so nothing is ever preserved.</item>
+    ///   <item>A delegated transaction root must be preserved, but only on SQL Server 2008 or
+    ///   newer; older servers cannot carry a delegated transaction across a reset.</item>
+    ///   <item>An enlisted transaction must always be preserved, independent of server version
+    ///   and independent of whether this connection is also the root.</item>
+    /// </list>
+    /// </summary>
+    [Theory]
+    // Not pooled: never preserve, regardless of any other state.
+    [InlineData(false, false, false, false, false)]
+    [InlineData(false, true, true, true, false)]
+    [InlineData(false, true, true, false, false)]
+    [InlineData(false, false, true, true, false)]
+    // Pooled, no transaction of any kind: nothing to preserve.
+    [InlineData(true, false, true, false, false)]
+    [InlineData(true, false, false, false, false)]
+    // Pooled delegated transaction root with no EnlistedTransaction. This is the transient
+    // half-state behind issue #4001: DetachCurrentTransactionIfEnded has already cleared
+    // EnlistedTransaction while the delegated transaction still reports itself as active.
+    // Preserving requires a 2008+ server.
+    [InlineData(true, true, true, false, true)]
+    [InlineData(true, true, false, false, false)]
+    // Pooled connection enlisted in someone else's transaction (not the root). This is the
+    // issue #2970 case, and it must be preserved even on pre-2008 servers.
+    [InlineData(true, false, true, true, true)]
+    [InlineData(true, false, false, true, true)]
+    // Pooled connection that is both a delegated root and has an EnlistedTransaction. This is
+    // the common state immediately after enlistment, since enlistment sets EnlistedTransaction
+    // unconditionally.
+    [InlineData(true, true, true, true, true)]
+    [InlineData(true, true, false, true, true)]
+    public void ShouldPreserveTransactionOnReset_CoversBothTransactionOwnershipModes(
+        bool isPooled,
+        bool isTransactionRoot,
+        bool is2008OrNewer,
+        bool hasEnlistedTransaction,
+        bool expected)
+    {
+        // Act
+        bool actual = SqlConnectionInternal.ShouldPreserveTransactionOnReset(
+            isPooled: isPooled,
+            isTransactionRoot: isTransactionRoot,
+            is2008OrNewer: is2008OrNewer,
+            hasEnlistedTransaction: hasEnlistedTransaction);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    /// <summary>
+    /// Regression guard for https://github.com/dotnet/SqlClient/issues/4001.
+    ///
+    /// A pooled delegated transaction root on a modern server must preserve its transaction even
+    /// though <c>EnlistedTransaction</c> has already been detached. An implementation that keys
+    /// only off <c>EnlistedTransaction</c> returns <see langword="false"/> here and corrupts the
+    /// pooled connection.
+    /// </summary>
+    [Fact]
+    public void ShouldPreserveTransactionOnReset_DelegatedRootWithoutEnlistedTransaction_IsPreserved()
+    {
+        Assert.True(SqlConnectionInternal.ShouldPreserveTransactionOnReset(
+            isPooled: true,
+            isTransactionRoot: true,
+            is2008OrNewer: true,
+            hasEnlistedTransaction: false));
+    }
+
+    /// <summary>
+    /// Regression guard for https://github.com/dotnet/SqlClient/issues/2970.
+    ///
+    /// A pooled connection that enlisted in a transaction it does not own must preserve that
+    /// transaction. An implementation that keys only off <c>IsTransactionRoot</c> returns
+    /// <see langword="false"/> here, and the connection silently continues in auto-commit mode.
+    /// </summary>
+    [Fact]
+    public void ShouldPreserveTransactionOnReset_EnlistedNonRoot_IsPreserved()
+    {
+        Assert.True(SqlConnectionInternal.ShouldPreserveTransactionOnReset(
+            isPooled: true,
+            isTransactionRoot: false,
+            is2008OrNewer: true,
+            hasEnlistedTransaction: true));
+    }
+
+    /// <summary>
+    /// A delegated transaction root cannot be preserved on a pre-2008 server, so such a
+    /// connection must be reset normally rather than recycled with a transaction attached.
+    /// This guard existed before https://github.com/dotnet/SqlClient/pull/3019 and is retained.
+    /// </summary>
+    [Fact]
+    public void ShouldPreserveTransactionOnReset_DelegatedRootOnLegacyServer_IsNotPreserved()
+    {
+        Assert.False(SqlConnectionInternal.ShouldPreserveTransactionOnReset(
+            isPooled: true,
+            isTransactionRoot: true,
+            is2008OrNewer: false,
+            hasEnlistedTransaction: false));
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionInternalResetTransactionTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionInternalResetTransactionTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Data.SqlClient.UnitTests;
 public class SqlConnectionInternalResetTransactionTests
 {
     /// <summary>
-    /// Exhaustively pins the predicate over every combination of its four inputs.
+    /// Exhaustively pins the predicate over all sixteen combinations of its four boolean inputs.
     ///
     /// The expectations encode three rules:
     /// <list type="number">
@@ -46,11 +46,16 @@ public class SqlConnectionInternalResetTransactionTests
     /// </list>
     /// </summary>
     [Theory]
-    // Not pooled: never preserve, regardless of any other state.
+    // Not pooled: never preserve, regardless of any other state. All eight combinations of the
+    // remaining inputs are enumerated so that rule 1 is pinned unconditionally.
     [InlineData(false, false, false, false, false)]
-    [InlineData(false, true, true, true, false)]
-    [InlineData(false, true, true, false, false)]
+    [InlineData(false, false, false, true, false)]
+    [InlineData(false, false, true, false, false)]
     [InlineData(false, false, true, true, false)]
+    [InlineData(false, true, false, false, false)]
+    [InlineData(false, true, false, true, false)]
+    [InlineData(false, true, true, false, false)]
+    [InlineData(false, true, true, true, false)]
     // Pooled, no transaction of any kind: nothing to preserve.
     [InlineData(true, false, true, false, false)]
     [InlineData(true, false, false, false, false)]

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionInternalResetTransactionTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionInternalResetTransactionTests.cs
@@ -34,50 +34,36 @@ namespace Microsoft.Data.SqlClient.UnitTests;
 public class SqlConnectionInternalResetTransactionTests
 {
     /// <summary>
-    /// Exhaustively pins the predicate over all sixteen combinations of its four boolean inputs.
+    /// Exhaustively pins the predicate over all eight combinations of its three boolean inputs.
     ///
-    /// The expectations encode three rules:
+    /// The expectations encode two rules:
     /// <list type="number">
     ///   <item>An unpooled connection is never recycled, so nothing is ever preserved.</item>
-    ///   <item>A delegated transaction root must be preserved, but only on SQL Server 2008 or
-    ///   newer; older servers cannot carry a delegated transaction across a reset.</item>
-    ///   <item>An enlisted transaction must always be preserved, independent of server version
-    ///   and independent of whether this connection is also the root.</item>
+    ///   <item>A pooled connection tied to a transaction in either way must be preserved.</item>
     /// </list>
     /// </summary>
     [Theory]
-    // Not pooled: never preserve, regardless of any other state. All eight combinations of the
-    // remaining inputs are enumerated so that rule 1 is pinned unconditionally.
-    [InlineData(false, false, false, false, false)]
-    [InlineData(false, false, false, true, false)]
-    [InlineData(false, false, true, false, false)]
-    [InlineData(false, false, true, true, false)]
-    [InlineData(false, true, false, false, false)]
-    [InlineData(false, true, false, true, false)]
-    [InlineData(false, true, true, false, false)]
-    [InlineData(false, true, true, true, false)]
+    // Not pooled: never preserve, regardless of any other state.
+    [InlineData(false, false, false, false)]
+    [InlineData(false, false, true, false)]
+    [InlineData(false, true, false, false)]
+    [InlineData(false, true, true, false)]
     // Pooled, no transaction of any kind: nothing to preserve.
-    [InlineData(true, false, true, false, false)]
-    [InlineData(true, false, false, false, false)]
+    [InlineData(true, false, false, false)]
+    // Pooled connection enlisted in someone else's transaction (not the root). This is the
+    // issue #2970 case.
+    [InlineData(true, false, true, true)]
     // Pooled delegated transaction root with no EnlistedTransaction. This is the transient
     // half-state behind issue #4001: DetachCurrentTransactionIfEnded has already cleared
     // EnlistedTransaction while the delegated transaction still reports itself as active.
-    // Preserving requires a 2008+ server.
-    [InlineData(true, true, true, false, true)]
-    [InlineData(true, true, false, false, false)]
-    // Pooled connection enlisted in someone else's transaction (not the root). This is the
-    // issue #2970 case, and it must be preserved even on pre-2008 servers.
-    [InlineData(true, false, true, true, true)]
-    [InlineData(true, false, false, true, true)]
+    [InlineData(true, true, false, true)]
     // Pooled connection that is both a delegated root and has an EnlistedTransaction. This is
     // the common state immediately after enlistment, since enlistment sets EnlistedTransaction
     // unconditionally.
-    [InlineData(true, true, true, true, true)]
-    [InlineData(true, true, false, true, true)]
+    [InlineData(true, true, true, true)]
     public void ShouldPreserveTransactionOnReset_CoversBothTransactionOwnershipModes(
         bool isPooled,
         bool isTransactionRoot,
-        bool is2008OrNewer,
         bool hasEnlistedTransaction,
         bool expected)
     {
@@ -85,7 +71,6 @@ public class SqlConnectionInternalResetTransactionTests
         bool actual = SqlConnectionInternal.ShouldPreserveTransactionOnReset(
             isPooled: isPooled,
             isTransactionRoot: isTransactionRoot,
-            is2008OrNewer: is2008OrNewer,
             hasEnlistedTransaction: hasEnlistedTransaction);
 
         // Assert
@@ -95,10 +80,10 @@ public class SqlConnectionInternalResetTransactionTests
     /// <summary>
     /// Regression guard for https://github.com/dotnet/SqlClient/issues/4001.
     ///
-    /// A pooled delegated transaction root on a modern server must preserve its transaction even
-    /// though <c>EnlistedTransaction</c> has already been detached. An implementation that keys
-    /// only off <c>EnlistedTransaction</c> returns <see langword="false"/> here and corrupts the
-    /// pooled connection.
+    /// A pooled delegated transaction root must preserve its transaction even though
+    /// <c>EnlistedTransaction</c> has already been detached. An implementation that keys only off
+    /// <c>EnlistedTransaction</c> returns <see langword="false"/> here and corrupts the pooled
+    /// connection.
     /// </summary>
     [Fact]
     public void ShouldPreserveTransactionOnReset_DelegatedRootWithoutEnlistedTransaction_IsPreserved()
@@ -106,7 +91,6 @@ public class SqlConnectionInternalResetTransactionTests
         Assert.True(SqlConnectionInternal.ShouldPreserveTransactionOnReset(
             isPooled: true,
             isTransactionRoot: true,
-            is2008OrNewer: true,
             hasEnlistedTransaction: false));
     }
 
@@ -123,22 +107,19 @@ public class SqlConnectionInternalResetTransactionTests
         Assert.True(SqlConnectionInternal.ShouldPreserveTransactionOnReset(
             isPooled: true,
             isTransactionRoot: false,
-            is2008OrNewer: true,
             hasEnlistedTransaction: true));
     }
 
     /// <summary>
-    /// A delegated transaction root cannot be preserved on a pre-2008 server, so such a
-    /// connection must be reset normally rather than recycled with a transaction attached.
-    /// This guard existed before https://github.com/dotnet/SqlClient/pull/3019 and is retained.
+    /// An unpooled connection is destroyed rather than recycled, so there is no subsequent use to
+    /// protect and the transaction must not be preserved.
     /// </summary>
     [Fact]
-    public void ShouldPreserveTransactionOnReset_DelegatedRootOnLegacyServer_IsNotPreserved()
+    public void ShouldPreserveTransactionOnReset_NotPooled_IsNotPreserved()
     {
         Assert.False(SqlConnectionInternal.ShouldPreserveTransactionOnReset(
-            isPooled: true,
+            isPooled: false,
             isTransactionRoot: true,
-            is2008OrNewer: false,
-            hasEnlistedTransaction: false));
+            hasEnlistedTransaction: true));
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionInternalResetTransactionTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionInternalResetTransactionTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Data.SqlClient.UnitTests;
 ///   </item>
 ///   <item>
 ///   Testing only <c>EnlistedTransaction</c> misses delegated transaction roots, whose
-///   server side transaction is then reset out from under System.Transactions, corrupting the
+///   server-side transaction is then reset out from under System.Transactions, corrupting the
 ///   connection as it is recycled through the pool
 ///   (https://github.com/dotnet/SqlClient/issues/4001).
 ///   </item>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionInternalResetTransactionTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionInternalResetTransactionTests.cs
@@ -43,19 +43,20 @@ public class SqlConnectionInternalResetTransactionTests
     /// </list>
     /// </summary>
     [Theory]
-    // Not pooled: never preserve, regardless of any other state.
+    // An unpooled connection is destroyed rather than recycled, so there is no subsequent use to
+    // protect and its transaction must not be preserved, regardless of any other state.
     [InlineData(false, false, false, false)]
     [InlineData(false, false, true, false)]
     [InlineData(false, true, false, false)]
     [InlineData(false, true, true, false)]
     // Pooled, no transaction of any kind: nothing to preserve.
     [InlineData(true, false, false, false)]
-    // Pooled connection enlisted in someone else's transaction (not the root). This is the
-    // issue #2970 case.
+    // Regression guard for #2970: an implementation keyed only on IsTransactionRoot returns false
+    // for a pooled connection enlisted in a transaction it does not own.
     [InlineData(true, false, true, true)]
-    // Pooled delegated transaction root with no EnlistedTransaction. This is the transient
-    // half-state behind issue #4001: DetachCurrentTransactionIfEnded has already cleared
-    // EnlistedTransaction while the delegated transaction still reports itself as active.
+    // Regression guard for #4001: an implementation keyed only on EnlistedTransaction returns
+    // false in this transient half-state, after the enlistment is detached but while the delegated
+    // transaction still reports itself as active.
     [InlineData(true, true, false, true)]
     // Pooled connection that is both a delegated root and has an EnlistedTransaction. This is
     // the common state immediately after enlistment, since enlistment sets EnlistedTransaction
@@ -77,49 +78,4 @@ public class SqlConnectionInternalResetTransactionTests
         Assert.Equal(expected, actual);
     }
 
-    /// <summary>
-    /// Regression guard for https://github.com/dotnet/SqlClient/issues/4001.
-    ///
-    /// A pooled delegated transaction root must preserve its transaction even though
-    /// <c>EnlistedTransaction</c> has already been detached. An implementation that keys only off
-    /// <c>EnlistedTransaction</c> returns <see langword="false"/> here and corrupts the pooled
-    /// connection.
-    /// </summary>
-    [Fact]
-    public void ShouldPreserveTransactionOnReset_DelegatedRootWithoutEnlistedTransaction_IsPreserved()
-    {
-        Assert.True(SqlConnectionInternal.ShouldPreserveTransactionOnReset(
-            isPooled: true,
-            isTransactionRoot: true,
-            hasEnlistedTransaction: false));
-    }
-
-    /// <summary>
-    /// Regression guard for https://github.com/dotnet/SqlClient/issues/2970.
-    ///
-    /// A pooled connection that enlisted in a transaction it does not own must preserve that
-    /// transaction. An implementation that keys only off <c>IsTransactionRoot</c> returns
-    /// <see langword="false"/> here, and the connection silently continues in auto-commit mode.
-    /// </summary>
-    [Fact]
-    public void ShouldPreserveTransactionOnReset_EnlistedNonRoot_IsPreserved()
-    {
-        Assert.True(SqlConnectionInternal.ShouldPreserveTransactionOnReset(
-            isPooled: true,
-            isTransactionRoot: false,
-            hasEnlistedTransaction: true));
-    }
-
-    /// <summary>
-    /// An unpooled connection is destroyed rather than recycled, so there is no subsequent use to
-    /// protect and the transaction must not be preserved.
-    /// </summary>
-    [Fact]
-    public void ShouldPreserveTransactionOnReset_NotPooled_IsNotPreserved()
-    {
-        Assert.False(SqlConnectionInternal.ShouldPreserveTransactionOnReset(
-            isPooled: false,
-            isTransactionRoot: true,
-            hasEnlistedTransaction: true));
-    }
 }


### PR DESCRIPTION
Fixes #4001

## Summary

A pooled connection could be returned in a broken state after a `TransactionScope` rollback. PR #3019 changed reset preservation from checking delegated transaction roots to checking enlisted transactions, fixing #2970 but missing the delegated-root state behind #4001.

This change preserves the transaction when a pooled connection is either:

- a delegated transaction root, or
- enlisted in a transaction.

```csharp
isPooled && (isTransactionRoot || hasEnlistedTransaction)
```

This retains the #2970 behavior while covering #4001.

## Verification

- Added an exhaustive 8-case unit theory for the reset predicate.
- Mutation checks detect both the #4001 and #2970 buggy conditions.
- Reporter's repro fails without the fix and passes with it on both pool implementations.
- Existing manual transaction tests pass 9/9.

📄 [Full root cause analysis](https://github.com/dotnet/SqlClient/blob/priyankatiwari08-fix-4001-preserve-delegated-transaction/doc/design-notes/4001-delegated-transaction-reset.md)

## Checklist

- [x] Tests added or updated
- [x] Public API changes documented — no public API changes
- [x] Verified against customer repro
- [x] No breaking changes introduced