### PR TITLE
Fix malformed UNC pipe path for IPv6 literals in managed SNI

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniProxy.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniProxy.netcore.cs
@@ -275,6 +275,16 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                 SniCommon.ReportSNIError(SniProviders.NP_PROV, 0, SniCommon.MultiSubnetFailoverWithNonTcpProtocol, Strings.SNI_ERROR_49);
                 return null;
             }
+
+            // Final safeguard: never hand a pipe path whose host component contains a colon
+            // to the OS. See DataSource.IsValidPipeHostName for details.
+            if (!DataSource.IsValidPipeHostName(details.PipeHostName))
+            {
+                SqlClientEventSource.Log.TrySNITraceEvent(nameof(SniProxy), EventType.ERR, "Invalid host name '{0}' for Named Pipes.", details.PipeHostName);
+                SniCommon.ReportSNIError(SniProviders.NP_PROV, 0, SniCommon.InvalidConnStringError, Strings.SNI_ERROR_25);
+                return null;
+            }
+
             return new SniNpHandle(details.PipeHostName, details.PipeName, timeout, tlsFirst, hostNameInCertificate, serverCertificateFilename);
         }
 
@@ -647,6 +657,15 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                         PipeName = SniNpHandle.DefaultPipePath;
                     }
 
+                    // An IPv6 literal cannot be expressed in a UNC pipe path. Fail here rather than
+                    // composing a malformed path. See IsValidPipeHostName for details.
+                    if (!IsValidPipeHostName(PipeHostName))
+                    {
+                        SqlClientEventSource.Log.TrySNITraceEvent(nameof(SniProxy), EventType.ERR, "Invalid host name '{0}' for Named Pipes.", PipeHostName);
+                        ReportSNIError(SniProviders.NP_PROV);
+                        return false;
+                    }
+
                     InferLocalServerName();
                     return true;
                 }
@@ -668,6 +687,15 @@ namespace Microsoft.Data.SqlClient.ManagedSni
 
                     if (string.IsNullOrEmpty(host))
                     {
+                        ReportSNIError(SniProviders.NP_PROV);
+                        return false;
+                    }
+
+                    // An IPv6 literal cannot be expressed in a UNC pipe path.
+                    // See IsValidPipeHostName for details.
+                    if (!IsValidPipeHostName(host))
+                    {
+                        SqlClientEventSource.Log.TrySNITraceEvent(nameof(SniProxy), EventType.ERR, "Invalid host name '{0}' for Named Pipes.", host);
                         ReportSNIError(SniProviders.NP_PROV);
                         return false;
                     }
@@ -729,6 +757,22 @@ namespace Microsoft.Data.SqlClient.ManagedSni
 
         private static bool IsLocalHost(string serverName) =>
             ".".Equals(serverName) || "(local)".Equals(serverName) || "localhost".Equals(serverName);
+
+        /// <summary>
+        /// Determines whether the given host name can legally appear as the host component of a
+        /// UNC pipe path (<c>\\host\pipe\sql\query</c>).
+        /// </summary>
+        /// <remarks>
+        /// A UNC host component may never contain a colon, so an IPv6 literal such as <c>::1</c>
+        /// or <c>[::1]</c> produces a malformed path like <c>\\::1\pipe\sql\query</c>. Handing that
+        /// to the OS sends the SMB redirector into an SMB session setup whose SPNEGO/NegoEx target
+        /// name embeds the IPv6 literal, which can fault LSASS on Windows and force a reboot.
+        /// Named Pipes over an IPv6 literal is not a supported configuration, so such data sources
+        /// are rejected before a pipe path is ever composed. IPv4 literals remain valid.
+        /// See https://github.com/dotnet/SqlClient/issues/4523.
+        /// </remarks>
+        internal static bool IsValidPipeHostName(string hostName) =>
+            !string.IsNullOrEmpty(hostName) && hostName.IndexOf(SemiColon) == -1;
     }
 }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniProxy.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniProxy.netcore.cs
@@ -644,7 +644,7 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                         {
                             // NamedPipeClientStream object will create the network path using PipeHostName and PipeName
                             // and can be seen in its _normalizedPipePath variable in the format \\servername\pipe\MSSQL$<instancename>\sql\query
-                            PipeHostName = ServerName = tokensByBackSlash[0];
+                            ServerName = tokensByBackSlash[0];
                             PipeName = $"{InstancePrefix}{tokensByBackSlash[1]}{PathSeparator}{DefaultPipeName}";
                         }
                         else
@@ -655,7 +655,7 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                     }
                     else
                     {
-                        PipeHostName = ServerName = _dataSourceAfterTrimmingProtocol;
+                        ServerName = _dataSourceAfterTrimmingProtocol;
                         PipeName = SniNpHandle.DefaultPipePath;
                     }
 
@@ -697,16 +697,6 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                         return false;
                     }
 
-                    // An IPv6 literal must be transcribed before it can appear in a UNC pipe path.
-                    // See GetUncCompatibleHostName for details.
-                    string uncHost = GetUncCompatibleHostName(host);
-                    if (uncHost is null)
-                    {
-                        SqlClientEventSource.Log.TrySNITraceEvent(nameof(SniProxy), EventType.ERR, "Invalid host name '{0}' for Named Pipes.", host);
-                        ReportSNIError(SniProviders.NP_PROV);
-                        return false;
-                    }
-
                     //Check if the "pipe" keyword is the first part of path
                     if (!PipeToken.Equals(tokensByBackSlash[3]))
                     {
@@ -733,6 +723,16 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                     if (string.IsNullOrWhiteSpace(InstanceName) && !DefaultPipeName.Equals(PipeName))
                     {
                         InstanceName = PipeToken + PipeName;
+                    }
+
+                    // An IPv6 literal must be transcribed before it can appear in a UNC pipe path.
+                    // See GetUncCompatibleHostName for details.
+                    string uncHost = GetUncCompatibleHostName(host);
+                    if (uncHost is null)
+                    {
+                        SqlClientEventSource.Log.TrySNITraceEvent(nameof(SniProxy), EventType.ERR, "Invalid host name '{0}' for Named Pipes.", host);
+                        ReportSNIError(SniProviders.NP_PROV);
+                        return false;
                     }
 
                     // ServerName drops any brackets because it feeds DNS resolution and SPN
@@ -782,10 +782,10 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                 return false;
             }
 
