### PR TITLE
[v7.1.0-preview3] Update SNI package reference to 7.1.0-preview3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,7 +52,7 @@
   -->
   <PropertyGroup>
     <!-- SNI version (external package, version declared once here) -->
-    <SniVersion>6.0.2</SniVersion>
+    <SniVersion>7.1.0-preview3.26226.3</SniVersion>
     <SniVersionRange>[$(SniVersion), $([MSBuild]::Add($(SniVersion.Split('.')[0]), 1)).0.0)</SniVersionRange>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description

Updates the SNI package reference to the newly published `7.1.0-preview3` build, in preparation for the MDS v7.1.0-preview3 release.

`Microsoft.Data.SqlClient.SNI` and `Microsoft.Data.SqlClient.SNI.runtime` have both been published at `7.1.0-preview3.26226.3`, aligning SNI's version numbering with MDS.

### Why this is required

`SniVersion` was last set to `6.0.2` in #4337 and has not changed since, so v7.1.0-preview1 and preview2 both shipped against SNI 6.0.2. The derived range currently evaluates to:

```
[6.0.2, 7.0.0)
```

The upper bound is exclusive at `7.0.0`, so the new `7.1.0-preview3` SNI falls **outside** the range and would never be picked up by floating resolution. Without this explicit bump, v7.1.0-preview3 would silently ship against SNI 6.0.x.

The rest of the version alignment is already in place — following the versioning consolidation in #4336, `SqlClientNextVersion` is set to `7.1.0-preview3` and the entire SqlClient family resolves from it. This change brings the SNI dependency in line so that everything points at preview3.

### Change

A single property update. `SniVersion` is declared once and fans out automatically to:

- `PackageVersion` entries for `Microsoft.Data.SqlClient.SNI` and `Microsoft.Data.SqlClient.SNI.runtime`
- The `$SniVersionRange$` token substituted into `Microsoft.Data.SqlClient.nuspec`

The derived range now evaluates to `[7.1.0-preview3.26226.3, 8.0.0)`. The `Split('.')[0]` ceiling calculation correctly yields `7` despite the prerelease suffix, and a future stable `7.1.0` will still satisfy the range since prerelease sorts below release.

## Validation

- `dotnet restore` resolves both packages at `7.1.0-preview3.26226.3`; `project.assets.json` confirms the ranges as `>= 7.1.0-preview3.26226.3 < 8.0.0`
- `dotnet build -f net9.0` — succeeded, 0 warnings, 0 errors
- `dotnet build -f net462` — succeeded, 0 warnings, 0 errors

## Checklist

- [x] Verified against the published SNI packages on the consumed feed
- [x] Restore and build succeed for both netfx and netcore target frameworks
- [x] No remaining references to the previous SNI version
- [x] Ensure no breaking changes introduced
- [ ] Tests added or updated — n/a, dependency version change only
- [ ] Public API changes documented — n/a, no API surface change

Release notes for v7.1.0-preview3 will follow in a separate PR.

[AB#47358](https://sqlclientdrivers.visualstudio.com/b49eac2d-45b3-4951-899d-b8637b46f89a/_workitems/edit/47358)
