### PR TITLE
Upgrade checkout actions to Node 24

### DIFF
--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -23,7 +23,7 @@ jobs:
       PR_REVIEWER_POOL: ${{ vars.PR_REVIEWER_POOL }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             .github/scripts/auto-assign-pr.js

--- a/.github/workflows/verify-aw-lock.yml
+++ b/.github/workflows/verify-aw-lock.yml
@@ -13,7 +13,7 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install gh-aw extension
         uses: github/gh-aw-actions/setup-cli@8c7d04ebf1ece56cd381446125da3e0f6896294a # v0.80.9


### PR DESCRIPTION
## Description

Upgrade the remaining direct `actions/checkout` references from v4 to v6. Checkout v6 runs on Node 24 and is already used by other workflows in this repository.

**Resolves warning in GH actions:**

[load-balance-assignees](https://github.com/dotnet/SqlClient/actions/runs/32415257837/job/96574832524#step:7:2)
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Issues

None.

## Testing

- Confirmed `actions/checkout@v6` declares `runs.using: node24`.
- Confirmed no direct `actions/checkout@v4` workflow references remain.
- Confirmed the workflow diff has no whitespace errors.

## Checklist

- [x] Tests added or updated (not applicable; workflow metadata-only change)
- [x] Public API changes documented (not applicable; no API changes)
- [x] Verified against customer repro (not applicable)
- [x] Ensure no breaking changes introduced