-            string literal = hostName;
+            ReadOnlySpan<char> literal = hostName.AsSpan();
             if (literal.Length > 2 && literal[0] == '[' && literal[literal.Length - 1] == ']')
             {
-                literal = literal.Substring(1, literal.Length - 2);
+                literal = literal.Slice(1, literal.Length - 2);
             }
 
             return IPAddress.TryParse(literal, out address) &&
@@ -837,9 +837,27 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                 return hostName;
             }
 
-            return TryParseIPv6Literal(hostName, out IPAddress address)
-                ? address.ToString().Replace(':', '-').Replace('%', 's') + IPv6LiteralHostSuffix
-                : null;
+            if (!TryParseIPv6Literal(hostName, out IPAddress address))
+            {
+                return null;
+            }
+
+            string literal = address.ToString();
+            return string.Create(literal.Length + IPv6LiteralHostSuffix.Length, literal,
+                static (destination, value) =>
+                {
+                    for (int i = 0; i < value.Length; i++)
+                    {
+                        destination[i] = value[i] switch
+                        {
+                            ':' => '-',
+                            '%' => 's',
+                            _ => value[i]
+                        };
+                    }
+
+                    IPv6LiteralHostSuffix.AsSpan().CopyTo(destination.Slice(value.Length));
+                });
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniProxy.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniProxy.netcore.cs
@@ -659,16 +659,18 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                         PipeName = SniNpHandle.DefaultPipePath;
                     }
 
-                    // An IPv6 literal must be transcribed before it can appear in a UNC pipe path.
-                    // ServerName keeps the original form because it is only used for SPN creation.
-                    // See GetUncCompatibleHostName for details.
-                    PipeHostName = GetUncCompatibleHostName(PipeHostName);
+                    // An IPv6 literal must be transcribed before it can appear in a UNC pipe path,
+                    // and ServerName must drop any brackets because it feeds DNS resolution and SPN
+                    // construction. See GetUncCompatibleHostName and NormalizeHostName for details.
+                    PipeHostName = GetUncCompatibleHostName(ServerName);
                     if (PipeHostName is null)
                     {
                         SqlClientEventSource.Log.TrySNITraceEvent(nameof(SniProxy), EventType.ERR, "Invalid host name '{0}' for Named Pipes.", ServerName);
                         ReportSNIError(SniProviders.NP_PROV);
                         return false;
                     }
+
+                    ServerName = NormalizeHostName(ServerName);
 
                     InferLocalServerName();
                     return true;
@@ -733,7 +735,9 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                         InstanceName = PipeToken + PipeName;
                     }
 
-                    ServerName = IsLocalHost(host) ? Environment.MachineName : host;
+                    // ServerName drops any brackets because it feeds DNS resolution and SPN
+                    // construction, neither of which accepts the bracketed spelling.
+                    ServerName = IsLocalHost(host) ? Environment.MachineName : NormalizeHostName(host);
                     // Pipe hostname is the hostname after leading \\ which should be passed down as is to open Named Pipe.
                     // For Named Pipes the ServerName makes sense for SPN creation only.
                     PipeHostName = uncHost;
@@ -764,6 +768,42 @@ namespace Microsoft.Data.SqlClient.ManagedSni
             ".".Equals(serverName) || "(local)".Equals(serverName) || "localhost".Equals(serverName);
 
         /// <summary>
+        /// Attempts to interpret a host name as an IPv6 literal, accepting the bracketed form
+        /// (<c>[::1]</c>) that users may carry over from URL syntax.
+        /// </summary>
+        private static bool TryParseIPv6Literal(string hostName, out IPAddress address)
+        {
+            address = null;
+
+            // A colon is the only character that can make a host name an IPv6 literal, so anything
+            // without one (host names, IPv4 literals, already-transcribed names) is not a candidate.
+            if (string.IsNullOrEmpty(hostName) || hostName.IndexOf(':') == -1)
+            {
+                return false;
+            }
+
+            string literal = hostName;
+            if (literal.Length > 2 && literal[0] == '[' && literal[literal.Length - 1] == ']')
+            {
+                literal = literal.Substring(1, literal.Length - 2);
+            }
+
+            return IPAddress.TryParse(literal, out address) &&
+                   address.AddressFamily == AddressFamily.InterNetworkV6;
+        }
+
+        /// <summary>
+        /// Returns the canonical form of a host name: a bracketed IPv6 literal is unwrapped to its
+        /// unbracketed form, and every other host name is returned unchanged.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="ServerName"/> feeds DNS resolution and SPN construction, neither of which
+        /// accepts the bracketed spelling, so the brackets must be dropped before it is used there.
+        /// </remarks>
+        internal static string NormalizeHostName(string hostName) =>
+            TryParseIPv6Literal(hostName, out IPAddress address) ? address.ToString() : hostName;
+
+        /// <summary>
         /// Converts a host name into a form that can legally appear as the host component of a UNC
         /// pipe path (<c>\\host\pipe\sql\query</c>), returning <see langword="null"/> if no such
         /// form exists.
@@ -792,27 +832,14 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                 return null;
             }
 
-            // A colon is the only character that forces a transcription, so anything without one
-            // (host names, IPv4 literals, already-transcribed names) passes through untouched.
             if (hostName.IndexOf(':') == -1)
             {
                 return hostName;
             }
 
-            // Accept the bracketed form (\\[::1]\...) that users may carry over from URL syntax.
-            string literal = hostName;
-            if (literal.Length > 2 && literal[0] == '[' && literal[literal.Length - 1] == ']')
-            {
-                literal = literal.Substring(1, literal.Length - 2);
-            }
-
-            if (!IPAddress.TryParse(literal, out IPAddress address) ||
-                address.AddressFamily != AddressFamily.InterNetworkV6)
-            {
-                return null;
-            }
-
-            return address.ToString().Replace(':', '-').Replace('%', 's') + IPv6LiteralHostSuffix;
+            return TryParseIPv6Literal(hostName, out IPAddress address)
+                ? address.ToString().Replace(':', '-').Replace('%', 's') + IPv6LiteralHostSuffix
+                : null;
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniProxy.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniProxy.netcore.cs
@@ -772,7 +772,7 @@ namespace Microsoft.Data.SqlClient.ManagedSni
         /// See https://github.com/dotnet/SqlClient/issues/4523.
         /// </remarks>
         internal static bool IsValidPipeHostName(string hostName) =>
-            !string.IsNullOrEmpty(hostName) && hostName.IndexOf(SemiColon) == -1;
+            !string.IsNullOrEmpty(hostName) && hostName.IndexOf(':') == -1;
     }
 }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniProxy.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniProxy.netcore.cs
@@ -276,9 +276,10 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                 return null;
             }
 
-            // Final safeguard: never hand a pipe path whose host component contains a colon
-            // to the OS. See DataSource.IsValidPipeHostName for details.
-            if (!DataSource.IsValidPipeHostName(details.PipeHostName))
+            // Final safeguard: never hand a pipe path whose host component contains a colon to the
+            // OS. DataSource transcribes IPv6 literals during parsing, so anything still holding a
+            // colon here is malformed. See DataSource.GetUncCompatibleHostName for details.
+            if (string.IsNullOrEmpty(details.PipeHostName) || details.PipeHostName.IndexOf(':') != -1)
             {
                 SqlClientEventSource.Log.TrySNITraceEvent(nameof(SniProxy), EventType.ERR, "Invalid host name '{0}' for Named Pipes.", details.PipeHostName);
                 SniCommon.ReportSNIError(SniProviders.NP_PROV, 0, SniCommon.InvalidConnStringError, Strings.SNI_ERROR_25);
@@ -349,6 +350,7 @@ namespace Microsoft.Data.SqlClient.ManagedSni
         private const string DefaultPipeName = "sql\\query";
         private const string InstancePrefix = "MSSQL$";
         private const string PathSeparator = "\\";
+        private const string IPv6LiteralHostSuffix = ".ipv6-literal.net";
 
         internal enum Protocol { TCP, NP, None, Admin };
 
@@ -657,11 +659,13 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                         PipeName = SniNpHandle.DefaultPipePath;
                     }
 
-                    // An IPv6 literal cannot be expressed in a UNC pipe path. Fail here rather than
-                    // composing a malformed path. See IsValidPipeHostName for details.
-                    if (!IsValidPipeHostName(PipeHostName))
+                    // An IPv6 literal must be transcribed before it can appear in a UNC pipe path.
+                    // ServerName keeps the original form because it is only used for SPN creation.
+                    // See GetUncCompatibleHostName for details.
+                    PipeHostName = GetUncCompatibleHostName(PipeHostName);
+                    if (PipeHostName is null)
                     {
-                        SqlClientEventSource.Log.TrySNITraceEvent(nameof(SniProxy), EventType.ERR, "Invalid host name '{0}' for Named Pipes.", PipeHostName);
+                        SqlClientEventSource.Log.TrySNITraceEvent(nameof(SniProxy), EventType.ERR, "Invalid host name '{0}' for Named Pipes.", ServerName);
                         ReportSNIError(SniProviders.NP_PROV);
                         return false;
                     }
@@ -691,9 +695,10 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                         return false;
                     }
 
-                    // An IPv6 literal cannot be expressed in a UNC pipe path.
-                    // See IsValidPipeHostName for details.
-                    if (!IsValidPipeHostName(host))
+                    // An IPv6 literal must be transcribed before it can appear in a UNC pipe path.
+                    // See GetUncCompatibleHostName for details.
+                    string uncHost = GetUncCompatibleHostName(host);
+                    if (uncHost is null)
                     {
                         SqlClientEventSource.Log.TrySNITraceEvent(nameof(SniProxy), EventType.ERR, "Invalid host name '{0}' for Named Pipes.", host);
                         ReportSNIError(SniProviders.NP_PROV);
@@ -731,7 +736,7 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                     ServerName = IsLocalHost(host) ? Environment.MachineName : host;
                     // Pipe hostname is the hostname after leading \\ which should be passed down as is to open Named Pipe.
                     // For Named Pipes the ServerName makes sense for SPN creation only.
-                    PipeHostName = host;
+                    PipeHostName = uncHost;
                 }
                 catch (UriFormatException)
                 {
@@ -759,20 +764,56 @@ namespace Microsoft.Data.SqlClient.ManagedSni
             ".".Equals(serverName) || "(local)".Equals(serverName) || "localhost".Equals(serverName);
 
         /// <summary>
-        /// Determines whether the given host name can legally appear as the host component of a
-        /// UNC pipe path (<c>\\host\pipe\sql\query</c>).
+        /// Converts a host name into a form that can legally appear as the host component of a UNC
+        /// pipe path (<c>\\host\pipe\sql\query</c>), returning <see langword="null"/> if no such
+        /// form exists.
         /// </summary>
         /// <remarks>
         /// A UNC host component may never contain a colon, so an IPv6 literal such as <c>::1</c>
-        /// or <c>[::1]</c> produces a malformed path like <c>\\::1\pipe\sql\query</c>. Handing that
-        /// to the OS sends the SMB redirector into an SMB session setup whose SPNEGO/NegoEx target
-        /// name embeds the IPv6 literal, which can fault LSASS on Windows and force a reboot.
-        /// Named Pipes over an IPv6 literal is not a supported configuration, so such data sources
-        /// are rejected before a pipe path is ever composed. IPv4 literals remain valid.
-        /// See https://github.com/dotnet/SqlClient/issues/4523.
+        /// cannot be used directly. Passing one through anyway composes a malformed path like
+        /// <c>\\::1\pipe\sql\query</c>, which sends the SMB redirector into an SMB session setup
+        /// whose SPNEGO/NegoEx target name embeds the IPv6 literal; that can fault LSASS on Windows
+        /// and force a reboot. See https://github.com/dotnet/SqlClient/issues/4523.
+        ///
+        /// Windows defines a transcription for exactly this case: replace each <c>:</c> with
+        /// <c>-</c> and each <c>%</c> (zone index) with <c>s</c>, then append
+        /// <c>.ipv6-literal.net</c>. For example <c>2001:db8::1</c> becomes
+        /// <c>2001-db8--1.ipv6-literal.net</c>. See
+        /// https://learn.microsoft.com/openspecs/windows_protocols/ms-dtyp/62e862f4-2a51-452e-8eeb-dc4ff5ee33cc.
+        ///
+        /// Host names without a colon (including IPv4 literals and already-transcribed
+        /// <c>.ipv6-literal.net</c> names) are returned unchanged. A colon-bearing host name that is
+        /// not a parseable IPv6 literal has no UNC form and is rejected.
         /// </remarks>
-        internal static bool IsValidPipeHostName(string hostName) =>
-            !string.IsNullOrEmpty(hostName) && hostName.IndexOf(':') == -1;
+        internal static string GetUncCompatibleHostName(string hostName)
+        {
+            if (string.IsNullOrEmpty(hostName))
+            {
+                return null;
+            }
+
+            // A colon is the only character that forces a transcription, so anything without one
+            // (host names, IPv4 literals, already-transcribed names) passes through untouched.
+            if (hostName.IndexOf(':') == -1)
+            {
+                return hostName;
+            }
+
+            // Accept the bracketed form (\\[::1]\...) that users may carry over from URL syntax.
+            string literal = hostName;
+            if (literal.Length > 2 && literal[0] == '[' && literal[literal.Length - 1] == ']')
+            {
+                literal = literal.Substring(1, literal.Length - 2);
+            }
+
+            if (!IPAddress.TryParse(literal, out IPAddress address) ||
+                address.AddressFamily != AddressFamily.InterNetworkV6)
+            {
+                return null;
+            }
+
+            return address.ToString().Replace(':', '-').Replace('%', 's') + IPv6LiteralHostSuffix;
+        }
     }
 }
 

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/ManagedSni/DataSourceNamedPipesTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/ManagedSni/DataSourceNamedPipesTests.cs
@@ -107,17 +107,41 @@ namespace Microsoft.Data.SqlClient.UnitTests.ManagedSni
         }
 
         /// <summary>
-        /// Verifies that an IPv6 literal keeps its original form in <see cref="DataSource.ServerName"/>,
-        /// which feeds SPN creation, even though the pipe host name is transcribed.
+        /// Verifies that an IPv6 literal is preserved (unbracketed) in <see cref="DataSource.ServerName"/>,
+        /// which feeds DNS resolution and SPN construction, while the pipe host name is transcribed.
+        /// The bracketed spelling must not survive into <see cref="DataSource.ServerName"/> because
+        /// neither DNS nor SPN construction accepts it.
         /// </summary>
-        [Fact]
-        public void ParseServerName_NamedPipesWithIPv6Literal_PreservesServerNameForSpn()
+        [Theory]
+        [InlineData(@"np:2001:db8::1")]
+        [InlineData(@"np:[2001:db8::1]")]
+        [InlineData(@"np:\\2001:db8::1\pipe\sql\query")]
+        [InlineData(@"np:\\[2001:db8::1]\pipe\sql\query")]
+        public void ParseServerName_NamedPipesWithIPv6Literal_PreservesUnbracketedServerNameForSpn(string dataSource)
         {
-            DataSource details = DataSource.ParseServerName(@"np:2001:db8::1");
+            DataSource details = DataSource.ParseServerName(dataSource);
 
             Assert.NotNull(details);
             Assert.Equal("2001:db8::1", details.ServerName);
             Assert.Equal("2001-db8--1.ipv6-literal.net", details.PipeHostName);
+        }
+
+        /// <summary>
+        /// Verifies <see cref="DataSource.NormalizeHostName"/> unwraps bracketed IPv6 literals and
+        /// leaves every other host name untouched.
+        /// </summary>
+        [Theory]
+        [InlineData("[::1]", "::1")]
+        [InlineData("::1", "::1")]
+        [InlineData("[2001:db8::1]", "2001:db8::1")]
+        [InlineData("[fe80::1%3]", "fe80::1%3")]
+        [InlineData("localhost", "localhost")]
+        [InlineData("127.0.0.1", "127.0.0.1")]
+        [InlineData("not:a:host", "not:a:host")]
+        [InlineData("", "")]
+        public void NormalizeHostName_ReturnsExpected(string hostName, string expected)
+        {
+            Assert.Equal(expected, DataSource.NormalizeHostName(hostName));
         }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/ManagedSni/DataSourceNamedPipesTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/ManagedSni/DataSourceNamedPipesTests.cs
@@ -1,0 +1,106 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NET
+
+using Microsoft.Data.SqlClient.ManagedSni;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests.ManagedSni
+{
+    /// <summary>
+    /// Regression tests for Named Pipes data source parsing in <see cref="DataSource"/>.
+    ///
+    /// A UNC path host component may never contain a colon, so an IPv6 literal server name
+    /// produces a malformed pipe path such as <c>\\::1\pipe\sql\query</c>. Handing that to the
+    /// OS sends the SMB redirector into an SMB session setup that can fault LSASS on Windows
+    /// and force a reboot. Such data sources must be rejected during parsing.
+    ///
+    /// See: https://github.com/dotnet/SqlClient/issues/4523
+    /// </summary>
+    public class DataSourceNamedPipesTests
+    {
+        [Theory]
+        [InlineData(@"np:::1")]
+        [InlineData(@"np:[::1]")]
+        [InlineData(@"np:fe80::1")]
+        [InlineData(@"np:2001:db8::1")]
+        [InlineData(@"\\::1\pipe\sql\query")]
+        [InlineData(@"np:\\::1\pipe\sql\query")]
+        [InlineData(@"np:\\[::1]\pipe\MSSQL$MYINSTANCE\sql\query")]
+        public void ParseServerName_NamedPipesWithIPv6Literal_IsRejected(string dataSource)
+        {
+            Assert.Null(DataSource.ParseServerName(dataSource));
+        }
+
+        [Theory]
+        [InlineData(@"np:127.0.0.1", "127.0.0.1")]
+        [InlineData(@"np:localhost", "localhost")]
+        [InlineData(@"np:.", ".")]
+        [InlineData(@"np:server\instance", "server")]
+        [InlineData(@"\\127.0.0.1\pipe\sql\query", "127.0.0.1")]
+        [InlineData(@"\\.\pipe\MSSQL$MYINSTANCE\sql\query", ".")]
+        [InlineData(@"\\my-server\pipe\sql\query", "my-server")]
+        public void ParseServerName_NamedPipesWithValidHost_IsAccepted(
+            string dataSource, string expectedPipeHostName)
+        {
+            DataSource details = DataSource.ParseServerName(dataSource);
+
+            Assert.NotNull(details);
+            Assert.Equal(DataSource.Protocol.NP, details.ResolvedProtocol);
+            Assert.Equal(expectedPipeHostName, details.PipeHostName);
+            Assert.False(string.IsNullOrEmpty(details.PipeName));
+        }
+
+        [Theory]
+        [InlineData(@"np:127.0.0.1", @"sql\query")]
+        [InlineData(@"np:localhost", @"sql\query")]
+        [InlineData(@"np:server\instance", @"MSSQL$instance\sql\query")]
+        public void ParseServerName_NamedPipesWithoutUncPath_ComposesDefaultPipeName(
+            string dataSource, string expectedPipeName)
+        {
+            DataSource details = DataSource.ParseServerName(dataSource);
+
+            Assert.NotNull(details);
+            Assert.Equal(expectedPipeName, details.PipeName);
+        }
+
+        /// <summary>
+        /// Without an explicit protocol prefix, managed SNI defaults to TCP, so an IPv6 literal
+        /// server name must continue to parse successfully and never reach the Named Pipes path.
+        /// </summary>
+        [Theory]
+        [InlineData("::1")]
+        [InlineData("[::1]")]
+        [InlineData("fe80::1")]
+        public void ParseServerName_IPv6LiteralWithoutProtocol_ResolvesToNonNamedPipes(string dataSource)
+        {
+            DataSource details = DataSource.ParseServerName(dataSource);
+
+            Assert.NotNull(details);
+            Assert.NotEqual(DataSource.Protocol.NP, details.ResolvedProtocol);
+        }
+
+        [Theory]
+        [InlineData("::1", false)]
+        [InlineData("[::1]", false)]
+        [InlineData("", false)]
+        [InlineData(".", true)]
+        [InlineData("localhost", true)]
+        [InlineData("127.0.0.1", true)]
+        [InlineData("my-server.contoso.com", true)]
+        public void IsValidPipeHostName_ReturnsExpected(string hostName, bool expected)
+        {
+            Assert.Equal(expected, DataSource.IsValidPipeHostName(hostName));
+        }
+
+        [Fact]
+        public void IsValidPipeHostName_Null_ReturnsFalse()
+        {
+            Assert.False(DataSource.IsValidPipeHostName(null));
+        }
+    }
+}
+
+#endif

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/ManagedSni/DataSourceNamedPipesTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/ManagedSni/DataSourceNamedPipesTests.cs
@@ -12,38 +12,60 @@ namespace Microsoft.Data.SqlClient.UnitTests.ManagedSni
     /// <summary>
     /// Regression tests for Named Pipes data source parsing in <see cref="DataSource"/>.
     ///
-    /// A UNC path host component may never contain a colon, so an IPv6 literal server name
-    /// produces a malformed pipe path such as <c>\\::1\pipe\sql\query</c>. Handing that to the
-    /// OS sends the SMB redirector into an SMB session setup that can fault LSASS on Windows
-    /// and force a reboot. Such data sources must be rejected during parsing.
+    /// A UNC path host component may never contain a colon, so an IPv6 literal server name cannot
+    /// be used directly. Passing one through anyway composes a malformed pipe path such as
+    /// <c>\\::1\pipe\sql\query</c>, which sends the SMB redirector into an SMB session setup that
+    /// can fault LSASS on Windows and force a reboot. Windows instead defines a transcription for
+    /// this case (<c>2001:db8::1</c> becomes <c>2001-db8--1.ipv6-literal.net</c>), which the parser
+    /// now applies so IPv6 Named Pipes connections keep working.
     ///
     /// See: https://github.com/dotnet/SqlClient/issues/4523
+    /// and https://learn.microsoft.com/openspecs/windows_protocols/ms-dtyp/62e862f4-2a51-452e-8eeb-dc4ff5ee33cc
     /// </summary>
     public class DataSourceNamedPipesTests
     {
         /// <summary>
-        /// Verifies that a Named Pipes data source whose host component is an IPv6 literal is
-        /// rejected during parsing, covering both the <c>np:host</c> form and the
-        /// <c>\\host\pipe\...</c> UNC form. Such a host cannot be expressed in a UNC path, and
-        /// composing one crashes LSASS on Windows.
+        /// Verifies that an IPv6 literal host is transcribed to its <c>.ipv6-literal.net</c> UNC
+        /// form, covering both the <c>np:host</c> form and the <c>\\host\pipe\...</c> UNC form,
+        /// with and without brackets and with a zone index.
         /// </summary>
         [Theory]
-        [InlineData(@"np:::1")]
-        [InlineData(@"np:[::1]")]
-        [InlineData(@"np:fe80::1")]
-        [InlineData(@"np:2001:db8::1")]
-        [InlineData(@"\\::1\pipe\sql\query")]
-        [InlineData(@"np:\\::1\pipe\sql\query")]
-        [InlineData(@"np:\\[::1]\pipe\MSSQL$MYINSTANCE\sql\query")]
-        public void ParseServerName_NamedPipesWithIPv6Literal_IsRejected(string dataSource)
+        [InlineData(@"np:::1", "--1.ipv6-literal.net")]
+        [InlineData(@"np:[::1]", "--1.ipv6-literal.net")]
+        [InlineData(@"np:2001:db8::1", "2001-db8--1.ipv6-literal.net")]
+        [InlineData(@"np:fe80::1%3", "fe80--1s3.ipv6-literal.net")]
+        [InlineData(@"\\::1\pipe\sql\query", "--1.ipv6-literal.net")]
+        [InlineData(@"np:\\::1\pipe\sql\query", "--1.ipv6-literal.net")]
+        [InlineData(@"np:\\[2001:db8::1]\pipe\MSSQL$MYINSTANCE\sql\query", "2001-db8--1.ipv6-literal.net")]
+        public void ParseServerName_NamedPipesWithIPv6Literal_IsTranscribedToUncForm(
+            string dataSource, string expectedPipeHostName)
+        {
+            DataSource details = DataSource.ParseServerName(dataSource);
+
+            Assert.NotNull(details);
+            Assert.Equal(DataSource.Protocol.NP, details.ResolvedProtocol);
+            Assert.Equal(expectedPipeHostName, details.PipeHostName);
+            // The pipe host name is what reaches the OS, so it must never carry a colon.
+            Assert.DoesNotContain(":", details.PipeHostName);
+        }
+
+        /// <summary>
+        /// Verifies that a colon-bearing host that is not a parseable IPv6 literal has no UNC form
+        /// and is therefore rejected, rather than composing a malformed pipe path.
+        /// </summary>
+        [Theory]
+        [InlineData(@"np:not:a:host")]
+        [InlineData(@"np:2001:db8:::::1")]
+        [InlineData(@"\\not:a:host\pipe\sql\query")]
+        public void ParseServerName_NamedPipesWithUnparseableColonHost_IsRejected(string dataSource)
         {
             Assert.Null(DataSource.ParseServerName(dataSource));
         }
 
         /// <summary>
-        /// Verifies that the new IPv6 literal rejection does not regress legitimate Named Pipes
-        /// data sources: IPv4 literals, <c>localhost</c>, <c>.</c>, named instances, and explicit
-        /// UNC pipe paths must still parse and yield the expected pipe host name.
+        /// Verifies that IPv6 transcription does not regress legitimate Named Pipes data sources:
+        /// IPv4 literals, <c>localhost</c>, <c>.</c>, named instances, and explicit UNC pipe paths
+        /// must still parse and yield an unchanged pipe host name.
         /// </summary>
         [Theory]
         [InlineData(@"np:127.0.0.1", "127.0.0.1")]
@@ -73,6 +95,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.ManagedSni
         [Theory]
         [InlineData(@"np:127.0.0.1", @"sql\query")]
         [InlineData(@"np:localhost", @"sql\query")]
+        [InlineData(@"np:::1", @"sql\query")]
         [InlineData(@"np:server\instance", @"MSSQL$instance\sql\query")]
         public void ParseServerName_NamedPipesWithoutUncPath_ComposesDefaultPipeName(
             string dataSource, string expectedPipeName)
@@ -81,6 +104,20 @@ namespace Microsoft.Data.SqlClient.UnitTests.ManagedSni
 
             Assert.NotNull(details);
             Assert.Equal(expectedPipeName, details.PipeName);
+        }
+
+        /// <summary>
+        /// Verifies that an IPv6 literal keeps its original form in <see cref="DataSource.ServerName"/>,
+        /// which feeds SPN creation, even though the pipe host name is transcribed.
+        /// </summary>
+        [Fact]
+        public void ParseServerName_NamedPipesWithIPv6Literal_PreservesServerNameForSpn()
+        {
+            DataSource details = DataSource.ParseServerName(@"np:2001:db8::1");
+
+            Assert.NotNull(details);
+            Assert.Equal("2001:db8::1", details.ServerName);
+            Assert.Equal("2001-db8--1.ipv6-literal.net", details.PipeHostName);
         }
 
         /// <summary>
@@ -100,31 +137,48 @@ namespace Microsoft.Data.SqlClient.UnitTests.ManagedSni
         }
 
         /// <summary>
-        /// Verifies <see cref="DataSource.IsValidPipeHostName"/> directly: a pipe host name must be
-        /// non-empty and free of colons.
+        /// Verifies <see cref="DataSource.GetUncCompatibleHostName"/> directly: colon-free host names
+        /// pass through untouched, IPv6 literals are transcribed per MS-DTYP, and colon-bearing host
+        /// names with no IPv6 interpretation return <see langword="null"/>.
         /// </summary>
         [Theory]
-        [InlineData("::1", false)]
-        [InlineData("[::1]", false)]
-        [InlineData("", false)]
-        [InlineData(".", true)]
-        [InlineData("localhost", true)]
-        [InlineData("127.0.0.1", true)]
-        [InlineData("my-server.contoso.com", true)]
-        public void IsValidPipeHostName_ReturnsExpected(string hostName, bool expected)
+        [InlineData(".", ".")]
+        [InlineData("localhost", "localhost")]
+        [InlineData("127.0.0.1", "127.0.0.1")]
+        [InlineData("my-server.contoso.com", "my-server.contoso.com")]
+        [InlineData("--1.ipv6-literal.net", "--1.ipv6-literal.net")]
+        [InlineData("::1", "--1.ipv6-literal.net")]
+        [InlineData("[::1]", "--1.ipv6-literal.net")]
+        [InlineData("2001:db8::1", "2001-db8--1.ipv6-literal.net")]
+        [InlineData("fe80::1%3", "fe80--1s3.ipv6-literal.net")]
+        public void GetUncCompatibleHostName_ReturnsExpected(string hostName, string expected)
         {
-            Assert.Equal(expected, DataSource.IsValidPipeHostName(hostName));
+            Assert.Equal(expected, DataSource.GetUncCompatibleHostName(hostName));
         }
 
         /// <summary>
-        /// Verifies <see cref="DataSource.IsValidPipeHostName"/> rejects a null host name.
-        /// Covered separately from the theory above because xUnit disallows null theory data
-        /// for a non-nullable string parameter.
+        /// Verifies <see cref="DataSource.GetUncCompatibleHostName"/> returns <see langword="null"/>
+        /// for host names that contain a colon but have no IPv6 interpretation, and for empty input.
+        /// </summary>
+        [Theory]
+        [InlineData("not:a:host")]
+        [InlineData("2001:db8:::::1")]
+        [InlineData("[:]")]
+        [InlineData("")]
+        public void GetUncCompatibleHostName_UnconvertibleHost_ReturnsNull(string hostName)
+        {
+            Assert.Null(DataSource.GetUncCompatibleHostName(hostName));
+        }
+
+        /// <summary>
+        /// Verifies <see cref="DataSource.GetUncCompatibleHostName"/> returns <see langword="null"/>
+        /// for a null host name. Covered separately from the theory above because xUnit disallows
+        /// null theory data for a non-nullable string parameter.
         /// </summary>
         [Fact]
-        public void IsValidPipeHostName_Null_ReturnsFalse()
+        public void GetUncCompatibleHostName_Null_ReturnsNull()
         {
-            Assert.False(DataSource.IsValidPipeHostName(null));
+            Assert.Null(DataSource.GetUncCompatibleHostName(null));
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/ManagedSni/DataSourceNamedPipesTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/ManagedSni/DataSourceNamedPipesTests.cs
@@ -158,6 +158,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.ManagedSni
 
             Assert.NotNull(details);
             Assert.NotEqual(DataSource.Protocol.NP, details.ResolvedProtocol);
+            Assert.Equal(dataSource, details.ServerName);
         }
 
         /// <summary>
@@ -174,6 +175,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.ManagedSni
         [InlineData("::1", "--1.ipv6-literal.net")]
         [InlineData("[::1]", "--1.ipv6-literal.net")]
         [InlineData("2001:db8::1", "2001-db8--1.ipv6-literal.net")]
+        [InlineData("::ffff:1.2.3.4", "--ffff-1.2.3.4.ipv6-literal.net")]
         [InlineData("fe80::1%3", "fe80--1s3.ipv6-literal.net")]
         public void GetUncCompatibleHostName_ReturnsExpected(string hostName, string expected)
         {

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/ManagedSni/DataSourceNamedPipesTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/ManagedSni/DataSourceNamedPipesTests.cs
@@ -21,6 +21,12 @@ namespace Microsoft.Data.SqlClient.UnitTests.ManagedSni
     /// </summary>
     public class DataSourceNamedPipesTests
     {
+        /// <summary>
+        /// Verifies that a Named Pipes data source whose host component is an IPv6 literal is
+        /// rejected during parsing, covering both the <c>np:host</c> form and the
+        /// <c>\\host\pipe\...</c> UNC form. Such a host cannot be expressed in a UNC path, and
+        /// composing one crashes LSASS on Windows.
+        /// </summary>
         [Theory]
         [InlineData(@"np:::1")]
         [InlineData(@"np:[::1]")]
@@ -34,6 +40,11 @@ namespace Microsoft.Data.SqlClient.UnitTests.ManagedSni
             Assert.Null(DataSource.ParseServerName(dataSource));
         }
 
+        /// <summary>
+        /// Verifies that the new IPv6 literal rejection does not regress legitimate Named Pipes
+        /// data sources: IPv4 literals, <c>localhost</c>, <c>.</c>, named instances, and explicit
+        /// UNC pipe paths must still parse and yield the expected pipe host name.
+        /// </summary>
         [Theory]
         [InlineData(@"np:127.0.0.1", "127.0.0.1")]
         [InlineData(@"np:localhost", "localhost")]
@@ -53,6 +64,12 @@ namespace Microsoft.Data.SqlClient.UnitTests.ManagedSni
             Assert.False(string.IsNullOrEmpty(details.PipeName));
         }
 
+        /// <summary>
+        /// Verifies that a Named Pipes data source given without a UNC path still composes the
+        /// default pipe name, including the <c>MSSQL$&lt;instance&gt;</c> prefix for named instances.
+        /// These forms are asserted separately from the UNC forms because the UNC path builds its
+        /// pipe name with <see cref="System.IO.Path.DirectorySeparatorChar"/>, which is platform dependent.
+        /// </summary>
         [Theory]
         [InlineData(@"np:127.0.0.1", @"sql\query")]
         [InlineData(@"np:localhost", @"sql\query")]
@@ -82,6 +99,10 @@ namespace Microsoft.Data.SqlClient.UnitTests.ManagedSni
             Assert.NotEqual(DataSource.Protocol.NP, details.ResolvedProtocol);
         }
 
+        /// <summary>
+        /// Verifies <see cref="DataSource.IsValidPipeHostName"/> directly: a pipe host name must be
+        /// non-empty and free of colons.
+        /// </summary>
         [Theory]
         [InlineData("::1", false)]
         [InlineData("[::1]", false)]
@@ -95,6 +116,11 @@ namespace Microsoft.Data.SqlClient.UnitTests.ManagedSni
             Assert.Equal(expected, DataSource.IsValidPipeHostName(hostName));
         }
 
+        /// <summary>
+        /// Verifies <see cref="DataSource.IsValidPipeHostName"/> rejects a null host name.
+        /// Covered separately from the theory above because xUnit disallows null theory data
+        /// for a non-nullable string parameter.
+        /// </summary>
         [Fact]
         public void IsValidPipeHostName_Null_ReturnsFalse()
         {


### PR DESCRIPTION
## Description

Ports the native SNI fix (ADO PR 8120) to the Managed SNI code base, with an IPv6 improvement over the native version.

A UNC path host component may never contain a colon, so an IPv6 literal server name composes a malformed pipe path such as `\\::1\pipe\sql\query`. Handing that path to the OS sends the SMB redirector into an SMB session setup whose SPNEGO/NegoEx target name embeds the IPv6 literal, hitting an access violation inside LSASS on Windows. LSASS is a critical process, so Windows forces a reboot.

Managed SNI does not walk the `sm` -> `tcp` -> `np` default protocol list the way native SNI does: with no protocol prefix it resolves to TCP, so `Server=::1` is already safe there. The malformed path is still reachable when Named Pipes is selected explicitly, for example `Server=np:::1`, `Server=np:[::1]`, or `Server=\\::1\pipe\sql\query`.

Rather than rejecting these outright (which would block IPv6 addresses that can work), the parser applies the UNC transcription Windows defines for exactly this case ([MS-DTYP 2.2.57](https://learn.microsoft.com/openspecs/windows_protocols/ms-dtyp/62e862f4-2a51-452e-8eeb-dc4ff5ee33cc)): replace each `:` with `-` and each `%` (zone index) with `s`, then append `.ipv6-literal.net`.

| Data source | Resulting `PipeHostName` |
| --- | --- |
| `np:::1` | `--1.ipv6-literal.net` |
| `np:[::1]` | `--1.ipv6-literal.net` |
| `np:2001:db8::1` | `2001-db8--1.ipv6-literal.net` |
| `np:fe80::1%3` | `fe80--1s3.ipv6-literal.net` |

Implementation, all in `ManagedSni/SniProxy.netcore.cs`:

- New `DataSource.GetUncCompatibleHostName` helper performs the transcription, accepting the bracketed `[::1]` spelling users often carry over from URL syntax.
- Applied at both Named Pipes host-assignment sites in `InferNamedPipesInformation` (the `np:host` form and the `\\host\pipe\...` UNC form).
- `SniProxy.CreateNpHandle` retains a colon check as a final safeguard, mirroring the `Np::OpenPipe` check in native SNI.

Edge behavior worth noting:

- Colon-free host names, including IPv4 literals and already-transcribed `.ipv6-literal.net` names, pass through untouched, so nothing that worked before changes. LocalDB, `localhost` and `.` are unaffected.
- `ServerName` deliberately keeps the original literal because it only feeds SPN creation; only `PipeHostName`, which is what reaches the OS, is transcribed.
- A colon-bearing host with no valid IPv6 interpretation (e.g. `not:a:host`) fails cleanly with the standard invalid-connection-string SNI error instead of composing a malformed path.

No public API changes.

## Issues

Fixes #4523 in the Managed SNI code path. Native SNI counterpart: `Microsoft.Data.SqlClient.sni` PR 8120.

## Testing

New unit tests in `src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/ManagedSni/DataSourceNamedPipesTests.cs`:

- IPv6 literals over Named Pipes are transcribed to their `.ipv6-literal.net` form, covering the `np:host` and UNC forms, bracketed and unbracketed spellings, and a zone index.
- Colon-bearing hosts with no IPv6 interpretation are still rejected.
- Valid Named Pipes data sources still parse unchanged: `np:127.0.0.1`, `np:localhost`, `np:.`, `np:server\instance`, `\\127.0.0.1\pipe\sql\query`, `\\.\pipe\MSSQL$MYINSTANCE\sql\query`, `\\my-server\pipe\sql\query`.
- `ServerName` keeps the original IPv6 literal for SPN purposes while `PipeHostName` is transcribed.
- IPv6 literals with no protocol prefix still resolve to TCP, so existing IPv6 TCP connections are untouched.
- Direct coverage of the `GetUncCompatibleHostName` helper, including the null and empty cases.

48 ManagedSni unit tests pass locally (`dotnet test -f net9.0 --filter FullyQualifiedName~ManagedSni`), and the driver builds clean across all TFMs. Pipe-name assertions deliberately avoid the UNC forms because that code path builds the name with `Path.DirectorySeparatorChar`, which is platform dependent.

Note that no automated test can cover the LSASS crash itself, since reproducing it reboots the machine. The native SNI PR was verified manually on Windows; this change removes the malformed path at the parser level, before it can reach the OS.
