### PR TITLE
Use the async Always Encrypted key store APIs on async execution paths

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveDelegate.Crypto.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveDelegate.Crypto.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Data.SqlClient
                 throw new RetryableEnclaveQueryExecutionException(e.Message, e);
             }
 
-            List<ColumnEncryptionKeyInfo> decryptedKeysToBeSentToEnclave = GetDecryptedKeysToBeSentToEnclave(keysToBeSentToEnclave, enclaveSessionParameters.ServerName, connection, command);
+            List<ColumnEncryptionKeyInfo> decryptedKeysToBeSentToEnclave = GetDecryptedKeysToBeSentToEnclave(keysToBeSentToEnclave, connection, command);
             return BuildEnclavePackage(decryptedKeysToBeSentToEnclave, queryText, counter, sqlEnclaveSession, enclaveSessionParameters.ServerName);
         }
 
@@ -192,6 +192,11 @@ namespace Microsoft.Data.SqlClient
 
             try
             {
+                // @TODO: GetEnclaveSession is still synchronous. On a session cache hit it is pure in-memory
+                // work, but on a miss it performs blocking attestation HTTP. Making it awaitable requires the
+                // async enclave provider hierarchy (Phase 3 of the async Always Encrypted spec), which adds
+                // public virtual API and therefore ships separately. Until then this is the one remaining
+                // blocking call on the asynchronous Always Encrypted path.
                 GetEnclaveSession(
                     attestationProtocol,
                     enclaveType,
@@ -212,7 +217,6 @@ namespace Microsoft.Data.SqlClient
 
             List<ColumnEncryptionKeyInfo> decryptedKeysToBeSentToEnclave = await GetDecryptedKeysToBeSentToEnclaveAsync(
                     keysToBeSentToEnclave,
-                    enclaveSessionParameters.ServerName,
                     connection,
                     command,
                     cancellationToken)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveDelegate.Crypto.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveDelegate.Crypto.cs
@@ -5,6 +5,8 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Data.SqlClient
 {
@@ -156,10 +158,87 @@ namespace Microsoft.Data.SqlClient
             }
 
             List<ColumnEncryptionKeyInfo> decryptedKeysToBeSentToEnclave = GetDecryptedKeysToBeSentToEnclave(keysToBeSentToEnclave, enclaveSessionParameters.ServerName, connection, command);
+            return BuildEnclavePackage(decryptedKeysToBeSentToEnclave, queryText, counter, sqlEnclaveSession, enclaveSessionParameters.ServerName);
+        }
+
+        /// <summary>
+        /// Asynchronously encrypts the byte package containing keys with the session key.
+        /// </summary>
+        /// <remarks>
+        /// Async counterpart of <see cref="GenerateEnclavePackage"/>. Only the column encryption key decryption
+        /// step performs I/O, so only that step is awaited; the remaining work is local cryptography and is
+        /// performed inline.
+        /// </remarks>
+        /// <param name="attestationProtocol">attestation protocol</param>
+        /// <param name="keysToBeSentToEnclave">Keys to be sent to enclave</param>
+        /// <param name="queryText">Text of the query being executed</param>
+        /// <param name="enclaveType">enclave type</param>
+        /// <param name="enclaveSessionParameters">The set of parameters required for enclave session.</param>
+        /// <param name="connection">connection executing the query</param>
+        /// <param name="command">command executing the query</param>
+        /// <param name="cancellationToken">Token used to request cancellation of the operation</param>
+        internal async Task<EnclavePackage> GenerateEnclavePackageAsync(
+            SqlConnectionAttestationProtocol attestationProtocol,
+            ConcurrentDictionary<int, SqlTceCipherInfoEntry> keysToBeSentToEnclave,
+            string queryText,
+            string enclaveType,
+            EnclaveSessionParameters enclaveSessionParameters,
+            SqlConnection connection,
+            SqlCommand command,
+            CancellationToken cancellationToken)
+        {
+            SqlEnclaveSession sqlEnclaveSession;
+            long counter;
+
+            try
+            {
+                GetEnclaveSession(
+                    attestationProtocol,
+                    enclaveType,
+                    enclaveSessionParameters,
+                    generateCustomData: false,
+                    isRetry: false,
+                    sqlEnclaveSession: out sqlEnclaveSession,
+                    counter: out counter,
+                    customData: out _,
+                    customDataLength: out _,
+                    throwIfNull: true
+                );
+            }
+            catch (Exception e)
+            {
+                throw new RetryableEnclaveQueryExecutionException(e.Message, e);
+            }
+
+            List<ColumnEncryptionKeyInfo> decryptedKeysToBeSentToEnclave = await GetDecryptedKeysToBeSentToEnclaveAsync(
+                    keysToBeSentToEnclave,
+                    enclaveSessionParameters.ServerName,
+                    connection,
+                    command,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            return BuildEnclavePackage(decryptedKeysToBeSentToEnclave, queryText, counter, sqlEnclaveSession, enclaveSessionParameters.ServerName);
+        }
+
+        /// <summary>
+        /// Assembles the enclave package from already-decrypted column encryption keys.
+        /// </summary>
+        /// <remarks>
+        /// Shared by the synchronous and asynchronous package generation paths. All work here is local
+        /// cryptography, so there is no asynchronous counterpart.
+        /// </remarks>
+        private EnclavePackage BuildEnclavePackage(
+            List<ColumnEncryptionKeyInfo> decryptedKeysToBeSentToEnclave,
+            string queryText,
+            long counter,
+            SqlEnclaveSession sqlEnclaveSession,
+            string serverName)
+        {
             byte[] queryStringHashBytes = ComputeQueryStringHash(queryText);
             byte[] keyBytePackage = GenerateBytePackageForKeys(counter, queryStringHashBytes, decryptedKeysToBeSentToEnclave);
             byte[] sessionKey = sqlEnclaveSession.GetSessionKey();
-            byte[] encryptedBytePackage = EncryptBytePackage(keyBytePackage, sessionKey, enclaveSessionParameters.ServerName);
+            byte[] encryptedBytePackage = EncryptBytePackage(keyBytePackage, sessionKey, serverName);
             byte[] enclaveSessionHandle = BitConverter.GetBytes(sqlEnclaveSession.SessionId);
             byte[] byteArrayToBeSentToEnclave = CombineByteArrays(enclaveSessionHandle, encryptedBytePackage);
             return new EnclavePackage(byteArrayToBeSentToEnclave, sqlEnclaveSession);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveDelegate.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveDelegate.cs
@@ -8,6 +8,8 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Data.SqlClient
 {
@@ -50,7 +52,7 @@ namespace Microsoft.Data.SqlClient
         /// <param name="connection"></param>
         /// <param name="command"></param>
         /// <returns></returns>
-        private List<ColumnEncryptionKeyInfo> GetDecryptedKeysToBeSentToEnclave(ConcurrentDictionary<int, SqlTceCipherInfoEntry> keysTobeSentToEnclave, string serverName, SqlConnection connection, SqlCommand command)
+        internal List<ColumnEncryptionKeyInfo> GetDecryptedKeysToBeSentToEnclave(ConcurrentDictionary<int, SqlTceCipherInfoEntry> keysTobeSentToEnclave, string serverName, SqlConnection connection, SqlCommand command)
         {
             List<ColumnEncryptionKeyInfo> decryptedKeysToBeSentToEnclave = new List<ColumnEncryptionKeyInfo>();
 
@@ -58,32 +60,79 @@ namespace Microsoft.Data.SqlClient
             {
                 SqlSecurityUtility.DecryptSymmetricKey(cipherInfo, out SqlClientSymmetricKey sqlClientSymmetricKey, out SqlEncryptionKeyInfo encryptionkeyInfoChosen, connection, command);
 
-                if (sqlClientSymmetricKey == null)
-                {
-                    throw SQL.NullArgumentInternal(nameof(sqlClientSymmetricKey), nameof(EnclaveDelegate), nameof(GetDecryptedKeysToBeSentToEnclave));
-                }
-                if (cipherInfo.ColumnEncryptionKeyValues == null)
-                {
-                    throw SQL.NullArgumentInternal(nameof(cipherInfo.ColumnEncryptionKeyValues), nameof(EnclaveDelegate), nameof(GetDecryptedKeysToBeSentToEnclave));
-                }
-                if (!(cipherInfo.ColumnEncryptionKeyValues.Count > 0))
-                {
-                    throw SQL.ColumnEncryptionKeysNotFound();
-                }
-
-                //cipherInfo.CekId is always 0, hence used cipherInfo.ColumnEncryptionKeyValues[0].cekId. Even when cek has multiple ColumnEncryptionKeyValues
-                //the cekid and the plaintext value will remain the same, what varies is the encrypted cek value, since the cek can be encrypted by 
-                //multiple CMKs
-                decryptedKeysToBeSentToEnclave.Add(
-                    new ColumnEncryptionKeyInfo(
-                        sqlClientSymmetricKey.RootKey,
-                        cipherInfo.ColumnEncryptionKeyValues[0].databaseId,
-                        cipherInfo.ColumnEncryptionKeyValues[0].cekMdVersion,
-                        cipherInfo.ColumnEncryptionKeyValues[0].cekId
-                    )
-                );
+                decryptedKeysToBeSentToEnclave.Add(CreateColumnEncryptionKeyInfo(cipherInfo, sqlClientSymmetricKey));
             }
             return decryptedKeysToBeSentToEnclave;
+        }
+
+        /// <summary>
+        /// Asynchronously decrypts the keys that need to be sent to the enclave.
+        /// </summary>
+        /// <remarks>
+        /// Async counterpart of <see cref="GetDecryptedKeysToBeSentToEnclave"/>. Each column encryption key is
+        /// resolved through <see cref="SqlSecurityUtility.DecryptSymmetricKeyAsync(SqlTceCipherInfoEntry, SqlConnection, SqlCommand, CancellationToken)"/>
+        /// so that key store providers performing network I/O (for example Azure Key Vault) do not block a
+        /// thread while the enclave package is being assembled.
+        /// </remarks>
+        /// <param name="keysTobeSentToEnclave">Keys that need to sent to the enclave</param>
+        /// <param name="serverName">Name of the server the keys are being resolved for</param>
+        /// <param name="connection">Connection executing the query</param>
+        /// <param name="command">Command executing the query</param>
+        /// <param name="cancellationToken">Token used to request cancellation of the operation</param>
+        internal async Task<List<ColumnEncryptionKeyInfo>> GetDecryptedKeysToBeSentToEnclaveAsync(
+            ConcurrentDictionary<int, SqlTceCipherInfoEntry> keysTobeSentToEnclave,
+            string serverName,
+            SqlConnection connection,
+            SqlCommand command,
+            CancellationToken cancellationToken)
+        {
+            List<ColumnEncryptionKeyInfo> decryptedKeysToBeSentToEnclave = new List<ColumnEncryptionKeyInfo>();
+
+            foreach (SqlTceCipherInfoEntry cipherInfo in keysTobeSentToEnclave.Values)
+            {
+                (SqlClientSymmetricKey sqlClientSymmetricKey, SqlEncryptionKeyInfo _) =
+                    await SqlSecurityUtility.DecryptSymmetricKeyAsync(cipherInfo, connection, command, cancellationToken)
+                        .ConfigureAwait(false);
+
+                decryptedKeysToBeSentToEnclave.Add(CreateColumnEncryptionKeyInfo(cipherInfo, sqlClientSymmetricKey));
+            }
+
+            return decryptedKeysToBeSentToEnclave;
+        }
+
+        /// <summary>
+        /// Validates a decrypted column encryption key and projects it into the shape the enclave expects.
+        /// </summary>
+        /// <remarks>
+        /// Shared by the synchronous and asynchronous decryption paths so that both apply identical validation
+        /// and produce identical <see cref="ColumnEncryptionKeyInfo"/> instances.
+        /// </remarks>
+        private static ColumnEncryptionKeyInfo CreateColumnEncryptionKeyInfo(
+            SqlTceCipherInfoEntry cipherInfo,
+            SqlClientSymmetricKey sqlClientSymmetricKey)
+        {
+            if (sqlClientSymmetricKey == null)
+            {
+                throw SQL.NullArgumentInternal(nameof(sqlClientSymmetricKey), nameof(EnclaveDelegate), nameof(GetDecryptedKeysToBeSentToEnclave));
+            }
+            if (cipherInfo.ColumnEncryptionKeyValues == null)
+            {
+                throw SQL.NullArgumentInternal(nameof(cipherInfo.ColumnEncryptionKeyValues), nameof(EnclaveDelegate), nameof(GetDecryptedKeysToBeSentToEnclave));
+            }
+            if (!(cipherInfo.ColumnEncryptionKeyValues.Count > 0))
+            {
+                throw SQL.ColumnEncryptionKeysNotFound();
+            }
+
+            //cipherInfo.CekId is always 0, hence used cipherInfo.ColumnEncryptionKeyValues[0].cekId. Even when cek has multiple ColumnEncryptionKeyValues
+            //the cekid and the plaintext value will remain the same, what varies is the encrypted cek value, since the cek can be encrypted by 
+            //multiple CMKs
+            return new ColumnEncryptionKeyInfo(
+                sqlClientSymmetricKey.RootKey,
+                cipherInfo.ColumnEncryptionKeyValues[0].databaseId,
+                cipherInfo.ColumnEncryptionKeyValues[0].cekMdVersion,
+                cipherInfo.ColumnEncryptionKeyValues[0].cekId
+            );
         }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveDelegate.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveDelegate.cs
@@ -48,13 +48,12 @@ namespace Microsoft.Data.SqlClient
         /// Decrypt the keys that need to be sent to the enclave
         /// </summary>
         /// <param name="keysTobeSentToEnclave">Keys that need to sent to the enclave</param>
-        /// <param name="serverName"></param>
-        /// <param name="connection"></param>
-        /// <param name="command"></param>
+        /// <param name="connection">Connection executing the query</param>
+        /// <param name="command">Command executing the query</param>
         /// <returns></returns>
-        internal List<ColumnEncryptionKeyInfo> GetDecryptedKeysToBeSentToEnclave(ConcurrentDictionary<int, SqlTceCipherInfoEntry> keysTobeSentToEnclave, string serverName, SqlConnection connection, SqlCommand command)
+        internal List<ColumnEncryptionKeyInfo> GetDecryptedKeysToBeSentToEnclave(ConcurrentDictionary<int, SqlTceCipherInfoEntry> keysTobeSentToEnclave, SqlConnection connection, SqlCommand command)
         {
-            List<ColumnEncryptionKeyInfo> decryptedKeysToBeSentToEnclave = new List<ColumnEncryptionKeyInfo>();
+            List<ColumnEncryptionKeyInfo> decryptedKeysToBeSentToEnclave = new List<ColumnEncryptionKeyInfo>(keysTobeSentToEnclave.Count);
 
             foreach (SqlTceCipherInfoEntry cipherInfo in keysTobeSentToEnclave.Values)
             {
@@ -75,18 +74,16 @@ namespace Microsoft.Data.SqlClient
         /// thread while the enclave package is being assembled.
         /// </remarks>
         /// <param name="keysTobeSentToEnclave">Keys that need to sent to the enclave</param>
-        /// <param name="serverName">Name of the server the keys are being resolved for</param>
         /// <param name="connection">Connection executing the query</param>
         /// <param name="command">Command executing the query</param>
         /// <param name="cancellationToken">Token used to request cancellation of the operation</param>
         internal async Task<List<ColumnEncryptionKeyInfo>> GetDecryptedKeysToBeSentToEnclaveAsync(
             ConcurrentDictionary<int, SqlTceCipherInfoEntry> keysTobeSentToEnclave,
-            string serverName,
             SqlConnection connection,
             SqlCommand command,
             CancellationToken cancellationToken)
         {
-            List<ColumnEncryptionKeyInfo> decryptedKeysToBeSentToEnclave = new List<ColumnEncryptionKeyInfo>();
+            List<ColumnEncryptionKeyInfo> decryptedKeysToBeSentToEnclave = new List<ColumnEncryptionKeyInfo>(keysTobeSentToEnclave.Count);
 
             foreach (SqlTceCipherInfoEntry cipherInfo in keysTobeSentToEnclave.Values)
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveDelegate.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveDelegate.cs
@@ -113,11 +113,11 @@ namespace Microsoft.Data.SqlClient
         {
             if (sqlClientSymmetricKey == null)
             {
-                throw SQL.NullArgumentInternal(nameof(sqlClientSymmetricKey), nameof(EnclaveDelegate), nameof(GetDecryptedKeysToBeSentToEnclave));
+                throw SQL.NullArgumentInternal(nameof(sqlClientSymmetricKey), nameof(EnclaveDelegate), nameof(CreateColumnEncryptionKeyInfo));
             }
             if (cipherInfo.ColumnEncryptionKeyValues == null)
             {
-                throw SQL.NullArgumentInternal(nameof(cipherInfo.ColumnEncryptionKeyValues), nameof(EnclaveDelegate), nameof(GetDecryptedKeysToBeSentToEnclave));
+                throw SQL.NullArgumentInternal(nameof(cipherInfo.ColumnEncryptionKeyValues), nameof(EnclaveDelegate), nameof(CreateColumnEncryptionKeyInfo));
             }
             if (!(cipherInfo.ColumnEncryptionKeyValues.Count > 0))
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Encryption.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Encryption.cs
@@ -14,7 +14,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Common;
 using Microsoft.Data.SqlClient.Connection;
-using Microsoft.Data.SqlClient.Utilities;
 
 namespace Microsoft.Data.SqlClient
 {
@@ -243,8 +242,32 @@ namespace Microsoft.Data.SqlClient
                 _activeConnection.EnclaveAttestationUrl,
                 _activeConnection.Database);
 
-        // @TODO: Isn't this doing things asynchronously? We should just have a purely asynchronous and a purely synchronous pathway instead of this mix of check this check that and flags.
-        private SqlDataReader GetParameterEncryptionDataReader(
+        /// <summary>
+        /// Schedules asynchronous consumption of the sp_describe_parameter_encryption results.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The returned task completes once the describe-parameter-encryption results have been read and every
+        /// column encryption key has been decrypted through the asynchronous key store provider APIs.
+        /// </para>
+        /// <para>
+        /// The work is dispatched with <see cref="Task.Run(Func{Task})"/> because the body issues blocking TDS
+        /// reads before reaching its first suspension point, and <c>PrepareForTransparentEncryption</c> is
+        /// invoked synchronously on the caller's thread by the asynchronous execution entry points. Dispatching
+        /// keeps that thread free, matching the behaviour of the continuation chain this replaced, while every
+        /// subsequent <c>await</c> releases the pooled thread for the duration of key store provider I/O.
+        /// </para>
+        /// </remarks>
+        /// <param name="returnTask">Receives the task representing the pending work</param>
+        /// <param name="fetchInputParameterEncryptionInfoTask">
+        /// Task representing the pending network write of the describe-parameter-encryption request, or
+        /// <c>null</c> when that write completed synchronously.
+        /// </param>
+        /// <param name="describeParameterEncryptionDataReader">Reader over the describe-parameter-encryption results</param>
+        /// <param name="describeParameterEncryptionRpcOriginalRpcMap">Map of encryption RPC requests to their original RPC requests</param>
+        /// <param name="describeParameterEncryptionNeeded">Whether describe parameter encryption was required</param>
+        /// <param name="isRetry">Indicates if this is a retry from a failed call</param>
+        private void GetParameterEncryptionDataReader(
             out Task returnTask,
             Task fetchInputParameterEncryptionInfoTask,
             SqlDataReader describeParameterEncryptionDataReader,
@@ -252,143 +275,102 @@ namespace Microsoft.Data.SqlClient
             bool describeParameterEncryptionNeeded,
             bool isRetry)
         {
-            returnTask = AsyncHelper.CreateContinuationTaskWithState(
-                taskToContinue: fetchInputParameterEncryptionInfoTask,
-                state: this,
-                onSuccess: sqlCommand =>
-                {
-                    bool processFinallyBlockAsync = true;
-                    bool decrementAsyncCountInFinallyBlockAsync = true;
-
-                    try
-                    {
-                        // Check for any exceptions on network write, before reading.
-                        sqlCommand.CheckThrowSNIException();
-
-                        // If it is async, then TryFetchInputParameterEncryptionInfo ->
-                        // RunExecuteReaderTds would have incremented the async count. Decrement it
-                        // when we are about to complete async execute reader.
-                        SqlConnectionInternal internalConnectionTds = sqlCommand._activeConnection.GetOpenTdsConnection();
-                        if (internalConnectionTds is not null)
-                        {
-                            internalConnectionTds.DecrementAsyncCount();
-                            decrementAsyncCountInFinallyBlockAsync = false;
-                        }
-
-                        // Complete executereader.
-                        // @TODO: If we can remove this reference, this could be a static lambda
-                        describeParameterEncryptionDataReader = sqlCommand.CompleteAsyncExecuteReader(
-                            isInternal: false,
-                            forDescribeParameterEncryption: true);
-                        Debug.Assert(sqlCommand._stateObj is null, "non-null state object in PrepareForTransparentEncryption.");
-
-                        // Read the results of describe parameter encryption.
-                        sqlCommand.ReadDescribeEncryptionParameterResults(
-                            describeParameterEncryptionDataReader,
-                            describeParameterEncryptionRpcOriginalRpcMap,
-                            isRetry);
-
-                        #if DEBUG
-                        // Failpoint to force the thread to halt to simulate cancellation of SqlCommand.
-                        if (_sleepAfterReadDescribeEncryptionParameterResults)
-                        {
-                            Thread.Sleep(TimeSpan.FromSeconds(10));
-                        }
-                        #endif
-                    }
-                    catch (Exception e)
-                    {
-                        processFinallyBlockAsync = ADP.IsCatchableExceptionType(e);
-                        throw;
-                    }
-                    finally
-                    {
-                        sqlCommand.PrepareTransparentEncryptionFinallyBlock(
-                            closeDataReader: processFinallyBlockAsync,
-                            decrementAsyncCount: decrementAsyncCountInFinallyBlockAsync,
-                            clearDataStructures: processFinallyBlockAsync,
-                            wasDescribeParameterEncryptionNeeded: describeParameterEncryptionNeeded,
-                            describeParameterEncryptionRpcOriginalRpcMap: describeParameterEncryptionRpcOriginalRpcMap,
-                            describeParameterEncryptionDataReader: describeParameterEncryptionDataReader);
-                    }
-                },
-                onFailure: static (sqlCommand, exception) =>
-                {
-                    sqlCommand.CachedAsyncState?.ResetAsyncState();
-                    if (exception is not null)
-                    {
-                        throw exception;
-                    }
-                });
-
-            return describeParameterEncryptionDataReader;
+            returnTask = Task.Run(() => GetParameterEncryptionDataReaderAsync(
+                fetchInputParameterEncryptionInfoTask,
+                describeParameterEncryptionDataReader,
+                describeParameterEncryptionRpcOriginalRpcMap,
+                describeParameterEncryptionNeeded,
+                isRetry));
         }
 
-        private SqlDataReader GetParameterEncryptionDataReaderAsync(
-            out Task returnTask,
+        /// <summary>
+        /// Awaits the describe-parameter-encryption request and consumes its results asynchronously.
+        /// </summary>
+        /// <remarks>
+        /// Failure of <paramref name="fetchInputParameterEncryptionInfoTask"/> resets the cached async state and
+        /// skips the transparent encryption finally block; cancellation of it does neither. Failures raised
+        /// while consuming the results run the finally block but leave the cached async state alone. These
+        /// semantics are inherited from the callback-based continuation this method replaced.
+        /// </remarks>
+        private async Task GetParameterEncryptionDataReaderAsync(
+            Task fetchInputParameterEncryptionInfoTask,
             SqlDataReader describeParameterEncryptionDataReader,
             ReadOnlyDictionary<_SqlRPC, _SqlRPC> describeParameterEncryptionRpcOriginalRpcMap,
             bool describeParameterEncryptionNeeded,
             bool isRetry)
         {
-            returnTask = Task.Run(() =>
+            if (fetchInputParameterEncryptionInfoTask is not null)
             {
-                bool processFinallyBlockAsync = true;
-                bool decrementAsyncCountInFinallyBlockAsync = true;
-
                 try
                 {
-                    // Check for any exception on network write before reading.
-                    CheckThrowSNIException();
-
-                    // If it is async, then TryFetchInputParameterEncryptionInfo ->
-                    // RunExecuteReaderTds would have incremented the async count. Decrement it
-                    // when we are about to complete async execute reader.
-                    SqlConnectionInternal internalConnectionTds = _activeConnection.GetOpenTdsConnection();
-                    if (internalConnectionTds is not null)
-                    {
-                        internalConnectionTds.DecrementAsyncCount();
-                        decrementAsyncCountInFinallyBlockAsync = false;
-                    }
-
-                    // Complete executereader.
-                    describeParameterEncryptionDataReader = CompleteAsyncExecuteReader(
-                        isInternal: false,
-                        forDescribeParameterEncryption: true);
-                    Debug.Assert(_stateObj is null, "non-null state object in PrepareForTransparentEncryption.");
-
-                    // Read the results of describe parameter encryption.
-                    ReadDescribeEncryptionParameterResults(
-                        describeParameterEncryptionDataReader,
-                        describeParameterEncryptionRpcOriginalRpcMap,
-                        isRetry);
-
-                    #if DEBUG
-                    // Failpoint to force the thread to halt to simulate cancellation of SqlCommand.
-                    if (_sleepAfterReadDescribeEncryptionParameterResults)
-                    {
-                        Thread.Sleep(TimeSpan.FromSeconds(10));
-                    }
-                    #endif
+                    await fetchInputParameterEncryptionInfoTask.ConfigureAwait(false);
                 }
-                catch (Exception e)
+                catch (OperationCanceledException)
                 {
-                    processFinallyBlockAsync = ADP.IsCatchableExceptionType(e);
                     throw;
                 }
-                finally
+                catch
                 {
-                    PrepareTransparentEncryptionFinallyBlock(
-                        closeDataReader: processFinallyBlockAsync,
-                        decrementAsyncCount: decrementAsyncCountInFinallyBlockAsync,
-                        clearDataStructures: processFinallyBlockAsync,
-                        wasDescribeParameterEncryptionNeeded: describeParameterEncryptionNeeded,
-                        describeParameterEncryptionRpcOriginalRpcMap: describeParameterEncryptionRpcOriginalRpcMap,
-                        describeParameterEncryptionDataReader: describeParameterEncryptionDataReader);
+                    CachedAsyncState?.ResetAsyncState();
+                    throw;
                 }
-            });
+            }
 
-            return describeParameterEncryptionDataReader;
+            bool processFinallyBlockAsync = true;
+            bool decrementAsyncCountInFinallyBlockAsync = true;
+
+            try
+            {
+                // Check for any exceptions on network write, before reading.
+                CheckThrowSNIException();
+
+                // If it is async, then TryFetchInputParameterEncryptionInfo ->
+                // RunExecuteReaderTds would have incremented the async count. Decrement it
+                // when we are about to complete async execute reader.
+                SqlConnectionInternal internalConnectionTds = _activeConnection.GetOpenTdsConnection();
+                if (internalConnectionTds is not null)
+                {
+                    internalConnectionTds.DecrementAsyncCount();
+                    decrementAsyncCountInFinallyBlockAsync = false;
+                }
+
+                // Complete executereader.
+                describeParameterEncryptionDataReader = CompleteAsyncExecuteReader(
+                    isInternal: false,
+                    forDescribeParameterEncryption: true);
+                Debug.Assert(_stateObj is null, "non-null state object in PrepareForTransparentEncryption.");
+
+                // Read the results of describe parameter encryption.
+                await ReadDescribeEncryptionParameterResultsAsync(
+                        describeParameterEncryptionDataReader,
+                        describeParameterEncryptionRpcOriginalRpcMap,
+                        isRetry,
+                        CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                #if DEBUG
+                // Failpoint to force the thread to halt to simulate cancellation of SqlCommand.
+                if (_sleepAfterReadDescribeEncryptionParameterResults)
+                {
+                    Thread.Sleep(TimeSpan.FromSeconds(10));
+                }
+                #endif
+            }
+            catch (Exception e)
+            {
+                processFinallyBlockAsync = ADP.IsCatchableExceptionType(e);
+                throw;
+            }
+            finally
+            {
+                PrepareTransparentEncryptionFinallyBlock(
+                    closeDataReader: processFinallyBlockAsync,
+                    decrementAsyncCount: decrementAsyncCountInFinallyBlockAsync,
+                    clearDataStructures: processFinallyBlockAsync,
+                    wasDescribeParameterEncryptionNeeded: describeParameterEncryptionNeeded,
+                    describeParameterEncryptionRpcOriginalRpcMap: describeParameterEncryptionRpcOriginalRpcMap,
+                    describeParameterEncryptionDataReader: describeParameterEncryptionDataReader);
+            }
         }
 
         private void InvalidateEnclaveSession()
@@ -662,7 +644,7 @@ namespace Microsoft.Data.SqlClient
                         // execution pending. Note that this should be done outside the task's
                         // continuation delegate.
                         processFinallyBlock = false;
-                        describeParameterEncryptionDataReader = GetParameterEncryptionDataReader(
+                        GetParameterEncryptionDataReader(
                             out returnTask,
                             fetchInputParameterEncryptionInfoTask,
                             describeParameterEncryptionDataReader,
@@ -682,8 +664,9 @@ namespace Microsoft.Data.SqlClient
                             // execution pending. Note that this should be done outside the task's
                             // continuation delegate.
                             processFinallyBlock = false;
-                            describeParameterEncryptionDataReader = GetParameterEncryptionDataReaderAsync(
+                            GetParameterEncryptionDataReader(
                                 out returnTask,
+                                fetchInputParameterEncryptionInfoTask: null,
                                 describeParameterEncryptionDataReader,
                                 describeParameterEncryptionRpcOriginalRpcMap,
                                 describeParameterEncryptionNeeded,
@@ -786,9 +769,106 @@ namespace Microsoft.Data.SqlClient
         /// <param name="describeParameterEncryptionRpcOriginalRpcMap"> Readonly dictionary with the map of parameter encryption rpc requests with the corresponding original rpc requests.</param>
         /// <param name="isRetry">Indicates if this is a retry from a failed call.</param>
         private void ReadDescribeEncryptionParameterResults(
-            SqlDataReader ds, // @TODO: Rename something more obvious
+            SqlDataReader ds,
             ReadOnlyDictionary<_SqlRPC, _SqlRPC> describeParameterEncryptionRpcOriginalRpcMap,
             bool isRetry)
+        {
+            PendingColumnEncryptionKeyOperations pending = new PendingColumnEncryptionKeyOperations();
+            ReadDescribeEncryptionParameterResultsCore(ds, describeParameterEncryptionRpcOriginalRpcMap, isRetry, pending);
+
+            foreach (ColumnMasterKeySignatureVerification verification in pending.SignatureVerifications)
+            {
+                SqlSecurityUtility.VerifyColumnMasterKeySignature(
+                    verification.KeyStoreName,
+                    verification.KeyPath,
+                    isEnclaveEnabled: true,
+                    verification.Signature,
+                    _activeConnection,
+                    this);
+            }
+
+            foreach (SqlCipherMetadata cipherMetadata in pending.KeyDecryptions)
+            {
+                SqlSecurityUtility.DecryptSymmetricKey(cipherMetadata, _activeConnection, this);
+            }
+
+            CacheQueryMetadataIfNeeded();
+        }
+
+        /// <summary>
+        /// Asynchronously reads the output of sp_describe_parameter_encryption.
+        /// </summary>
+        /// <remarks>
+        /// Async counterpart of <see cref="ReadDescribeEncryptionParameterResults"/>. Result set parsing is
+        /// shared with the synchronous path; only the column master key signature verifications and column
+        /// encryption key decryptions differ, and those are the operations that may reach out to a key store
+        /// over the network.
+        /// </remarks>
+        /// <param name="ds">Resultset from calling to sp_describe_parameter_encryption</param>
+        /// <param name="describeParameterEncryptionRpcOriginalRpcMap">Readonly dictionary with the map of parameter encryption rpc requests with the corresponding original rpc requests.</param>
+        /// <param name="isRetry">Indicates if this is a retry from a failed call.</param>
+        /// <param name="cancellationToken">Token used to request cancellation of the operation</param>
+        private async Task ReadDescribeEncryptionParameterResultsAsync(
+            SqlDataReader ds,
+            ReadOnlyDictionary<_SqlRPC, _SqlRPC> describeParameterEncryptionRpcOriginalRpcMap,
+            bool isRetry,
+            CancellationToken cancellationToken)
+        {
+            PendingColumnEncryptionKeyOperations pending = new PendingColumnEncryptionKeyOperations();
+            ReadDescribeEncryptionParameterResultsCore(ds, describeParameterEncryptionRpcOriginalRpcMap, isRetry, pending);
+
+            foreach (ColumnMasterKeySignatureVerification verification in pending.SignatureVerifications)
+            {
+                await SqlSecurityUtility.VerifyColumnMasterKeySignatureAsync(
+                        verification.KeyStoreName,
+                        verification.KeyPath,
+                        isEnclaveEnabled: true,
+                        verification.Signature,
+                        _activeConnection,
+                        this,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            foreach (SqlCipherMetadata cipherMetadata in pending.KeyDecryptions)
+            {
+                await SqlSecurityUtility.DecryptSymmetricKeyAsync(cipherMetadata, _activeConnection, this, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            CacheQueryMetadataIfNeeded();
+        }
+
+        /// <summary>
+        /// Adds the encryption metadata for the current query to the query metadata cache when applicable.
+        /// </summary>
+        private void CacheQueryMetadataIfNeeded()
+        {
+            // If we are not in Batch RPC mode, update the query cache with the encryption MD.
+            if (!_batchRPCMode && ShouldCacheEncryptionMetadata && _parameters?.Count > 0)
+            {
+                SqlQueryMetadataCache.GetInstance().AddQueryMetadata(this, ignoreQueriesWithReturnValueParams: true);
+            }
+        }
+
+        /// <summary>
+        /// Parses the result sets returned by sp_describe_parameter_encryption.
+        /// </summary>
+        /// <remarks>
+        /// Column master key signature verification and column encryption key decryption are not performed
+        /// here; they are recorded in <paramref name="pending"/> so that the caller can execute them either
+        /// synchronously or asynchronously. Deferring them also means no key store network call is made while
+        /// the describe-parameter-encryption reader is still positioned mid-stream.
+        /// </remarks>
+        /// <param name="ds">Resultset from calling to sp_describe_parameter_encryption</param>
+        /// <param name="describeParameterEncryptionRpcOriginalRpcMap">Readonly dictionary with the map of parameter encryption rpc requests with the corresponding original rpc requests.</param>
+        /// <param name="isRetry">Indicates if this is a retry from a failed call.</param>
+        /// <param name="pending">Collects the key store operations that the caller must complete</param>
+        private void ReadDescribeEncryptionParameterResultsCore(
+            SqlDataReader ds, // @TODO: Rename something more obvious
+            ReadOnlyDictionary<_SqlRPC, _SqlRPC> describeParameterEncryptionRpcOriginalRpcMap,
+            bool isRetry,
+            PendingColumnEncryptionKeyOperations pending)
         {
             // @TODO: This should be SqlTceCipherInfoTable
             Dictionary<int, SqlTceCipherInfoEntry> columnEncryptionKeyTable = new Dictionary<int, SqlTceCipherInfoEntry>();
@@ -820,7 +900,7 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 // 1) Read the first result set that contains the column encryption key list
-                bool enclaveMetadataExists = ReadDescribeEncryptionParameterResultsKeys(ds, columnEncryptionKeyTable);
+                bool enclaveMetadataExists = ReadDescribeEncryptionParameterResultsKeys(ds, columnEncryptionKeyTable, pending);
                 if (!enclaveMetadataExists && !ds.NextResult())
                 {
                     throw SQL.UnexpectedDescribeParamFormatParameterMetadata();
@@ -854,7 +934,7 @@ namespace Microsoft.Data.SqlClient
                 int receivedMetadataCount = 0;
                 if (!enclaveMetadataExists || ds.NextResult())
                 {
-                    receivedMetadataCount = ReadDescribeEncryptionParameterResultsMetadata(ds, rpc, columnEncryptionKeyTable);
+                    receivedMetadataCount = ReadDescribeEncryptionParameterResultsMetadata(ds, rpc, columnEncryptionKeyTable, pending);
                 }
 
                 // When the RPC object gets reused, the parameter array has more parameters that the valid params for the command.
@@ -902,12 +982,38 @@ namespace Microsoft.Data.SqlClient
                     }
                 }
             }
+        }
 
-            // If we are not in Batch RPC mode, update the query cache with the encryption MD.
-            if (!_batchRPCMode && ShouldCacheEncryptionMetadata && _parameters?.Count > 0)
+        /// <summary>
+        /// Key store operations discovered while parsing sp_describe_parameter_encryption results, deferred so
+        /// that they can be executed either synchronously or asynchronously.
+        /// </summary>
+        private sealed class PendingColumnEncryptionKeyOperations
+        {
+            /// <summary>Column master key signatures that must be verified.</summary>
+            internal List<ColumnMasterKeySignatureVerification> SignatureVerifications { get; } = new();
+
+            /// <summary>Column encryption keys that must be decrypted.</summary>
+            internal List<SqlCipherMetadata> KeyDecryptions { get; } = new();
+        }
+
+        /// <summary>
+        /// Describes a pending column master key signature verification.
+        /// </summary>
+        private readonly struct ColumnMasterKeySignatureVerification
+        {
+            internal ColumnMasterKeySignatureVerification(string keyStoreName, string keyPath, byte[] signature)
             {
-                SqlQueryMetadataCache.GetInstance().AddQueryMetadata(this, ignoreQueriesWithReturnValueParams: true);
+                KeyStoreName = keyStoreName;
+                KeyPath = keyPath;
+                Signature = signature;
             }
+
+            internal string KeyStoreName { get; }
+
+            internal string KeyPath { get; }
+
+            internal byte[] Signature { get; }
         }
 
         private void ReadDescribeEncryptionParameterResultsAttestation(SqlDataReader ds, bool isRetry)
@@ -960,7 +1066,8 @@ namespace Microsoft.Data.SqlClient
 
         private bool ReadDescribeEncryptionParameterResultsKeys(
             SqlDataReader ds,
-            Dictionary<int, SqlTceCipherInfoEntry> columnEncryptionKeyTable)
+            Dictionary<int, SqlTceCipherInfoEntry> columnEncryptionKeyTable,
+            PendingColumnEncryptionKeyOperations pending)
         {
             bool enclaveMetadataExists = true;
             while (ds.Read())
@@ -1060,13 +1167,10 @@ namespace Microsoft.Data.SqlClient
                             length: keySignatureLength);
                     }
 
-                    SqlSecurityUtility.VerifyColumnMasterKeySignature(
-                        providerName,
-                        keyPath,
-                        isEnclaveEnabled: isRequestedByEnclave,
-                        keySignature,
-                        _activeConnection,
-                        this);
+                    // Defer signature verification: it may reach a key store over the network and must not
+                    // run while this reader is still positioned mid-result-set.
+                    pending.SignatureVerifications.Add(
+                        new ColumnMasterKeySignatureVerification(providerName, keyPath, keySignature));
 
                     // Lookup the key, failing which throw an exception
                     // @TODO: Seriously, we *just* did this, why are we looking it up again??
@@ -1101,7 +1205,8 @@ namespace Microsoft.Data.SqlClient
         private int ReadDescribeEncryptionParameterResultsMetadata(
             SqlDataReader ds,
             _SqlRPC rpc,
-            Dictionary<int, SqlTceCipherInfoEntry> columnEncryptionKeyTable)
+            Dictionary<int, SqlTceCipherInfoEntry> columnEncryptionKeyTable,
+            PendingColumnEncryptionKeyOperations pending)
         {
             Debug.Assert(rpc is not null, "Describe Parameter Encryption requested for non-TCE spec proc");
 
@@ -1156,8 +1261,10 @@ namespace Microsoft.Data.SqlClient
                                 encryptionType: columnEncryptionType,
                                 normalizationRuleVersion: columnNormalizationRuleVersion);
 
-                            // Decrypt the symmetric key. This will also validate and throw if needed.
-                            SqlSecurityUtility.DecryptSymmetricKey(sqlParameter.CipherMetadata, _activeConnection, this);
+                            // Defer decryption of the symmetric key: it may reach a key store over the network
+                            // and must not run while this reader is still positioned mid-result-set. Decryption
+                            // also validates the metadata and will throw if it is invalid.
+                            pending.KeyDecryptions.Add(sqlParameter.CipherMetadata);
 
                             // This is effective only for _batchRPCMode even though we set it for
                             // non-_batchRPCMode also, since for non-_batchRPCMode, param options

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Encryption.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Encryption.cs
@@ -251,14 +251,18 @@ namespace Microsoft.Data.SqlClient
         /// column encryption key has been decrypted through the asynchronous key store provider APIs.
         /// </para>
         /// <para>
-        /// The work is dispatched with <see cref="Task.Run(Func{Task})"/> because the body issues blocking TDS
-        /// reads before reaching its first suspension point, and <c>PrepareForTransparentEncryption</c> is
-        /// invoked synchronously on the caller's thread by the asynchronous execution entry points. Dispatching
-        /// keeps that thread free, matching the behaviour of the continuation chain this replaced, while every
-        /// subsequent <c>await</c> releases the pooled thread for the duration of key store provider I/O.
+        /// The work is dispatched with <see cref="Task.Run(Func{Task})"/> rather than awaited inline because
+        /// the body issues blocking TDS reads before reaching a suspension point, and
+        /// <c>PrepareForTransparentEncryption</c> runs synchronously on the caller's thread under the
+        /// asynchronous execution entry points. Awaiting inline would run those reads on the caller's thread
+        /// whenever <paramref name="fetchInputParameterEncryptionInfoTask"/> is <c>null</c> or already
+        /// completed. This preserves the behaviour of the two continuations it replaced, which reached the
+        /// thread pool via <c>Task.Run</c> and via <c>ContinueWith</c> without
+        /// <see cref="TaskContinuationOptions.ExecuteSynchronously"/> respectively, so neither could run
+        /// inline either. Once dispatched, every <c>await</c> releases the pooled thread for the duration of
+        /// key store provider I/O.
         /// </para>
         /// </remarks>
-        /// <param name="returnTask">Receives the task representing the pending work</param>
         /// <param name="fetchInputParameterEncryptionInfoTask">
         /// Task representing the pending network write of the describe-parameter-encryption request, or
         /// <c>null</c> when that write completed synchronously.
@@ -267,21 +271,19 @@ namespace Microsoft.Data.SqlClient
         /// <param name="describeParameterEncryptionRpcOriginalRpcMap">Map of encryption RPC requests to their original RPC requests</param>
         /// <param name="describeParameterEncryptionNeeded">Whether describe parameter encryption was required</param>
         /// <param name="isRetry">Indicates if this is a retry from a failed call</param>
-        private void GetParameterEncryptionDataReader(
-            out Task returnTask,
+        /// <returns>A task that completes once the describe-parameter-encryption results have been consumed</returns>
+        private Task GetParameterEncryptionDataReaderAsync(
             Task fetchInputParameterEncryptionInfoTask,
             SqlDataReader describeParameterEncryptionDataReader,
             ReadOnlyDictionary<_SqlRPC, _SqlRPC> describeParameterEncryptionRpcOriginalRpcMap,
             bool describeParameterEncryptionNeeded,
-            bool isRetry)
-        {
-            returnTask = Task.Run(() => GetParameterEncryptionDataReaderAsync(
+            bool isRetry) =>
+            Task.Run(() => ConsumeDescribeParameterEncryptionResultsAsync(
                 fetchInputParameterEncryptionInfoTask,
                 describeParameterEncryptionDataReader,
                 describeParameterEncryptionRpcOriginalRpcMap,
                 describeParameterEncryptionNeeded,
                 isRetry));
-        }
 
         /// <summary>
         /// Awaits the describe-parameter-encryption request and consumes its results asynchronously.
@@ -292,7 +294,7 @@ namespace Microsoft.Data.SqlClient
         /// while consuming the results run the finally block but leave the cached async state alone. These
         /// semantics are inherited from the callback-based continuation this method replaced.
         /// </remarks>
-        private async Task GetParameterEncryptionDataReaderAsync(
+        private async Task ConsumeDescribeParameterEncryptionResultsAsync(
             Task fetchInputParameterEncryptionInfoTask,
             SqlDataReader describeParameterEncryptionDataReader,
             ReadOnlyDictionary<_SqlRPC, _SqlRPC> describeParameterEncryptionRpcOriginalRpcMap,
@@ -731,8 +733,7 @@ namespace Microsoft.Data.SqlClient
                         // execution pending. Note that this should be done outside the task's
                         // continuation delegate.
                         processFinallyBlock = false;
-                        GetParameterEncryptionDataReader(
-                            out returnTask,
+                        returnTask = GetParameterEncryptionDataReaderAsync(
                             fetchInputParameterEncryptionInfoTask,
                             describeParameterEncryptionDataReader,
                             describeParameterEncryptionRpcOriginalRpcMap,
@@ -751,8 +752,7 @@ namespace Microsoft.Data.SqlClient
                             // execution pending. Note that this should be done outside the task's
                             // continuation delegate.
                             processFinallyBlock = false;
-                            GetParameterEncryptionDataReader(
-                                out returnTask,
+                            returnTask = GetParameterEncryptionDataReaderAsync(
                                 fetchInputParameterEncryptionInfoTask: null,
                                 describeParameterEncryptionDataReader,
                                 describeParameterEncryptionRpcOriginalRpcMap,

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Encryption.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Encryption.cs
@@ -345,7 +345,7 @@ namespace Microsoft.Data.SqlClient
                         describeParameterEncryptionDataReader,
                         describeParameterEncryptionRpcOriginalRpcMap,
                         isRetry,
-                        CancellationToken.None)
+                        _asyncExecutionCancellationToken)
                     .ConfigureAwait(false);
 
                 #if DEBUG

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Encryption.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Encryption.cs
@@ -557,6 +557,105 @@ namespace Microsoft.Data.SqlClient
             out bool usedCache,
             bool isRetry)
         {
+            returnTask = null;
+            usedCache = false;
+
+            // If we are not in _batchRPC and not already retrying, attempt to fetch the cipher MD for
+            // each parameter from the cache. If this succeeds then return immediately, otherwise just
+            // fall back to the full crypto MD discovery.
+            if (!_batchRPCMode && !isRetry && _parameters?.Count > 0)
+            {
+                SqlQueryMetadataCache cache = SqlQueryMetadataCache.GetInstance();
+
+                if (!isAsync)
+                {
+                    if (cache.GetQueryMetadataIfExists(this))
+                    {
+                        usedCache = true;
+                        return;
+                    }
+                }
+                else if (cache.TryGetCachedQueryMetadata(this, out SqlQueryMetadataCache.CachedQueryMetadata metadata))
+                {
+                    // The cached metadata matched, but the column encryption keys still have to be
+                    // loaded, which may require key store network I/O. Hand the rest of the work to a
+                    // task so that the caller's thread is not blocked on it.
+                    usedCache = true;
+                    returnTask = CompleteCachedQueryMetadataAsync(
+                        metadata,
+                        timeout,
+                        completion,
+                        asyncWrite,
+                        isRetry);
+                    return;
+                }
+            }
+
+            PrepareForTransparentEncryptionCore(
+                isAsync,
+                timeout,
+                completion,
+                out returnTask,
+                asyncWrite,
+                isRetry);
+        }
+
+        /// <summary>
+        /// Finishes a query metadata cache lookup whose column encryption keys still had to be loaded,
+        /// falling back to a full describe parameter encryption round trip if the cached key information
+        /// turned out to be stale.
+        /// </summary>
+        /// <remarks>
+        /// The command reports <c>usedCache = true</c> even when this method falls back, because the
+        /// caller has already returned by the time the fallback is discovered. That is deliberately
+        /// conservative: over-reporting a cache hit can only cause one additional retry attempt of an
+        /// already failing execution, whereas under-reporting it would suppress the
+        /// <see cref="TdsEnums.TCE_CONVERSION_ERROR_CLIENT_RETRY"/> retry that a genuine cache hit needs.
+        /// </remarks>
+        private async Task CompleteCachedQueryMetadataAsync(
+            SqlQueryMetadataCache.CachedQueryMetadata metadata,
+            int timeout,
+            TaskCompletionSource<object> completion,
+            bool asyncWrite,
+            bool isRetry)
+        {
+            bool cacheHit = await SqlQueryMetadataCache.GetInstance()
+                .CompleteCachedQueryMetadataAsync(this, metadata, _asyncExecutionCancellationToken)
+                .ConfigureAwait(false);
+
+            if (cacheHit)
+            {
+                return;
+            }
+
+            // The cached key information was stale, so run the full describe parameter encryption
+            // round trip. It issues blocking TDS writes, but we are already off the caller's thread.
+            PrepareForTransparentEncryptionCore(
+                isAsync: true,
+                timeout,
+                completion,
+                out Task describeTask,
+                asyncWrite,
+                isRetry);
+
+            if (describeTask is not null)
+            {
+                await describeTask.ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Performs transparent parameter encryption preparation by issuing a full
+        /// sp_describe_parameter_encryption round trip, bypassing the query metadata cache.
+        /// </summary>
+        private void PrepareForTransparentEncryptionCore(
+            bool isAsync,
+            int timeout,
+            TaskCompletionSource<object> completion, // @TODO: Only used for debug checks
+            out Task returnTask,
+            bool asyncWrite,
+            bool isRetry)
+        {
             Debug.Assert(_activeConnection != null,
                 "_activeConnection should not be null in PrepareForTransparentEncryption.");
             Debug.Assert(_activeConnection.Parser != null,
@@ -574,18 +673,6 @@ namespace Microsoft.Data.SqlClient
             bool describeParameterEncryptionNeeded = false;
             SqlDataReader describeParameterEncryptionDataReader = null;
             returnTask = null;
-            usedCache = false;
-
-            // If we are not in _batchRPC and not already retrying, attempt to fetch the cipher MD for each parameter from the cache.
-            // If this succeeds then return immediately, otherwise just fall back to the full crypto MD discovery.
-            if (!_batchRPCMode &&
-                !isRetry &&
-                _parameters?.Count > 0 &&
-                SqlQueryMetadataCache.GetInstance().GetQueryMetadataIfExists(this))
-            {
-                usedCache = true;
-                return;
-            }
 
             // A flag to indicate if finallyblock needs to execute.
             bool processFinallyBlock = true;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Encryption.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Encryption.cs
@@ -262,6 +262,14 @@ namespace Microsoft.Data.SqlClient
         /// inline either. Once dispatched, every <c>await</c> releases the pooled thread for the duration of
         /// key store provider I/O.
         /// </para>
+        /// <para>
+        /// Do not "optimise" this into an inline <c>await</c> of
+        /// <paramref name="fetchInputParameterEncryptionInfoTask"/> in order to save a thread pool dispatch.
+        /// That task is completed by the network write callback, so an inline continuation would run the
+        /// blocking TDS reads below on an SNI callback thread. The replaced <c>ContinueWith</c> deliberately
+        /// omitted <see cref="TaskContinuationOptions.ExecuteSynchronously"/> for exactly this reason. The
+        /// dispatch this costs is negligible next to the round trip it accompanies.
+        /// </para>
         /// </remarks>
         /// <param name="fetchInputParameterEncryptionInfoTask">
         /// Task representing the pending network write of the describe-parameter-encryption request, or
@@ -271,19 +279,22 @@ namespace Microsoft.Data.SqlClient
         /// <param name="describeParameterEncryptionRpcOriginalRpcMap">Map of encryption RPC requests to their original RPC requests</param>
         /// <param name="describeParameterEncryptionNeeded">Whether describe parameter encryption was required</param>
         /// <param name="isRetry">Indicates if this is a retry from a failed call</param>
+        /// <param name="cancellationToken">Token used to request cancellation of the key store operations</param>
         /// <returns>A task that completes once the describe-parameter-encryption results have been consumed</returns>
         private Task GetParameterEncryptionDataReaderAsync(
             Task fetchInputParameterEncryptionInfoTask,
             SqlDataReader describeParameterEncryptionDataReader,
             ReadOnlyDictionary<_SqlRPC, _SqlRPC> describeParameterEncryptionRpcOriginalRpcMap,
             bool describeParameterEncryptionNeeded,
-            bool isRetry) =>
+            bool isRetry,
+            CancellationToken cancellationToken) =>
             Task.Run(() => ConsumeDescribeParameterEncryptionResultsAsync(
                 fetchInputParameterEncryptionInfoTask,
                 describeParameterEncryptionDataReader,
                 describeParameterEncryptionRpcOriginalRpcMap,
                 describeParameterEncryptionNeeded,
-                isRetry));
+                isRetry,
+                cancellationToken));
 
         /// <summary>
         /// Awaits the describe-parameter-encryption request and consumes its results asynchronously.
@@ -299,7 +310,8 @@ namespace Microsoft.Data.SqlClient
             SqlDataReader describeParameterEncryptionDataReader,
             ReadOnlyDictionary<_SqlRPC, _SqlRPC> describeParameterEncryptionRpcOriginalRpcMap,
             bool describeParameterEncryptionNeeded,
-            bool isRetry)
+            bool isRetry,
+            CancellationToken cancellationToken)
         {
             if (fetchInputParameterEncryptionInfoTask is not null)
             {
@@ -347,7 +359,7 @@ namespace Microsoft.Data.SqlClient
                         describeParameterEncryptionDataReader,
                         describeParameterEncryptionRpcOriginalRpcMap,
                         isRetry,
-                        _asyncExecutionCancellationToken)
+                        cancellationToken)
                     .ConfigureAwait(false);
 
                 #if DEBUG
@@ -562,6 +574,11 @@ namespace Microsoft.Data.SqlClient
             returnTask = null;
             usedCache = false;
 
+            // Capture the caller's cancellation token once, here, while we are still on the thread that
+            // started the execution. Everything below may run after the operation has completed and
+            // cleared the field, so reading it later could silently observe CancellationToken.None.
+            CancellationToken cancellationToken = isAsync ? _asyncExecutionCancellationToken : CancellationToken.None;
+
             // If we are not in _batchRPC and not already retrying, attempt to fetch the cipher MD for
             // each parameter from the cache. If this succeeds then return immediately, otherwise just
             // fall back to the full crypto MD discovery.
@@ -588,7 +605,8 @@ namespace Microsoft.Data.SqlClient
                         timeout,
                         completion,
                         asyncWrite,
-                        isRetry);
+                        isRetry,
+                        cancellationToken);
                     return;
                 }
             }
@@ -599,7 +617,8 @@ namespace Microsoft.Data.SqlClient
                 completion,
                 out returnTask,
                 asyncWrite,
-                isRetry);
+                isRetry,
+                cancellationToken);
         }
 
         /// <summary>
@@ -619,10 +638,11 @@ namespace Microsoft.Data.SqlClient
             int timeout,
             TaskCompletionSource<object> completion,
             bool asyncWrite,
-            bool isRetry)
+            bool isRetry,
+            CancellationToken cancellationToken)
         {
             bool cacheHit = await SqlQueryMetadataCache.GetInstance()
-                .CompleteCachedQueryMetadataAsync(this, metadata, _asyncExecutionCancellationToken)
+                .CompleteCachedQueryMetadataAsync(this, metadata, cancellationToken)
                 .ConfigureAwait(false);
 
             if (cacheHit)
@@ -638,7 +658,8 @@ namespace Microsoft.Data.SqlClient
                 completion,
                 out Task describeTask,
                 asyncWrite,
-                isRetry);
+                isRetry,
+                cancellationToken);
 
             if (describeTask is not null)
             {
@@ -650,13 +671,18 @@ namespace Microsoft.Data.SqlClient
         /// Performs transparent parameter encryption preparation by issuing a full
         /// sp_describe_parameter_encryption round trip, bypassing the query metadata cache.
         /// </summary>
+        /// <remarks>
+        /// <paramref name="cancellationToken"/> is captured by the caller while it is still on the thread
+        /// that started the execution, and is used only by the asynchronous key store provider calls.
+        /// </remarks>
         private void PrepareForTransparentEncryptionCore(
             bool isAsync,
             int timeout,
             TaskCompletionSource<object> completion, // @TODO: Only used for debug checks
             out Task returnTask,
             bool asyncWrite,
-            bool isRetry)
+            bool isRetry,
+            CancellationToken cancellationToken)
         {
             Debug.Assert(_activeConnection != null,
                 "_activeConnection should not be null in PrepareForTransparentEncryption.");
@@ -738,7 +764,8 @@ namespace Microsoft.Data.SqlClient
                             describeParameterEncryptionDataReader,
                             describeParameterEncryptionRpcOriginalRpcMap,
                             describeParameterEncryptionNeeded,
-                            isRetry);
+                            isRetry,
+                            cancellationToken);
 
                         decrementAsyncCountInFinallyBlock = false;
                     }
@@ -757,7 +784,8 @@ namespace Microsoft.Data.SqlClient
                                 describeParameterEncryptionDataReader,
                                 describeParameterEncryptionRpcOriginalRpcMap,
                                 describeParameterEncryptionNeeded,
-                                isRetry);
+                                isRetry,
+                                cancellationToken);
 
                             decrementAsyncCountInFinallyBlock = false;
                         }
@@ -863,20 +891,23 @@ namespace Microsoft.Data.SqlClient
             PendingColumnEncryptionKeyOperations pending = new PendingColumnEncryptionKeyOperations();
             ReadDescribeEncryptionParameterResultsCore(ds, describeParameterEncryptionRpcOriginalRpcMap, isRetry, pending);
 
-            foreach (ColumnMasterKeySignatureVerification verification in pending.SignatureVerifications)
+            IReadOnlyList<ColumnMasterKeySignatureVerification> verifications = pending.SignatureVerifications;
+            for (int i = 0; i < verifications.Count; i++)
             {
+                ColumnMasterKeySignatureVerification verification = verifications[i];
                 SqlSecurityUtility.VerifyColumnMasterKeySignature(
                     verification.KeyStoreName,
                     verification.KeyPath,
-                    isEnclaveEnabled: true,
+                    verification.IsEnclaveEnabled,
                     verification.Signature,
                     _activeConnection,
                     this);
             }
 
-            foreach (SqlCipherMetadata cipherMetadata in pending.KeyDecryptions)
+            IReadOnlyList<SqlCipherMetadata> keyDecryptions = pending.KeyDecryptions;
+            for (int i = 0; i < keyDecryptions.Count; i++)
             {
-                SqlSecurityUtility.DecryptSymmetricKey(cipherMetadata, _activeConnection, this);
+                SqlSecurityUtility.DecryptSymmetricKey(keyDecryptions[i], _activeConnection, this);
             }
 
             CacheQueryMetadataIfNeeded();
@@ -904,12 +935,14 @@ namespace Microsoft.Data.SqlClient
             PendingColumnEncryptionKeyOperations pending = new PendingColumnEncryptionKeyOperations();
             ReadDescribeEncryptionParameterResultsCore(ds, describeParameterEncryptionRpcOriginalRpcMap, isRetry, pending);
 
-            foreach (ColumnMasterKeySignatureVerification verification in pending.SignatureVerifications)
+            IReadOnlyList<ColumnMasterKeySignatureVerification> verifications = pending.SignatureVerifications;
+            for (int i = 0; i < verifications.Count; i++)
             {
+                ColumnMasterKeySignatureVerification verification = verifications[i];
                 await SqlSecurityUtility.VerifyColumnMasterKeySignatureAsync(
                         verification.KeyStoreName,
                         verification.KeyPath,
-                        isEnclaveEnabled: true,
+                        verification.IsEnclaveEnabled,
                         verification.Signature,
                         _activeConnection,
                         this,
@@ -917,9 +950,15 @@ namespace Microsoft.Data.SqlClient
                     .ConfigureAwait(false);
             }
 
-            foreach (SqlCipherMetadata cipherMetadata in pending.KeyDecryptions)
+            // Decrypted sequentially rather than with Task.WhenAll. Distinct SqlCipherMetadata entries
+            // frequently share a column encryption key, and SqlSymmetricKeyCache.GetKeyAsync deliberately
+            // does not hold its gate across provider I/O, so concurrent misses for the same key would each
+            // issue their own key store call. Sequential decryption lets the first result populate the cache
+            // for the rest, which matters more than overlapping the few distinct keys a query uses.
+            IReadOnlyList<SqlCipherMetadata> keyDecryptions = pending.KeyDecryptions;
+            for (int i = 0; i < keyDecryptions.Count; i++)
             {
-                await SqlSecurityUtility.DecryptSymmetricKeyAsync(cipherMetadata, _activeConnection, this, cancellationToken)
+                await SqlSecurityUtility.DecryptSymmetricKeyAsync(keyDecryptions[i], _activeConnection, this, cancellationToken)
                     .ConfigureAwait(false);
             }
 
@@ -942,10 +981,19 @@ namespace Microsoft.Data.SqlClient
         /// Parses the result sets returned by sp_describe_parameter_encryption.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Column master key signature verification and column encryption key decryption are not performed
         /// here; they are recorded in <paramref name="pending"/> so that the caller can execute them either
         /// synchronously or asynchronously. Deferring them also means no key store network call is made while
         /// the describe-parameter-encryption reader is still positioned mid-stream.
+        /// </para>
+        /// <para>
+        /// Deferring these operations changes which exception surfaces when a query hits more than one
+        /// problem. Previously verification and decryption were interleaved with parsing, so a bad signature
+        /// on the first key was raised before the parameter metadata result set was parsed at all. Now parsing
+        /// always completes first, so a malformed result set is reported in preference to a key store failure.
+        /// The set of exceptions that can be thrown, and the state left behind on failure, are unchanged.
+        /// </para>
         /// </remarks>
         /// <param name="ds">Resultset from calling to sp_describe_parameter_encryption</param>
         /// <param name="describeParameterEncryptionRpcOriginalRpcMap">Readonly dictionary with the map of parameter encryption rpc requests with the corresponding original rpc requests.</param>
@@ -1077,11 +1125,30 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         private sealed class PendingColumnEncryptionKeyOperations
         {
+            private List<ColumnMasterKeySignatureVerification> _signatureVerifications;
+            private List<SqlCipherMetadata> _keyDecryptions;
+
             /// <summary>Column master key signatures that must be verified.</summary>
-            internal List<ColumnMasterKeySignatureVerification> SignatureVerifications { get; } = new();
+            internal IReadOnlyList<ColumnMasterKeySignatureVerification> SignatureVerifications =>
+                (IReadOnlyList<ColumnMasterKeySignatureVerification>)_signatureVerifications ??
+                Array.Empty<ColumnMasterKeySignatureVerification>();
 
             /// <summary>Column encryption keys that must be decrypted.</summary>
-            internal List<SqlCipherMetadata> KeyDecryptions { get; } = new();
+            internal IReadOnlyList<SqlCipherMetadata> KeyDecryptions =>
+                (IReadOnlyList<SqlCipherMetadata>)_keyDecryptions ?? Array.Empty<SqlCipherMetadata>();
+
+            /// <summary>
+            /// Records a column master key signature that must be verified before the query runs.
+            /// </summary>
+            internal void AddSignatureVerification(string keyStoreName, string keyPath, bool isEnclaveEnabled, byte[] signature) =>
+                (_signatureVerifications ??= new List<ColumnMasterKeySignatureVerification>())
+                    .Add(new ColumnMasterKeySignatureVerification(keyStoreName, keyPath, isEnclaveEnabled, signature));
+
+            /// <summary>
+            /// Records a column encryption key that must be decrypted before the query runs.
+            /// </summary>
+            internal void AddKeyDecryption(SqlCipherMetadata cipherMetadata) =>
+                (_keyDecryptions ??= new List<SqlCipherMetadata>()).Add(cipherMetadata);
         }
 
         /// <summary>
@@ -1089,16 +1156,23 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         private readonly struct ColumnMasterKeySignatureVerification
         {
-            internal ColumnMasterKeySignatureVerification(string keyStoreName, string keyPath, byte[] signature)
+            internal ColumnMasterKeySignatureVerification(string keyStoreName, string keyPath, bool isEnclaveEnabled, byte[] signature)
             {
                 KeyStoreName = keyStoreName;
                 KeyPath = keyPath;
+                IsEnclaveEnabled = isEnclaveEnabled;
                 Signature = signature;
             }
 
             internal string KeyStoreName { get; }
 
             internal string KeyPath { get; }
+
+            /// <summary>
+            /// Whether the server reported that this key is required by the enclave. Carried explicitly
+            /// rather than assumed, because it selects which signature the key store validates.
+            /// </summary>
+            internal bool IsEnclaveEnabled { get; }
 
             internal byte[] Signature { get; }
         }
@@ -1256,8 +1330,7 @@ namespace Microsoft.Data.SqlClient
 
                     // Defer signature verification: it may reach a key store over the network and must not
                     // run while this reader is still positioned mid-result-set.
-                    pending.SignatureVerifications.Add(
-                        new ColumnMasterKeySignatureVerification(providerName, keyPath, keySignature));
+                    pending.AddSignatureVerification(providerName, keyPath, isRequestedByEnclave, keySignature);
 
                     // Lookup the key, failing which throw an exception
                     // @TODO: Seriously, we *just* did this, why are we looking it up again??
@@ -1351,7 +1424,7 @@ namespace Microsoft.Data.SqlClient
                             // Defer decryption of the symmetric key: it may reach a key store over the network
                             // and must not run while this reader is still positioned mid-result-set. Decryption
                             // also validates the metadata and will throw if it is invalid.
-                            pending.KeyDecryptions.Add(sqlParameter.CipherMetadata);
+                            pending.AddKeyDecryption(sqlParameter.CipherMetadata);
 
                             // This is effective only for _batchRPCMode even though we set it for
                             // non-_batchRPCMode also, since for non-_batchRPCMode, param options

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.NonQuery.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.NonQuery.cs
@@ -331,6 +331,8 @@ namespace Microsoft.Data.SqlClient
 
         private void CleanupAfterExecuteNonQueryAsync(Task<int> task, TaskCompletionSource<int> source, Guid operationId)
         {
+            _asyncExecutionCancellationToken = default;
+
             if (task.IsFaulted)
             {
                 Exception e = task.Exception?.InnerException;
@@ -696,6 +698,8 @@ namespace Microsoft.Data.SqlClient
 
                 registration = cancellationToken.Register(callback: s_cancelIgnoreFailure, state: this);
             }
+
+            _asyncExecutionCancellationToken = cancellationToken;
 
             Task<int> returnedTask = source.Task;
             returnedTask = RegisterForConnectionCloseNotification(returnedTask);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Reader.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Reader.cs
@@ -1030,11 +1030,16 @@ namespace Microsoft.Data.SqlClient
         /// <summary>
         /// Test-only failpoint that forces a retryable enclave failure during package generation.
         /// </summary>
+        /// <remarks>
+        /// Both guards are required and are not redundant: <see cref="ConditionalAttribute"/> elides the
+        /// call sites in non-DEBUG builds, while the <c>#if DEBUG</c> is needed because the body still
+        /// compiles there and the field it reads is itself DEBUG-only.
+        /// </remarks>
+        // @TODO: These should be wrapped with something other than DEBUG since we don't even run tests in debug mode
         [Conditional("DEBUG")]
         private void ThrowIfForcedRetryableEnclaveQueryExecutionException()
         {
             #if DEBUG
-            // @TODO: These should be wrapped with something other than DEBUG since we don't even run tests in debug mode
             // Test-only code for forcing a retryable exception to occur
             if (_forceRetryableEnclaveQueryExecutionExceptionDuringGenerateEnclavePackage)
             {
@@ -1855,6 +1860,11 @@ namespace Microsoft.Data.SqlClient
                 // The remainder of the execution issues blocking TDS writes, so it must never run inline on
                 // the caller's thread (nor on a network callback thread). Task.Run reproduces the thread pool
                 // hand-off that the previous ContinueWith-based continuation provided.
+                // Capture the caller's cancellation token here, on the thread that started the
+                // execution. The body below runs after a thread pool hand-off and may observe the field
+                // already cleared by the execution's cleanup continuation.
+                CancellationToken cancellationToken = isAsync ? _asyncExecutionCancellationToken : CancellationToken.None;
+
                 task = Task.Run(() => ContinueRunExecuteReaderTdsAsync(
                     describeParameterEncryptionTask,
                     cmdBehavior,
@@ -1865,7 +1875,8 @@ namespace Microsoft.Data.SqlClient
                     parameterEncryptionStart,
                     asyncWrite,
                     isRetry,
-                    ds));
+                    ds,
+                    cancellationToken));
 
                 return ds;
             }
@@ -1912,7 +1923,8 @@ namespace Microsoft.Data.SqlClient
             long parameterEncryptionStart,
             bool asyncWrite,
             bool isRetry,
-            SqlDataReader ds)
+            SqlDataReader ds,
+            CancellationToken cancellationToken)
         {
             try
             {
@@ -1920,11 +1932,15 @@ namespace Microsoft.Data.SqlClient
             }
             catch
             {
+                // Unlike ConsumeDescribeParameterEncryptionResultsAsync, cancellation is reset here as
+                // well as failure. That asymmetry is deliberate: this method replaced
+                // AsyncHelper.ContinueTaskWithState, which supplied an onCancellation callback, whereas
+                // that one replaced CreateContinuationTaskWithState, which did not.
                 CachedAsyncState?.ResetAsyncState();
                 throw;
             }
 
-            await GenerateEnclavePackageAsync(_asyncExecutionCancellationToken).ConfigureAwait(false);
+            await GenerateEnclavePackageAsync(cancellationToken).ConfigureAwait(false);
 
             RunExecuteReaderTds(
                 cmdBehavior,

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Reader.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Reader.cs
@@ -893,46 +893,17 @@ namespace Microsoft.Data.SqlClient
 
         private void GenerateEnclavePackage()
         {
-            // Skip processing if there are no keys to send to enclave
-            if (keysToBeSentToEnclave is null || keysToBeSentToEnclave.IsEmpty)
+            if (!TryPrepareEnclavePackageGeneration(
+                    out string enclaveType,
+                    out SqlConnectionAttestationProtocol attestationProtocol))
             {
                 return;
-            }
-
-            // Validate attestation url is provided when necessary
-            if (string.IsNullOrWhiteSpace(_activeConnection.EnclaveAttestationUrl) &&
-                _activeConnection.AttestationProtocol is not SqlConnectionAttestationProtocol.None)
-            {
-                throw SQL.NoAttestationUrlSpecifiedForEnclaveBasedQueryGeneratingEnclavePackage(
-                    _activeConnection.Parser.EnclaveType);
-            }
-
-            // Validate enclave type
-            string enclaveType = _activeConnection.Parser.EnclaveType;
-            if (string.IsNullOrWhiteSpace(enclaveType))
-            {
-                throw SQL.EnclaveTypeNullForEnclaveBasedQuery();
-            }
-
-            // Validate protocol type
-            SqlConnectionAttestationProtocol attestationProtocol = _activeConnection.AttestationProtocol;
-            if (attestationProtocol is SqlConnectionAttestationProtocol.NotSpecified)
-            {
-                throw SQL.AttestationProtocolNotSpecifiedForGeneratingEnclavePackage();
             }
 
             // Generate the enclave package
             try
             {
-                #if DEBUG
-                // @TODO: These should be wrapped with something other than DEBUG since we don't even run tests in debug mode
-                // Test-only code for forcing a retryable exception to occur
-                if (_forceRetryableEnclaveQueryExecutionExceptionDuringGenerateEnclavePackage)
-                {
-                    _forceRetryableEnclaveQueryExecutionExceptionDuringGenerateEnclavePackage = false;
-                    throw new EnclaveDelegate.RetryableEnclaveQueryExecutionException("testing", null);
-                }
-                #endif
+                ThrowIfForcedRetryableEnclaveQueryExecutionException();
 
                 enclavePackage = EnclaveDelegate.Instance.GenerateEnclavePackage(
                     attestationProtocol,
@@ -951,6 +922,124 @@ namespace Microsoft.Data.SqlClient
             {
                 throw SQL.ExceptionWhenGeneratingEnclavePackage(e);
             }
+        }
+
+        /// <summary>
+        /// Asynchronously generates the enclave package for the current command.
+        /// </summary>
+        /// <remarks>
+        /// Async counterpart of <see cref="GenerateEnclavePackage"/>. Column encryption keys destined for the
+        /// enclave are decrypted through the asynchronous key store provider APIs, so a key store that performs
+        /// network I/O does not block a thread while the package is generated.
+        /// </remarks>
+        /// <param name="cancellationToken">Token used to request cancellation of the operation</param>
+        private async Task GenerateEnclavePackageAsync(CancellationToken cancellationToken)
+        {
+            if (!TryPrepareEnclavePackageGeneration(
+                    out string enclaveType,
+                    out SqlConnectionAttestationProtocol attestationProtocol))
+            {
+                return;
+            }
+
+            // Generate the enclave package
+            try
+            {
+                ThrowIfForcedRetryableEnclaveQueryExecutionException();
+
+                enclavePackage = await EnclaveDelegate.Instance.GenerateEnclavePackageAsync(
+                        attestationProtocol,
+                        keysToBeSentToEnclave,
+                        CommandText,
+                        enclaveType,
+                        GetEnclaveSessionParameters(),
+                        _activeConnection,
+                        command: this,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (EnclaveDelegate.RetryableEnclaveQueryExecutionException)
+            {
+                throw;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Propagate cancellation unwrapped so the returned Task is cancelled rather than faulted
+                // with an enclave-specific exception that would suggest an attestation problem.
+                throw;
+            }
+            catch (Exception e)
+            {
+                throw SQL.ExceptionWhenGeneratingEnclavePackage(e);
+            }
+        }
+
+        /// <summary>
+        /// Validates the connection state required to generate an enclave package.
+        /// </summary>
+        /// <remarks>
+        /// Shared by the synchronous and asynchronous enclave package generation paths so that both perform
+        /// identical validation and throw identical exceptions.
+        /// </remarks>
+        /// <param name="enclaveType">The validated enclave type reported by the server</param>
+        /// <param name="attestationProtocol">The validated attestation protocol configured on the connection</param>
+        /// <returns>
+        /// <c>false</c> when there are no keys to send to the enclave and package generation must be skipped;
+        /// otherwise <c>true</c>.
+        /// </returns>
+        private bool TryPrepareEnclavePackageGeneration(
+            out string enclaveType,
+            out SqlConnectionAttestationProtocol attestationProtocol)
+        {
+            enclaveType = null;
+            attestationProtocol = SqlConnectionAttestationProtocol.NotSpecified;
+
+            // Skip processing if there are no keys to send to enclave
+            if (keysToBeSentToEnclave is null || keysToBeSentToEnclave.IsEmpty)
+            {
+                return false;
+            }
+
+            // Validate attestation url is provided when necessary
+            if (string.IsNullOrWhiteSpace(_activeConnection.EnclaveAttestationUrl) &&
+                _activeConnection.AttestationProtocol is not SqlConnectionAttestationProtocol.None)
+            {
+                throw SQL.NoAttestationUrlSpecifiedForEnclaveBasedQueryGeneratingEnclavePackage(
+                    _activeConnection.Parser.EnclaveType);
+            }
+
+            // Validate enclave type
+            enclaveType = _activeConnection.Parser.EnclaveType;
+            if (string.IsNullOrWhiteSpace(enclaveType))
+            {
+                throw SQL.EnclaveTypeNullForEnclaveBasedQuery();
+            }
+
+            // Validate protocol type
+            attestationProtocol = _activeConnection.AttestationProtocol;
+            if (attestationProtocol is SqlConnectionAttestationProtocol.NotSpecified)
+            {
+                throw SQL.AttestationProtocolNotSpecifiedForGeneratingEnclavePackage();
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Test-only failpoint that forces a retryable enclave failure during package generation.
+        /// </summary>
+        [Conditional("DEBUG")]
+        private void ThrowIfForcedRetryableEnclaveQueryExecutionException()
+        {
+            #if DEBUG
+            // @TODO: These should be wrapped with something other than DEBUG since we don't even run tests in debug mode
+            // Test-only code for forcing a retryable exception to occur
+            if (_forceRetryableEnclaveQueryExecutionExceptionDuringGenerateEnclavePackage)
+            {
+                _forceRetryableEnclaveQueryExecutionExceptionDuringGenerateEnclavePackage = false;
+                throw new EnclaveDelegate.RetryableEnclaveQueryExecutionException("testing", null);
+            }
+            #endif
         }
 
         private Task<SqlDataReader> InternalExecuteReaderAsync(
@@ -1759,55 +1848,21 @@ namespace Microsoft.Data.SqlClient
                 // @TODO: I guess this means async execution? Using tasks as the primary means of determining async vs sync is clunky. It would be better to have separate async vs sync pathways.
                 long parameterEncryptionStart = ADP.TimerCurrent();
 
-                // @TODO: This can totally be a non-generic TCS
-                // @TODO: This is a prime candidate for proper async-await execution
-                TaskCompletionSource<object> completion = new TaskCompletionSource<object>();
-                AsyncHelper.ContinueTaskWithState(
-                    taskToContinue: describeParameterEncryptionTask,
-                    taskCompletionSource: completion,
-                    state: this,
-                    onSuccess: sqlCommand =>
-                    {
-                        sqlCommand.GenerateEnclavePackage();
-                        sqlCommand.RunExecuteReaderTds(
-                            cmdBehavior,
-                            runBehavior,
-                            returnStream,
-                            isAsync,
-                            TdsParserStaticMethods.GetRemainingTimeout(timeout, parameterEncryptionStart),
-                            out Task subTask,
-                            asyncWrite,
-                            isRetry,
-                            ds);
+                // The remainder of the execution issues blocking TDS writes, so it must never run inline on
+                // the caller's thread (nor on a network callback thread). Task.Run reproduces the thread pool
+                // hand-off that the previous ContinueWith-based continuation provided.
+                task = Task.Run(() => ContinueRunExecuteReaderTdsAsync(
+                    describeParameterEncryptionTask,
+                    cmdBehavior,
+                    runBehavior,
+                    returnStream,
+                    isAsync,
+                    timeout,
+                    parameterEncryptionStart,
+                    asyncWrite,
+                    isRetry,
+                    ds));
 
-                        if (subTask is null)
-                        {
-                            // @TODO: Why would this ever be the case? We should structure this so that it doesn't need to be checked.
-                            completion.SetResult(null);
-                        }
-                        else
-                        {
-                            AsyncHelper.ContinueTaskWithState(
-                                taskToContinue: subTask,
-                                taskCompletionSource: completion,
-                                state: completion,
-                                onSuccess: static state => state.SetResult(null));
-                        }
-                    },
-                    onFailure: static (sqlCommand, exception) =>
-                    {
-                        sqlCommand.CachedAsyncState?.ResetAsyncState();
-                        if (exception is not null)
-                        {
-                            throw exception;
-                        }
-                    },
-                    onCancellation: static sqlCommand =>
-                    {
-                        sqlCommand.CachedAsyncState?.ResetAsyncState();
-                    });
-
-                task = completion.Task;
                 return ds;
             }
             else
@@ -1824,6 +1879,63 @@ namespace Microsoft.Data.SqlClient
                     asyncWrite,
                     isRetry,
                     ds);
+            }
+        }
+
+        /// <summary>
+        /// Completes transparent parameter encryption processing and then executes the command.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Awaits the describe-parameter-encryption round trip, generates the enclave package using the
+        /// asynchronous key store provider APIs, and then issues the actual command execution. This replaces a
+        /// callback-based continuation chain so that key store network I/O yields the thread instead of
+        /// blocking it.
+        /// </para>
+        /// <para>
+        /// Error semantics match the previous continuation chain: a failure or cancellation of the
+        /// describe-parameter-encryption round trip resets the cached async state, while a failure that occurs
+        /// after that point is surfaced without resetting it.
+        /// </para>
+        /// </remarks>
+        private async Task ContinueRunExecuteReaderTdsAsync(
+            Task describeParameterEncryptionTask,
+            CommandBehavior cmdBehavior,
+            RunBehavior runBehavior,
+            bool returnStream,
+            bool isAsync,
+            int timeout,
+            long parameterEncryptionStart,
+            bool asyncWrite,
+            bool isRetry,
+            SqlDataReader ds)
+        {
+            try
+            {
+                await describeParameterEncryptionTask.ConfigureAwait(false);
+            }
+            catch
+            {
+                CachedAsyncState?.ResetAsyncState();
+                throw;
+            }
+
+            await GenerateEnclavePackageAsync(CancellationToken.None).ConfigureAwait(false);
+
+            RunExecuteReaderTds(
+                cmdBehavior,
+                runBehavior,
+                returnStream,
+                isAsync,
+                TdsParserStaticMethods.GetRemainingTimeout(timeout, parameterEncryptionStart),
+                out Task subTask,
+                asyncWrite,
+                isRetry,
+                ds);
+
+            if (subTask is not null)
+            {
+                await subTask.ConfigureAwait(false);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Reader.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Reader.cs
@@ -597,6 +597,8 @@ namespace Microsoft.Data.SqlClient
             TaskCompletionSource<SqlDataReader> source,
             Guid operationId)
         {
+            _asyncExecutionCancellationToken = default;
+
             if (task.IsFaulted)
             {
                 Exception e = task.Exception.InnerException;
@@ -1086,6 +1088,8 @@ namespace Microsoft.Data.SqlClient
 
                 registration = cancellationToken.Register(s_cancelIgnoreFailure, state: this);
             }
+
+            _asyncExecutionCancellationToken = cancellationToken;
 
             Task<SqlDataReader> returnedTask = source.Task;
             ExecuteReaderAsyncCallContext context = null;
@@ -1920,7 +1924,7 @@ namespace Microsoft.Data.SqlClient
                 throw;
             }
 
-            await GenerateEnclavePackageAsync(CancellationToken.None).ConfigureAwait(false);
+            await GenerateEnclavePackageAsync(_asyncExecutionCancellationToken).ConfigureAwait(false);
 
             RunExecuteReaderTds(
                 cmdBehavior,

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Xml.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Xml.cs
@@ -366,6 +366,8 @@ namespace Microsoft.Data.SqlClient
             TaskCompletionSource<XmlReader> source,
             Guid operationId)
         {
+            _asyncExecutionCancellationToken = default;
+
             if (task.IsFaulted)
             {
                 Exception e = task.Exception?.InnerException;
@@ -500,6 +502,8 @@ namespace Microsoft.Data.SqlClient
 
                 registration = cancellationToken.Register(callback: s_cancelIgnoreFailure, state: this);
             }
+
+            _asyncExecutionCancellationToken = cancellationToken;
 
             // @TODO: This can be cleaned up to lines if InnerConnection is always SqlInternalConnection
             ExecuteXmlReaderAsyncCallContext context = null;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -153,6 +153,20 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         private AsyncState _cachedAsyncState = null;
 
+        /// <summary>
+        /// Cancellation token supplied by the caller of the asynchronous execution that is currently in
+        /// flight, or <see cref="CancellationToken.None"/> when the command is executing synchronously.
+        /// </summary>
+        /// <remarks>
+        /// The asynchronous execution entry points reach the Always Encrypted machinery through several
+        /// layers of synchronous, callback-driven code that carry no cancellation token. Rather than
+        /// threading a token through every one of those signatures — including the synchronous paths that
+        /// would only ever pass <see cref="CancellationToken.None"/> — the token is recorded here for the
+        /// duration of the operation. It is currently consumed only by the asynchronous Always Encrypted
+        /// key store calls, which are the sole cancellable I/O in that machinery.
+        /// </remarks>
+        private CancellationToken _asyncExecutionCancellationToken;
+
         private int _currentlyExecutingBatch;
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -158,12 +158,20 @@ namespace Microsoft.Data.SqlClient
         /// flight, or <see cref="CancellationToken.None"/> when the command is executing synchronously.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The asynchronous execution entry points reach the Always Encrypted machinery through several
         /// layers of synchronous, callback-driven code that carry no cancellation token. Rather than
         /// threading a token through every one of those signatures — including the synchronous paths that
         /// would only ever pass <see cref="CancellationToken.None"/> — the token is recorded here for the
         /// duration of the operation. It is currently consumed only by the asynchronous Always Encrypted
         /// key store calls, which are the sole cancellable I/O in that machinery.
+        /// </para>
+        /// <para>
+        /// Read this field only on the thread that started the execution, and pass the captured value on as
+        /// an explicit parameter. The Always Encrypted work is handed to the thread pool and can still be
+        /// running when the execution's cleanup continuation resets this field, so a read taken after that
+        /// hand-off may silently observe <see cref="CancellationToken.None"/>.
+        /// </para>
         /// </remarks>
         private CancellationToken _asyncExecutionCancellationToken;
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlQueryMetadataCache.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlQueryMetadataCache.cs
@@ -9,6 +9,7 @@ using System.Data;
 using System.Diagnostics;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace Microsoft.Data.SqlClient
@@ -47,8 +48,54 @@ namespace Microsoft.Data.SqlClient
         /// <summary>
         /// <para> Retrieves the query metadata for a specific query from the cache.</para>
         /// </summary>
+        /// <remarks>
+        /// Column encryption keys are loaded synchronously, which may block the calling thread on key
+        /// store I/O. Asynchronous execution paths should use <see cref="TryGetCachedQueryMetadata"/>
+        /// followed by <see cref="CompleteCachedQueryMetadataAsync"/> instead.
+        /// </remarks>
         internal bool GetQueryMetadataIfExists(SqlCommand sqlCommand)
         {
+            if (!TryGetCachedQueryMetadata(sqlCommand, out CachedQueryMetadata metadata))
+            {
+                return false;
+            }
+
+            foreach (SqlCipherMetadata cipherMetadata in metadata.KeysToLoad)
+            {
+                try
+                {
+                    SqlSecurityUtility.DecryptSymmetricKey(cipherMetadata, sqlCommand.Connection, sqlCommand);
+                }
+                catch (Exception ex) when (ex is SqlException or ArgumentException)
+                {
+                    OnKeyLoadFailed(sqlCommand, clearParameterMetadata: true);
+                    return false;
+                }
+                catch (Exception)
+                {
+                    OnKeyLoadFailed(sqlCommand, clearParameterMetadata: false);
+                    throw;
+                }
+            }
+
+            CompleteCachedQueryMetadata(sqlCommand, metadata);
+            return true;
+        }
+
+        /// <summary>
+        /// Performs the purely in-memory portion of a query metadata cache lookup.
+        /// </summary>
+        /// <remarks>
+        /// On success every parameter has been assigned a private copy of its cached cipher metadata and
+        /// <paramref name="metadata"/> describes the column encryption keys that still have to be loaded.
+        /// The caller must then either load those keys and call <see cref="CompleteCachedQueryMetadata"/>,
+        /// or call <see cref="CompleteCachedQueryMetadataAsync"/> which does both. Splitting the lookup this
+        /// way lets asynchronous execution paths await key store I/O instead of blocking on it.
+        /// </remarks>
+        internal bool TryGetCachedQueryMetadata(SqlCommand sqlCommand, out CachedQueryMetadata metadata)
+        {
+            metadata = default;
+
             // Return immediately if caching is disabled.
             if (!SqlConnection.ColumnEncryptionQueryMetadataCacheEnabled)
             {
@@ -98,6 +145,7 @@ namespace Microsoft.Data.SqlClient
 
             // Create a copy of the cipherMD in order to load the key.
             // The key shouldn't be loaded in the cached version for security reasons.
+            List<SqlCipherMetadata> keysToLoad = new();
             foreach (SqlParameter param in sqlCommand.Parameters)
             {
                 SqlCipherMetadata cipherMdCopy = null;
@@ -117,43 +165,112 @@ namespace Microsoft.Data.SqlClient
 
                 if (cipherMdCopy is not null)
                 {
-                    // Try to get the encryption key. If the key information is stale, this might fail.
-                    // In this case, just fail the cache lookup.
-                    try
-                    {
-                        SqlSecurityUtility.DecryptSymmetricKey(cipherMdCopy, sqlCommand.Connection, sqlCommand);
-                    }
-                    catch (Exception ex) when (ex is SqlException or ArgumentException)
-                    {
-                        // Invalidate the cache entry.
-                        InvalidateCacheEntry(sqlCommand);
-
-                        foreach (SqlParameter paramToCleanup in sqlCommand.Parameters)
-                        {
-                            paramToCleanup.CipherMetadata = null;
-                        }
-
-                        IncrementCacheMisses();
-                        return false;
-                    }
-                    catch (Exception)
-                    {
-                        // Invalidate the cache entry.
-                        InvalidateCacheEntry(sqlCommand);
-                        throw;
-                    }
+                    keysToLoad.Add(cipherMdCopy);
                 }
             }
 
+            metadata = new CachedQueryMetadata(enclaveLookupKey, keysToLoad);
+            return true;
+        }
+
+        /// <summary>
+        /// Loads the outstanding column encryption keys for a cache lookup using the asynchronous key
+        /// store provider APIs and then finishes the lookup.
+        /// </summary>
+        /// <returns>
+        /// <see langword="true"/> if the lookup completed as a cache hit; <see langword="false"/> if the
+        /// cached key information was stale, in which case the entry has been invalidated and the caller
+        /// must fall back to a full describe parameter encryption round trip.
+        /// </returns>
+        internal async Task<bool> CompleteCachedQueryMetadataAsync(
+            SqlCommand sqlCommand,
+            CachedQueryMetadata metadata,
+            CancellationToken cancellationToken)
+        {
+            foreach (SqlCipherMetadata cipherMetadata in metadata.KeysToLoad)
+            {
+                try
+                {
+                    await SqlSecurityUtility.DecryptSymmetricKeyAsync(
+                        cipherMetadata,
+                        sqlCommand.Connection,
+                        sqlCommand,
+                        cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is SqlException or ArgumentException)
+                {
+                    // The key information is stale, so fail the cache lookup.
+                    OnKeyLoadFailed(sqlCommand, clearParameterMetadata: true);
+                    return false;
+                }
+                catch (Exception)
+                {
+                    OnKeyLoadFailed(sqlCommand, clearParameterMetadata: false);
+                    throw;
+                }
+            }
+
+            CompleteCachedQueryMetadata(sqlCommand, metadata);
+            return true;
+        }
+
+        /// <summary>
+        /// Finishes a successful cache lookup by publishing the enclave keys and recording the hit.
+        /// </summary>
+        private void CompleteCachedQueryMetadata(SqlCommand sqlCommand, CachedQueryMetadata metadata)
+        {
             ConcurrentDictionary<int, SqlTceCipherInfoEntry> enclaveKeys =
-                _cache.Get<ConcurrentDictionary<int, SqlTceCipherInfoEntry>>(enclaveLookupKey);
+                _cache.Get<ConcurrentDictionary<int, SqlTceCipherInfoEntry>>(metadata.EnclaveLookupKey);
             if (enclaveKeys is not null)
             {
                 sqlCommand.keysToBeSentToEnclave = CreateCopyOfEnclaveKeys(enclaveKeys);
             }
 
             IncrementCacheHits();
-            return true;
+        }
+
+        /// <summary>
+        /// Rolls back a cache lookup whose column encryption key load failed.
+        /// </summary>
+        private void OnKeyLoadFailed(SqlCommand sqlCommand, bool clearParameterMetadata)
+        {
+            // Invalidate the cache entry.
+            InvalidateCacheEntry(sqlCommand);
+
+            if (!clearParameterMetadata)
+            {
+                return;
+            }
+
+            foreach (SqlParameter paramToCleanup in sqlCommand.Parameters)
+            {
+                paramToCleanup.CipherMetadata = null;
+            }
+
+            IncrementCacheMisses();
+        }
+
+        /// <summary>
+        /// The in-memory result of a query metadata cache probe, before its column encryption keys
+        /// have been loaded.
+        /// </summary>
+        internal readonly struct CachedQueryMetadata
+        {
+            internal CachedQueryMetadata(string enclaveLookupKey, List<SqlCipherMetadata> keysToLoad)
+            {
+                EnclaveLookupKey = enclaveLookupKey;
+                KeysToLoad = keysToLoad;
+            }
+
+            /// <summary>
+            /// The cache key under which this query's enclave keys are stored.
+            /// </summary>
+            internal string EnclaveLookupKey { get; }
+
+            /// <summary>
+            /// The parameter cipher metadata whose column encryption keys still have to be decrypted.
+            /// </summary>
+            internal List<SqlCipherMetadata> KeysToLoad { get; }
         }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlQueryMetadataCache.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlQueryMetadataCache.cs
@@ -207,6 +207,14 @@ namespace Microsoft.Data.SqlClient
                     OnKeyLoadFailed(sqlCommand, clearParameterMetadata: true);
                     return false;
                 }
+                catch (OperationCanceledException)
+                {
+                    // Cancellation says nothing about whether the cached metadata is still valid, so
+                    // leave the entry in place for the next caller instead of forcing it to pay for
+                    // another describe parameter encryption round trip. This case cannot arise on the
+                    // synchronous path, which is why only this overload handles it.
+                    throw;
+                }
                 catch (Exception)
                 {
                     OnKeyLoadFailed(sqlCommand, clearParameterMetadata: false);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlQueryMetadataCache.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlQueryMetadataCache.cs
@@ -60,11 +60,12 @@ namespace Microsoft.Data.SqlClient
                 return false;
             }
 
-            foreach (SqlCipherMetadata cipherMetadata in metadata.KeysToLoad)
+            IReadOnlyList<SqlCipherMetadata> keysToLoad = metadata.KeysToLoad;
+            for (int i = 0; i < keysToLoad.Count; i++)
             {
                 try
                 {
-                    SqlSecurityUtility.DecryptSymmetricKey(cipherMetadata, sqlCommand.Connection, sqlCommand);
+                    SqlSecurityUtility.DecryptSymmetricKey(keysToLoad[i], sqlCommand.Connection, sqlCommand);
                 }
                 catch (Exception ex) when (ex is SqlException or ArgumentException)
                 {
@@ -145,7 +146,9 @@ namespace Microsoft.Data.SqlClient
 
             // Create a copy of the cipherMD in order to load the key.
             // The key shouldn't be loaded in the cached version for security reasons.
-            List<SqlCipherMetadata> keysToLoad = new();
+            // Allocated lazily: a cached query whose parameters are all plaintext needs no list at all,
+            // and this runs on every metadata cache hit.
+            List<SqlCipherMetadata> keysToLoad = null;
             foreach (SqlParameter param in sqlCommand.Parameters)
             {
                 SqlCipherMetadata cipherMdCopy = null;
@@ -165,7 +168,7 @@ namespace Microsoft.Data.SqlClient
 
                 if (cipherMdCopy is not null)
                 {
-                    keysToLoad.Add(cipherMdCopy);
+                    (keysToLoad ??= new List<SqlCipherMetadata>()).Add(cipherMdCopy);
                 }
             }
 
@@ -187,12 +190,13 @@ namespace Microsoft.Data.SqlClient
             CachedQueryMetadata metadata,
             CancellationToken cancellationToken)
         {
-            foreach (SqlCipherMetadata cipherMetadata in metadata.KeysToLoad)
+            IReadOnlyList<SqlCipherMetadata> keysToLoad = metadata.KeysToLoad;
+            for (int i = 0; i < keysToLoad.Count; i++)
             {
                 try
                 {
                     await SqlSecurityUtility.DecryptSymmetricKeyAsync(
-                        cipherMetadata,
+                        keysToLoad[i],
                         sqlCommand.Connection,
                         sqlCommand,
                         cancellationToken).ConfigureAwait(false);
@@ -259,7 +263,7 @@ namespace Microsoft.Data.SqlClient
             internal CachedQueryMetadata(string enclaveLookupKey, List<SqlCipherMetadata> keysToLoad)
             {
                 EnclaveLookupKey = enclaveLookupKey;
-                KeysToLoad = keysToLoad;
+                KeysToLoad = (IReadOnlyList<SqlCipherMetadata>)keysToLoad ?? Array.Empty<SqlCipherMetadata>();
             }
 
             /// <summary>
@@ -270,7 +274,7 @@ namespace Microsoft.Data.SqlClient
             /// <summary>
             /// The parameter cipher metadata whose column encryption keys still have to be decrypted.
             /// </summary>
-            internal List<SqlCipherMetadata> KeysToLoad { get; }
+            internal IReadOnlyList<SqlCipherMetadata> KeysToLoad { get; }
         }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSecurityUtility.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSecurityUtility.cs
@@ -8,6 +8,8 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Data.Common;
 using Microsoft.Data.SqlClient.AlwaysEncrypted;
 
@@ -215,6 +217,96 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <summary>
+        /// <para> Asynchronously decrypts the symmetric key and saves it in metadata. In addition, initializes
+        /// the SqlClientEncryptionAlgorithm for rapid decryption.</para>
+        /// </summary>
+        /// <remarks>
+        /// This is the async counterpart of <see cref="DecryptSymmetricKey(SqlCipherMetadata, SqlConnection, SqlCommand)"/>
+        /// and mutates <paramref name="md"/> in exactly the same way.
+        /// </remarks>
+        internal static async Task DecryptSymmetricKeyAsync(SqlCipherMetadata md, SqlConnection connection, SqlCommand command, CancellationToken cancellationToken)
+        {
+            Debug.Assert(md is not null, "md should not be null in DecryptSymmetricKeyAsync.");
+
+            (SqlClientSymmetricKey symKey, SqlEncryptionKeyInfo encryptionkeyInfoChosen) =
+                await DecryptSymmetricKeyAsync(md.EncryptionInfo, connection, command, cancellationToken).ConfigureAwait(false);
+
+            // Given the symmetric key instantiate a SqlClientEncryptionAlgorithm object and cache it in metadata
+            md.CipherAlgorithm = null;
+            SqlClientEncryptionAlgorithm cipherAlgorithm = null;
+            string algorithmName = ValidateAndGetEncryptionAlgorithmName(md.CipherAlgorithmId, md.CipherAlgorithmName); // may throw
+            EncryptionAlgorithmFactoryList.GetAlgorithm(symKey, md.EncryptionType, algorithmName, out cipherAlgorithm); // will validate algorithm name and type
+            Debug.Assert(cipherAlgorithm is not null);
+            md.CipherAlgorithm = cipherAlgorithm;
+            md.EncryptionKeyInfo = encryptionkeyInfoChosen;
+        }
+
+        /// <summary>
+        /// Asynchronously decrypts the symmetric key.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Async methods cannot declare <c>out</c> parameters, so the two values reported by
+        /// <see cref="DecryptSymmetricKey(SqlTceCipherInfoEntry, out SqlClientSymmetricKey, out SqlEncryptionKeyInfo, SqlConnection, SqlCommand)"/>
+        /// are returned as a tuple instead (spec Design Decision 4).
+        /// </para>
+        /// <para>
+        /// Like the sync overload, each candidate key is tried in turn and failures are remembered so that the
+        /// last one can be rethrown if every candidate fails. Unlike the sync overload, a cancellation of
+        /// <paramref name="cancellationToken"/> is never swallowed: it abandons the loop immediately instead of
+        /// causing the remaining candidates to be attempted.
+        /// </para>
+        /// </remarks>
+        internal static async Task<(SqlClientSymmetricKey Key, SqlEncryptionKeyInfo KeyInfoChosen)> DecryptSymmetricKeyAsync(
+            SqlTceCipherInfoEntry sqlTceCipherInfoEntry,
+            SqlConnection connection,
+            SqlCommand command,
+            CancellationToken cancellationToken)
+        {
+            Debug.Assert(connection is not null, "Connection should not be null.");
+            Debug.Assert(sqlTceCipherInfoEntry is not null, "sqlTceCipherInfoEntry should not be null in DecryptSymmetricKeyAsync.");
+            Debug.Assert(sqlTceCipherInfoEntry.ColumnEncryptionKeyValues is not null,
+                    "sqlTceCipherInfoEntry.ColumnEncryptionKeyValues should not be null in DecryptSymmetricKeyAsync.");
+
+            SqlClientSymmetricKey sqlClientSymmetricKey = null;
+            SqlEncryptionKeyInfo encryptionkeyInfoChosen = null;
+            Exception lastException = null;
+            SqlSymmetricKeyCache globalCekCache = SqlSymmetricKeyCache.GetInstance();
+
+            foreach (SqlEncryptionKeyInfo keyInfo in sqlTceCipherInfoEntry.ColumnEncryptionKeyValues)
+            {
+                try
+                {
+                    sqlClientSymmetricKey = ShouldUseInstanceLevelProviderFlow(keyInfo.keyStoreName, connection, command) ?
+                        await GetKeyFromLocalProvidersAsync(keyInfo, connection, command, cancellationToken).ConfigureAwait(false) :
+                        await globalCekCache.GetKeyAsync(keyInfo, connection, command, cancellationToken).ConfigureAwait(false);
+                    encryptionkeyInfoChosen = keyInfo;
+                    break;
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    // The caller cancelled. Do not treat this as a failure of this particular key and do not
+                    // attempt the remaining keys; propagate so that the returned Task is cancelled.
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    lastException = e;
+                }
+            }
+
+            if (sqlClientSymmetricKey is null)
+            {
+                Debug.Assert(lastException is not null, "CEK decryption failed without raising exceptions");
+                throw lastException;
+            }
+
+            Debug.Assert(encryptionkeyInfoChosen is not null, "encryptionkeyInfoChosen must have a value.");
+
+            return (sqlClientSymmetricKey, encryptionkeyInfoChosen);
+        }
+
+        /// <summary>
         /// Decrypts the symmetric key and saves it in metadata.
         /// </summary>
         internal static void DecryptSymmetricKey(SqlTceCipherInfoEntry sqlTceCipherInfoEntry, out SqlClientSymmetricKey sqlClientSymmetricKey, out SqlEncryptionKeyInfo encryptionkeyInfoChosen, SqlConnection connection, SqlCommand command)
@@ -275,6 +367,58 @@ namespace Microsoft.Data.SqlClient
             try
             {
                 plaintextKey = provider.DecryptColumnEncryptionKey(keyInfo.keyPath, keyInfo.algorithmName, keyInfo.encryptedKey);
+            }
+            catch (Exception e)
+            {
+                // Generate a new exception and throw.
+                string keyHex = GetBytesAsString(keyInfo.encryptedKey, fLast: true, countOfBytes: 10);
+                throw SQL.KeyDecryptionFailed(keyInfo.keyStoreName, keyHex, e);
+            }
+
+            return new SqlClientSymmetricKey(plaintextKey);
+        }
+
+        /// <summary>
+        /// Asynchronous counterpart of <see cref="GetKeyFromLocalProviders"/>.
+        /// </summary>
+        /// <remarks>
+        /// Instance-level providers are never backed by the global CEK cache, so this method performs the
+        /// provider call directly. A cancellation of <paramref name="cancellationToken"/> is propagated
+        /// unwrapped rather than being reported as <c>SQL.KeyDecryptionFailed</c>.
+        /// </remarks>
+        private static async Task<SqlClientSymmetricKey> GetKeyFromLocalProvidersAsync(
+            SqlEncryptionKeyInfo keyInfo,
+            SqlConnection connection,
+            SqlCommand command,
+            CancellationToken cancellationToken)
+        {
+            string serverName = connection.DataSource;
+            Debug.Assert(serverName is not null, @"serverName should not be null.");
+
+            Debug.Assert(SqlConnection.ColumnEncryptionTrustedMasterKeyPaths is not null, @"SqlConnection.ColumnEncryptionTrustedMasterKeyPaths should not be null");
+
+            ThrowIfKeyPathIsNotTrustedForServer(serverName, keyInfo.keyPath);
+            if (!TryGetColumnEncryptionKeyStoreProvider(keyInfo.keyStoreName, out SqlColumnEncryptionKeyStoreProvider provider, connection, command))
+            {
+                throw SQL.UnrecognizedKeyStoreProviderName(keyInfo.keyStoreName,
+                    SqlConnection.GetColumnEncryptionSystemKeyStoreProvidersNames(),
+                    GetListOfProviderNamesThatWereSearched(connection, command));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Decrypt the CEK
+            // We will simply bubble up the exception from the DecryptColumnEncryptionKeyAsync function.
+            byte[] plaintextKey;
+            try
+            {
+                plaintextKey = await provider
+                    .DecryptColumnEncryptionKeyAsync(keyInfo.keyPath, keyInfo.algorithmName, keyInfo.encryptedKey, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception e)
             {
@@ -348,6 +492,92 @@ namespace Microsoft.Data.SqlClient
                         isValidSignature = cachedResult == SignatureVerificationResult.True;
                     }
                 }
+            }
+            catch (Exception e)
+            {
+                throw SQL.UnableToVerifyColumnMasterKeySignature(e);
+            }
+
+            if (!isValidSignature)
+            {
+                throw SQL.ColumnMasterKeySignatureVerificationFailed(keyPath);
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously verifies Column Master Key Signature.
+        /// </summary>
+        /// <remarks>
+        /// Mirrors <see cref="VerifyColumnMasterKeySignature"/>, including wrapping failures in
+        /// <c>SQL.UnableToVerifyColumnMasterKeySignature</c>. The single exception is a cancellation of
+        /// <paramref name="cancellationToken"/>, which is propagated unwrapped so the returned Task is
+        /// cancelled rather than faulted with an <see cref="InvalidOperationException"/>.
+        /// </remarks>
+        internal static async Task VerifyColumnMasterKeySignatureAsync(
+            string keyStoreName,
+            string keyPath,
+            bool isEnclaveEnabled,
+            byte[] CMKSignature,
+            SqlConnection connection,
+            SqlCommand command,
+            CancellationToken cancellationToken)
+        {
+            bool isValidSignature = false;
+
+            try
+            {
+                Debug.Assert(SqlConnection.ColumnEncryptionTrustedMasterKeyPaths is not null,
+                        @"SqlConnection.ColumnEncryptionTrustedMasterKeyPaths should not be null");
+
+                if (CMKSignature is null || CMKSignature.Length == 0)
+                {
+                    throw SQL.ColumnMasterKeySignatureNotFound(keyPath);
+                }
+
+                ThrowIfKeyPathIsNotTrustedForServer(connection.DataSource, keyPath);
+
+                // Attempt to look up the provider and verify CMK Signature
+                if (!TryGetColumnEncryptionKeyStoreProvider(keyStoreName, out SqlColumnEncryptionKeyStoreProvider provider, connection, command))
+                {
+                    throw SQL.InvalidKeyStoreProviderName(keyStoreName,
+                        SqlConnection.GetColumnEncryptionSystemKeyStoreProvidersNames(),
+                        GetListOfProviderNamesThatWereSearched(connection, command));
+                }
+
+                if (ShouldUseInstanceLevelProviderFlow(keyStoreName, connection, command))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    isValidSignature = await provider
+                        .VerifyColumnMasterKeyMetadataAsync(keyPath, isEnclaveEnabled, CMKSignature, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    SignatureVerificationResult cachedResult = ColumnMasterKeyMetadataSignatureVerificationCache.Instance
+                        .GetSignatureVerificationResult(keyStoreName, keyPath, isEnclaveEnabled, CMKSignature);
+
+                    if (cachedResult == SignatureVerificationResult.NotFound)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        // Cache miss: verify with the provider and cache the result.
+                        // Exceptions from VerifyColumnMasterKeyMetadataAsync bubble up to the outer catch.
+                        isValidSignature = await provider
+                            .VerifyColumnMasterKeyMetadataAsync(keyPath, isEnclaveEnabled, CMKSignature, cancellationToken)
+                            .ConfigureAwait(false);
+                        ColumnMasterKeyMetadataSignatureVerificationCache.Instance
+                            .AddSignatureVerificationResult(keyStoreName, keyPath, isEnclaveEnabled, CMKSignature, isValidSignature);
+                    }
+                    else
+                    {
+                        isValidSignature = cachedResult == SignatureVerificationResult.True;
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception e)
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSymmetricKeyCache.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSymmetricKeyCache.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace Microsoft.Data.SqlClient
@@ -36,22 +37,7 @@ namespace Microsoft.Data.SqlClient
         {
             string serverName = connection.DataSource;
             Debug.Assert(serverName is not null, @"serverName should not be null.");
-            StringBuilder cacheLookupKeyBuilder = new(serverName, capacity: serverName.Length + SqlSecurityUtility.GetBase64LengthFromByteLength(keyInfo.encryptedKey.Length) + keyInfo.keyStoreName.Length + 2/*separators*/);
-
-#if DEBUG
-            int capacity = cacheLookupKeyBuilder.Capacity;
-#endif //DEBUG
-
-            cacheLookupKeyBuilder.Append(":");
-            cacheLookupKeyBuilder.Append(Convert.ToBase64String(keyInfo.encryptedKey));
-            cacheLookupKeyBuilder.Append(":");
-            cacheLookupKeyBuilder.Append(keyInfo.keyStoreName);
-
-            string cacheLookupKey = cacheLookupKeyBuilder.ToString();
-
-#if DEBUG
-            Debug.Assert(cacheLookupKey.Length <= capacity, "We needed to allocate a larger array");
-#endif //DEBUG
+            string cacheLookupKey = CreateCacheLookupKey(keyInfo, serverName);
 
             // Acquire the lock to ensure thread safety when accessing the cache
             _cacheLock.Wait();
@@ -109,6 +95,142 @@ namespace Microsoft.Data.SqlClient
                 // Release the lock to allow other threads to access the cache
                 _cacheLock.Release();
             }
+        }
+
+        /// <summary>
+        /// <para> Asynchronously retrieves Symmetric Key (in plaintext) given the encryption material.</para>
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>_cacheLock</c> is a process-wide gate that the synchronous <see cref="GetKey"/> path blocks on
+        /// with <see cref="SemaphoreSlim.Wait()"/>. Holding it across the awaited provider call would therefore
+        /// stall every synchronous caller's thread for the duration of that (potentially remote) call. To avoid
+        /// that, this method follows the check-release-fetch-relock pattern required by FR-012: the gate is held
+        /// only for the cache lookup and for the cache insertion, never across I/O.
+        /// </para>
+        /// <para>
+        /// The consequence, accepted by FR-014, is that concurrent async callers that miss the cache for the
+        /// same key may each decrypt it. That is weaker than the synchronous path, which serializes the fetch.
+        /// The results are equivalent, and the first caller to publish its result wins: subsequent callers
+        /// return the already-cached instance so that all callers observe the same key object.
+        /// </para>
+        /// </remarks>
+        internal async Task<SqlClientSymmetricKey> GetKeyAsync(SqlEncryptionKeyInfo keyInfo, SqlConnection connection, SqlCommand command, CancellationToken cancellationToken)
+        {
+            string serverName = connection.DataSource;
+            Debug.Assert(serverName is not null, @"serverName should not be null.");
+            string cacheLookupKey = CreateCacheLookupKey(keyInfo, serverName);
+
+            // Acquire the lock to ensure thread safety when accessing the cache, and release it before
+            // performing any I/O so that synchronous callers are never blocked behind a remote call.
+            await _cacheLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (_cache.TryGetValue(cacheLookupKey, out SqlClientSymmetricKey cachedKey))
+                {
+                    return cachedKey;
+                }
+            }
+            finally
+            {
+                _cacheLock.Release();
+            }
+
+            Debug.Assert(SqlConnection.ColumnEncryptionTrustedMasterKeyPaths is not null, @"SqlConnection.ColumnEncryptionTrustedMasterKeyPaths should not be null");
+
+            SqlSecurityUtility.ThrowIfKeyPathIsNotTrustedForServer(serverName, keyInfo.keyPath);
+
+            // Key Not found, attempt to look up the provider and decrypt CEK
+            if (!SqlSecurityUtility.TryGetColumnEncryptionKeyStoreProvider(keyInfo.keyStoreName, out SqlColumnEncryptionKeyStoreProvider provider, connection, command))
+            {
+                throw SQL.UnrecognizedKeyStoreProviderName(keyInfo.keyStoreName,
+                        SqlConnection.GetColumnEncryptionSystemKeyStoreProvidersNames(),
+                        SqlSecurityUtility.GetListOfProviderNamesThatWereSearched(connection, command));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Decrypt the CEK
+            // We will simply bubble up the exception from the DecryptColumnEncryptionKeyAsync function.
+            byte[] plaintextKey;
+            try
+            {
+                // AKV provider registration supports multi-user scenarios, so it is not safe to cache the CEK in the global provider.
+                // The CEK cache is a global cache, and is shared across all connections.
+                // To prevent conflicts between CEK caches, global providers should not use their own CEK caches
+                //
+                // Unlike the sync path this assignment happens outside the gate, so two async callers may write
+                // it concurrently. The write is idempotent (always TimeSpan.Zero), so the outcome is the same.
+                provider.ColumnEncryptionKeyCacheTtl = new TimeSpan(0);
+                plaintextKey = await provider
+                    .DecryptColumnEncryptionKeyAsync(keyInfo.keyPath, keyInfo.algorithmName, keyInfo.encryptedKey, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Cancellation is propagated unwrapped so the returned Task is cancelled rather than faulted.
+                throw;
+            }
+            catch (Exception e)
+            {
+                // Generate a new exception and throw.
+                string keyHex = SqlSecurityUtility.GetBytesAsString(keyInfo.encryptedKey, fLast: true, countOfBytes: 10);
+                throw SQL.KeyDecryptionFailed(keyInfo.keyStoreName, keyHex, e);
+            }
+
+            SqlClientSymmetricKey decryptedKey = new SqlClientSymmetricKey(plaintextKey);
+
+            // If the cache TTL is zero, don't even bother inserting to the cache.
+            TimeSpan cacheTtl = SqlConnection.ColumnEncryptionKeyCacheTtl;
+            if (cacheTtl == TimeSpan.Zero)
+            {
+                return decryptedKey;
+            }
+
+            await _cacheLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                // Another caller may have populated the entry while this one was decrypting. In that case the
+                // first one wins, exactly as in the sync path, so that all callers observe the same key object.
+                if (_cache.TryGetValue(cacheLookupKey, out SqlClientSymmetricKey concurrentlyCachedKey))
+                {
+                    return concurrentlyCachedKey;
+                }
+
+                _cache.Set(cacheLookupKey, decryptedKey, absoluteExpirationRelativeToNow: cacheTtl);
+            }
+            finally
+            {
+                _cacheLock.Release();
+            }
+
+            return decryptedKey;
+        }
+
+        /// <summary>
+        /// Builds the cache lookup key for the given encryption material. Pure function shared by the sync
+        /// and async lookup paths.
+        /// </summary>
+        private static string CreateCacheLookupKey(SqlEncryptionKeyInfo keyInfo, string serverName)
+        {
+            StringBuilder cacheLookupKeyBuilder = new(serverName, capacity: serverName.Length + SqlSecurityUtility.GetBase64LengthFromByteLength(keyInfo.encryptedKey.Length) + keyInfo.keyStoreName.Length + 2/*separators*/);
+
+#if DEBUG
+            int capacity = cacheLookupKeyBuilder.Capacity;
+#endif //DEBUG
+
+            cacheLookupKeyBuilder.Append(":");
+            cacheLookupKeyBuilder.Append(Convert.ToBase64String(keyInfo.encryptedKey));
+            cacheLookupKeyBuilder.Append(":");
+            cacheLookupKeyBuilder.Append(keyInfo.keyStoreName);
+
+            string cacheLookupKey = cacheLookupKeyBuilder.ToString();
+
+#if DEBUG
+            Debug.Assert(cacheLookupKey.Length <= capacity, "We needed to allocate a larger array");
+#endif //DEBUG
+
+            return cacheLookupKey;
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSymmetricKeyCache.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSymmetricKeyCache.cs
@@ -187,7 +187,10 @@ namespace Microsoft.Data.SqlClient
                 return decryptedKey;
             }
 
-            await _cacheLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            // Deliberately not cancellable. The expensive, remote part of this method is already done; the
+            // section below is in-memory only. Honouring cancellation here would throw away a completed key
+            // decryption and leave the next caller to repeat it.
+            await _cacheLock.WaitAsync().ConfigureAwait(false);
             try
             {
                 // Another caller may have populated the entry while this one was decrypting. In that case the

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/AsyncKeyStoreProviderTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/AsyncKeyStoreProviderTests.cs
@@ -1,0 +1,156 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted.Setup;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
+{
+    /// <summary>
+    /// Verifies that the asynchronous command execution paths dispatch column encryption key
+    /// operations through the <b>asynchronous</b> key store provider APIs, while the synchronous
+    /// paths continue to use the synchronous APIs.
+    /// </summary>
+    [Trait("Set", "AE")]
+    public sealed class AsyncKeyStoreProviderTests : IClassFixture<SQLSetupStrategyCertStoreProvider>
+    {
+        private readonly SQLSetupStrategy _fixture;
+
+        public AsyncKeyStoreProviderTests(SQLSetupStrategyCertStoreProvider fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsTargetReadyForAeWithKeyStore))]
+        [ClassData(typeof(AEConnectionStringProvider))]
+        public void SyncExecutionUsesSyncKeyStoreProviderApi(string connectionString)
+        {
+            RecordingKeyStoreProvider provider = new();
+
+            using SqlConnection connection = new(connectionString);
+            connection.Open();
+            connection.RegisterColumnEncryptionKeyStoreProvidersOnConnection(Wrap(provider));
+
+            using SqlCommand command = CreateEncryptedParameterCommand(connection);
+            Assert.Throws<SqlException>(() => command.ExecuteReader());
+
+            Assert.True(provider.SyncCalls > 0, "Expected the synchronous provider API to be used by ExecuteReader.");
+            Assert.Equal(0, provider.AsyncCalls);
+        }
+
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsTargetReadyForAeWithKeyStore))]
+        [ClassData(typeof(AEConnectionStringProvider))]
+        public async Task ExecuteReaderAsyncUsesAsyncKeyStoreProviderApi(string connectionString)
+        {
+            await AssertAsyncApiUsed(connectionString, command => command.ExecuteReaderAsync());
+        }
+
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsTargetReadyForAeWithKeyStore))]
+        [ClassData(typeof(AEConnectionStringProvider))]
+        public async Task ExecuteNonQueryAsyncUsesAsyncKeyStoreProviderApi(string connectionString)
+        {
+            await AssertAsyncApiUsed(connectionString, command => command.ExecuteNonQueryAsync());
+        }
+
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsTargetReadyForAeWithKeyStore))]
+        [ClassData(typeof(AEConnectionStringProvider))]
+        public async Task AsyncExecutionHonoursCancellationToken(string connectionString)
+        {
+            RecordingKeyStoreProvider provider = new();
+
+            using SqlConnection connection = new(connectionString);
+            await connection.OpenAsync();
+            connection.RegisterColumnEncryptionKeyStoreProvidersOnConnection(Wrap(provider));
+
+            using CancellationTokenSource cts = new();
+            using SqlCommand command = CreateEncryptedParameterCommand(connection);
+
+            // The provider cancels the token from inside the async decrypt call, which proves the
+            // caller's token was threaded all the way down into the key store operation.
+            provider.OnAsyncCall = () => cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => command.ExecuteReaderAsync(cts.Token));
+
+            Assert.True(provider.AsyncCalls > 0, "Expected the asynchronous provider API to be used.");
+        }
+
+        private async Task AssertAsyncApiUsed(string connectionString, Func<SqlCommand, Task> execute)
+        {
+            RecordingKeyStoreProvider provider = new();
+
+            using SqlConnection connection = new(connectionString);
+            await connection.OpenAsync();
+            connection.RegisterColumnEncryptionKeyStoreProvidersOnConnection(Wrap(provider));
+
+            using SqlCommand command = CreateEncryptedParameterCommand(connection);
+            await Assert.ThrowsAsync<SqlException>(() => execute(command));
+
+            Assert.True(provider.AsyncCalls > 0, "Expected the asynchronous provider API to be used.");
+            Assert.Equal(0, provider.SyncCalls);
+        }
+
+        private static Dictionary<string, SqlColumnEncryptionKeyStoreProvider> Wrap(
+            RecordingKeyStoreProvider provider) =>
+            new() { { DummyKeyStoreProvider.Name, provider } };
+
+        private SqlCommand CreateEncryptedParameterCommand(SqlConnection connection)
+        {
+            SqlCommand command = new(
+                $"SELECT * FROM [{_fixture.CustomKeyStoreProviderTestTable.Name}] WHERE CustomerID = @id",
+                connection,
+                transaction: null,
+                SqlCommandColumnEncryptionSetting.Enabled);
+            command.Parameters.AddWithValue("id", 9);
+            return command;
+        }
+
+        /// <summary>
+        /// Records which key store provider overload the driver invoked. Both overloads throw so
+        /// that the test never depends on real key material; the assertions are made on the counters.
+        /// </summary>
+        private sealed class RecordingKeyStoreProvider : SqlColumnEncryptionKeyStoreProvider
+        {
+            private int _syncCalls;
+            private int _asyncCalls;
+
+            public int SyncCalls => Volatile.Read(ref _syncCalls);
+
+            public int AsyncCalls => Volatile.Read(ref _asyncCalls);
+
+            public Action OnAsyncCall { get; set; }
+
+            public override byte[] DecryptColumnEncryptionKey(
+                string masterKeyPath,
+                string encryptionAlgorithm,
+                byte[] encryptedColumnEncryptionKey)
+            {
+                Interlocked.Increment(ref _syncCalls);
+                throw new NotImplementedException();
+            }
+
+            public override Task<byte[]> DecryptColumnEncryptionKeyAsync(
+                string masterKeyPath,
+                string encryptionAlgorithm,
+                byte[] encryptedColumnEncryptionKey,
+                CancellationToken cancellationToken = default)
+            {
+                Interlocked.Increment(ref _asyncCalls);
+                OnAsyncCall?.Invoke();
+                cancellationToken.ThrowIfCancellationRequested();
+                throw new NotImplementedException();
+            }
+
+            public override byte[] EncryptColumnEncryptionKey(
+                string masterKeyPath,
+                string encryptionAlgorithm,
+                byte[] columnEncryptionKey) =>
+                throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/EnclaveDelegateAsyncShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/EnclaveDelegateAsyncShould.cs
@@ -94,7 +94,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
 
             List<ColumnEncryptionKeyInfo> keys = await EnclaveDelegate.Instance.GetDecryptedKeysToBeSentToEnclaveAsync(
                 NewKeyTable(NewCipherInfoEntry()),
-                serverName: "async-ae-enclave-unit-test",
                 connection,
                 command: null,
                 CancellationToken.None);
@@ -120,7 +119,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
 
             List<ColumnEncryptionKeyInfo> keys = await EnclaveDelegate.Instance.GetDecryptedKeysToBeSentToEnclaveAsync(
                 NewKeyTable(NewCipherInfoEntry(ordinal: 0), NewCipherInfoEntry(ordinal: 1), NewCipherInfoEntry(ordinal: 2)),
-                serverName: "async-ae-enclave-unit-test",
                 connection,
                 command: null,
                 CancellationToken.None);
@@ -142,7 +140,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
 
             List<ColumnEncryptionKeyInfo> keys = EnclaveDelegate.Instance.GetDecryptedKeysToBeSentToEnclave(
                 NewKeyTable(NewCipherInfoEntry()),
-                serverName: "async-ae-enclave-unit-test",
                 connection,
                 command: null);
 
@@ -167,7 +164,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
             await Assert.ThrowsAnyAsync<OperationCanceledException>(
                 () => EnclaveDelegate.Instance.GetDecryptedKeysToBeSentToEnclaveAsync(
                     NewKeyTable(NewCipherInfoEntry()),
-                    serverName: "async-ae-enclave-unit-test",
                     connection,
                     command: null,
                     cts.Token));
@@ -191,7 +187,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
             SqlException exception = await Assert.ThrowsAsync<SqlException>(
                 () => EnclaveDelegate.Instance.GetDecryptedKeysToBeSentToEnclaveAsync(
                     NewKeyTable(NewCipherInfoEntry()),
-                    serverName: "async-ae-enclave-unit-test",
                     connection,
                     command: null,
                     CancellationToken.None));

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/EnclaveDelegateAsyncShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/EnclaveDelegateAsyncShould.cs
@@ -1,0 +1,239 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// The Always Encrypted enclave layer is internal and nullable-oblivious, and several of its members
+// legitimately accept or produce nulls. Nullable analysis is disabled for this file so the tests can
+// mirror those signatures exactly.
+#nullable disable
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
+{
+    /// <summary>
+    /// Tests for the asynchronous column encryption key resolution used when building an enclave package.
+    /// </summary>
+    /// <remarks>
+    /// The enclave package itself cannot be produced without an attested enclave session, so these tests
+    /// target the one step of that flow which performs key store I/O.
+    /// </remarks>
+    public class EnclaveDelegateAsyncShould
+    {
+        private const string ProviderName = "TEST_ENCLAVE_ASYNC_PROVIDER";
+        private const string KeyPath = "test-enclave-key-path";
+        private const string EncryptionAlgorithm = "RSA_OAEP";
+
+        private const int DatabaseId = 42;
+        private const int CekId = 7;
+        private const ulong CekMdVersion = 3;
+
+        // The AEAD_AES_256_CBC_HMAC_SHA256 algorithm requires a 256 bit root key.
+        private static byte[] NewPlaintextKey(byte seed)
+        {
+            byte[] key = new byte[32];
+            for (int i = 0; i < key.Length; i++)
+            {
+                key[i] = (byte)(seed + i);
+            }
+            return key;
+        }
+
+        private static SqlConnection NewConnection(SqlColumnEncryptionKeyStoreProvider provider)
+        {
+            SqlConnection connection = new SqlConnection("Data Source=async-ae-enclave-unit-test;Column Encryption Setting=Enabled");
+            connection.RegisterColumnEncryptionKeyStoreProvidersOnConnection(
+                new Dictionary<string, SqlColumnEncryptionKeyStoreProvider> { [ProviderName] = provider });
+            return connection;
+        }
+
+        /// <summary>
+        /// Produces a cipher info entry whose cache lookup key cannot collide with any other test. The CEK
+        /// cache is a process-wide singleton shared by every test in this assembly.
+        /// </summary>
+        private static SqlTceCipherInfoEntry NewCipherInfoEntry(int ordinal = 0)
+        {
+            SqlTceCipherInfoEntry entry = new SqlTceCipherInfoEntry(ordinal);
+            entry.Add(
+                encryptedKey: Guid.NewGuid().ToByteArray(),
+                databaseId: DatabaseId,
+                cekId: CekId,
+                cekVersion: 1,
+                cekMdVersion: CekMdVersion,
+                keyPath: KeyPath,
+                keyStoreName: ProviderName,
+                algorithmName: EncryptionAlgorithm);
+            return entry;
+        }
+
+        private static ConcurrentDictionary<int, SqlTceCipherInfoEntry> NewKeyTable(params SqlTceCipherInfoEntry[] entries)
+        {
+            ConcurrentDictionary<int, SqlTceCipherInfoEntry> table = new();
+            for (int i = 0; i < entries.Length; i++)
+            {
+                table[i] = entries[i];
+            }
+            return table;
+        }
+
+        /// <summary>
+        /// The whole point of the change: the enclave key resolution must go through the provider's async
+        /// API so a key store performing network I/O never blocks the pooled thread.
+        /// </summary>
+        [Fact]
+        public async Task GetDecryptedKeysToBeSentToEnclaveAsync_UsesAsyncProviderApi()
+        {
+            byte[] expectedKey = NewPlaintextKey(seed: 11);
+            TestEnclaveKeyStoreProvider provider = new TestEnclaveKeyStoreProvider { PlaintextKey = expectedKey };
+            using SqlConnection connection = NewConnection(provider);
+
+            List<ColumnEncryptionKeyInfo> keys = await EnclaveDelegate.Instance.GetDecryptedKeysToBeSentToEnclaveAsync(
+                NewKeyTable(NewCipherInfoEntry()),
+                serverName: "async-ae-enclave-unit-test",
+                connection,
+                command: null,
+                CancellationToken.None);
+
+            ColumnEncryptionKeyInfo key = Assert.Single(keys);
+            Assert.Equal(expectedKey, key.DecryptedKeyBytes);
+            Assert.Equal(DatabaseId, key.DatabaseId);
+            Assert.Equal(CekId, key.KeyId);
+            Assert.Equal(CekMdVersion, key.KeyMetadataVersion);
+
+            Assert.Equal(1, provider.DecryptAsyncCallCount);
+            Assert.Equal(0, provider.DecryptCallCount);
+        }
+
+        /// <summary>
+        /// Every requested key must be resolved, and each one must use the async provider API.
+        /// </summary>
+        [Fact]
+        public async Task GetDecryptedKeysToBeSentToEnclaveAsync_ResolvesEveryRequestedKey()
+        {
+            TestEnclaveKeyStoreProvider provider = new TestEnclaveKeyStoreProvider { PlaintextKey = NewPlaintextKey(seed: 23) };
+            using SqlConnection connection = NewConnection(provider);
+
+            List<ColumnEncryptionKeyInfo> keys = await EnclaveDelegate.Instance.GetDecryptedKeysToBeSentToEnclaveAsync(
+                NewKeyTable(NewCipherInfoEntry(ordinal: 0), NewCipherInfoEntry(ordinal: 1), NewCipherInfoEntry(ordinal: 2)),
+                serverName: "async-ae-enclave-unit-test",
+                connection,
+                command: null,
+                CancellationToken.None);
+
+            Assert.Equal(3, keys.Count);
+            Assert.Equal(3, provider.DecryptAsyncCallCount);
+            Assert.Equal(0, provider.DecryptCallCount);
+        }
+
+        /// <summary>
+        /// The synchronous path must keep using the synchronous provider API so that custom providers which
+        /// only override the synchronous members continue to work unchanged.
+        /// </summary>
+        [Fact]
+        public void GetDecryptedKeysToBeSentToEnclave_UsesSyncProviderApi()
+        {
+            TestEnclaveKeyStoreProvider provider = new TestEnclaveKeyStoreProvider { PlaintextKey = NewPlaintextKey(seed: 37) };
+            using SqlConnection connection = NewConnection(provider);
+
+            List<ColumnEncryptionKeyInfo> keys = EnclaveDelegate.Instance.GetDecryptedKeysToBeSentToEnclave(
+                NewKeyTable(NewCipherInfoEntry()),
+                serverName: "async-ae-enclave-unit-test",
+                connection,
+                command: null);
+
+            Assert.Single(keys);
+            Assert.Equal(1, provider.DecryptCallCount);
+            Assert.Equal(0, provider.DecryptAsyncCallCount);
+        }
+
+        /// <summary>
+        /// Cancellation must surface as a cancelled task rather than being wrapped in an
+        /// Always Encrypted specific exception, and no provider call must be made.
+        /// </summary>
+        [Fact]
+        public async Task GetDecryptedKeysToBeSentToEnclaveAsync_WhenCancelled_ProducesCancelledTask()
+        {
+            TestEnclaveKeyStoreProvider provider = new TestEnclaveKeyStoreProvider { PlaintextKey = NewPlaintextKey(seed: 53) };
+            using SqlConnection connection = NewConnection(provider);
+
+            using CancellationTokenSource cts = new();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => EnclaveDelegate.Instance.GetDecryptedKeysToBeSentToEnclaveAsync(
+                    NewKeyTable(NewCipherInfoEntry()),
+                    serverName: "async-ae-enclave-unit-test",
+                    connection,
+                    command: null,
+                    cts.Token));
+
+            Assert.Equal(0, provider.DecryptAsyncCallCount);
+        }
+
+        /// <summary>
+        /// A provider failure must propagate to the caller — wrapped exactly as the synchronous path wraps
+        /// it — rather than producing a partially populated enclave key list.
+        /// </summary>
+        [Fact]
+        public async Task GetDecryptedKeysToBeSentToEnclaveAsync_WhenProviderFails_Propagates()
+        {
+            TestEnclaveKeyStoreProvider provider = new TestEnclaveKeyStoreProvider
+            {
+                DecryptAsyncCallback = _ => throw new InvalidOperationException("key store unavailable"),
+            };
+            using SqlConnection connection = NewConnection(provider);
+
+            SqlException exception = await Assert.ThrowsAsync<SqlException>(
+                () => EnclaveDelegate.Instance.GetDecryptedKeysToBeSentToEnclaveAsync(
+                    NewKeyTable(NewCipherInfoEntry()),
+                    serverName: "async-ae-enclave-unit-test",
+                    connection,
+                    command: null,
+                    CancellationToken.None));
+
+            Assert.IsType<InvalidOperationException>(exception.InnerException);
+            Assert.Equal("key store unavailable", exception.InnerException.Message);
+        }
+
+        private sealed class TestEnclaveKeyStoreProvider : SqlColumnEncryptionKeyStoreProvider
+        {
+            private int _decryptCallCount;
+            private int _decryptAsyncCallCount;
+
+            internal byte[] PlaintextKey { get; set; } = new byte[32];
+
+            internal Func<CancellationToken, Task<byte[]>> DecryptAsyncCallback { get; set; }
+
+            internal int DecryptCallCount => _decryptCallCount;
+
+            internal int DecryptAsyncCallCount => _decryptAsyncCallCount;
+
+            public override byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey)
+            {
+                Interlocked.Increment(ref _decryptCallCount);
+                return PlaintextKey;
+            }
+
+            public override Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey, CancellationToken cancellationToken = default)
+            {
+                Interlocked.Increment(ref _decryptAsyncCallCount);
+                Func<CancellationToken, Task<byte[]>> callback = DecryptAsyncCallback;
+                return callback is not null ? callback(cancellationToken) : Task.FromResult(PlaintextKey);
+            }
+
+            public override byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey)
+                => throw new NotSupportedException();
+
+            public override byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations)
+                => throw new NotSupportedException();
+
+            public override bool VerifyColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations, byte[] signature)
+                => throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/SqlQueryMetadataCacheAsyncShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/SqlQueryMetadataCacheAsyncShould.cs
@@ -144,8 +144,13 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
             Assert.True(command.Parameters[0].CipherMetadata.IsAlgorithmInitialized());
         }
 
+        /// <summary>
+        /// Cancellation says nothing about whether the cached metadata is still valid, so a cancelled
+        /// key load must not report a hit and must not evict the entry. Evicting it would make the next
+        /// caller pay for a full describe parameter encryption round trip.
+        /// </summary>
         [Fact]
-        public async Task CompleteCachedQueryMetadataAsync_WhenCancelled_DoesNotReportHit()
+        public async Task CompleteCachedQueryMetadataAsync_WhenCancelled_DoesNotReportHitOrEvictTheEntry()
         {
             TestKeyStoreProvider provider = new TestKeyStoreProvider { PlaintextKey = NewPlaintextKey(seed: 43) };
             SqlCommand command = NewCachedCommand(provider);
@@ -159,6 +164,15 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
             await Assert.ThrowsAnyAsync<OperationCanceledException>(
                 () => SqlQueryMetadataCache.GetInstance()
                     .CompleteCachedQueryMetadataAsync(command, metadata, cts.Token));
+
+            // The entry must still be there, and a subsequent uncancelled load must succeed.
+            Assert.True(SqlQueryMetadataCache.GetInstance()
+                .TryGetCachedQueryMetadata(command, out SqlQueryMetadataCache.CachedQueryMetadata retryMetadata));
+
+            Assert.True(await SqlQueryMetadataCache.GetInstance()
+                .CompleteCachedQueryMetadataAsync(command, retryMetadata, CancellationToken.None));
+
+            Assert.True(command.Parameters[0].CipherMetadata.IsAlgorithmInitialized());
         }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/SqlQueryMetadataCacheAsyncShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/SqlQueryMetadataCacheAsyncShould.cs
@@ -1,0 +1,205 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// The Always Encrypted utility layer is internal and nullable-oblivious, and several of its members
+// legitimately accept or produce nulls. Nullable analysis is disabled for this file so the tests can
+// mirror those signatures exactly.
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
+{
+    /// <summary>
+    /// Tests for the split of <see cref="SqlQueryMetadataCache"/> lookups into an in-memory probe
+    /// (<c>TryGetCachedQueryMetadata</c>) and an awaitable column encryption key load
+    /// (<c>CompleteCachedQueryMetadataAsync</c>), which is what lets asynchronous execution paths
+    /// avoid blocking the caller's thread on key store I/O.
+    /// </summary>
+    public class SqlQueryMetadataCacheAsyncShould
+    {
+        private const string ProviderName = "TEST_METADATA_CACHE_PROVIDER";
+        private const string KeyPath = "metadata-cache-key-path";
+        private const string EncryptionAlgorithm = "RSA_OAEP";
+
+        // The AEAD_AES_256_CBC_HMAC_SHA256 algorithm requires a 256 bit root key.
+        private static byte[] NewPlaintextKey(byte seed)
+        {
+            byte[] key = new byte[32];
+            for (int i = 0; i < key.Length; i++)
+            {
+                key[i] = (byte)(seed + i);
+            }
+            return key;
+        }
+
+        /// <summary>
+        /// Builds a command whose single parameter carries cipher metadata backed by unique key
+        /// material, so that neither the process-wide query metadata cache nor the process-wide
+        /// column encryption key cache can collide with another test.
+        /// </summary>
+        private static SqlCommand NewCommandWithCipherMetadata(SqlColumnEncryptionKeyStoreProvider provider)
+        {
+            SqlConnection connection = new SqlConnection(
+                "Data Source=async-ae-metadata-cache-test;Initial Catalog=async-ae-db;Column Encryption Setting=Enabled");
+            connection.RegisterColumnEncryptionKeyStoreProvidersOnConnection(
+                new Dictionary<string, SqlColumnEncryptionKeyStoreProvider> { { ProviderName, provider } });
+
+            SqlCommand command = new SqlCommand($"SELECT * FROM T WHERE C = @p -- {Guid.NewGuid()}", connection);
+            SqlParameter parameter = command.Parameters.AddWithValue("@p", 1);
+
+            SqlTceCipherInfoEntry entry = new SqlTceCipherInfoEntry(ordinal: 0);
+            entry.Add(
+                encryptedKey: Guid.NewGuid().ToByteArray(),
+                databaseId: 1,
+                cekId: 1,
+                cekVersion: 1,
+                cekMdVersion: 1,
+                keyPath: KeyPath,
+                keyStoreName: ProviderName,
+                algorithmName: EncryptionAlgorithm);
+
+            parameter.CipherMetadata = new SqlCipherMetadata(
+                entry,
+                ordinal: 0,
+                cipherAlgorithmId: 2, // AEAD_AES_256_CBC_HMAC_SHA256
+                cipherAlgorithmName: null,
+                encryptionType: 1, // Deterministic
+                normalizationRuleVersion: 1);
+
+            return command;
+        }
+
+        private static SqlCommand NewCachedCommand(SqlColumnEncryptionKeyStoreProvider provider)
+        {
+            SqlCommand command = NewCommandWithCipherMetadata(provider);
+            SqlQueryMetadataCache.GetInstance().AddQueryMetadata(command, ignoreQueriesWithReturnValueParams: true);
+            return command;
+        }
+
+        [Fact]
+        public async Task CompleteCachedQueryMetadataAsync_UsesAsyncKeyStoreProviderApi()
+        {
+            TestKeyStoreProvider provider = new TestKeyStoreProvider { PlaintextKey = NewPlaintextKey(seed: 41) };
+            SqlCommand command = NewCachedCommand(provider);
+
+            Assert.True(SqlQueryMetadataCache.GetInstance()
+                .TryGetCachedQueryMetadata(command, out SqlQueryMetadataCache.CachedQueryMetadata metadata));
+
+            // The probe must not have touched the key store: that is the whole point of the split.
+            Assert.Equal(0, provider.DecryptCallCount);
+            Assert.Equal(0, provider.DecryptAsyncCallCount);
+            Assert.NotEmpty(metadata.KeysToLoad);
+
+            Assert.True(await SqlQueryMetadataCache.GetInstance()
+                .CompleteCachedQueryMetadataAsync(command, metadata, CancellationToken.None));
+
+            Assert.Equal(1, provider.DecryptAsyncCallCount);
+            Assert.Equal(0, provider.DecryptCallCount);
+            Assert.True(command.Parameters[0].CipherMetadata.IsAlgorithmInitialized());
+        }
+
+        [Fact]
+        public async Task CompleteCachedQueryMetadataAsync_WhenKeyIsStale_ReportsMissAndClearsMetadata()
+        {
+            TestKeyStoreProvider provider = new TestKeyStoreProvider
+            {
+                DecryptAsyncCallback = _ => throw new ArgumentException("stale key"),
+            };
+            SqlCommand command = NewCachedCommand(provider);
+
+            Assert.True(SqlQueryMetadataCache.GetInstance()
+                .TryGetCachedQueryMetadata(command, out SqlQueryMetadataCache.CachedQueryMetadata metadata));
+
+            // A stale key must degrade to a cache miss rather than surface as an execution failure, so
+            // that the caller falls back to a full describe parameter encryption round trip.
+            Assert.False(await SqlQueryMetadataCache.GetInstance()
+                .CompleteCachedQueryMetadataAsync(command, metadata, CancellationToken.None));
+
+            Assert.Null(command.Parameters[0].CipherMetadata);
+
+            // The entry must have been invalidated so the next lookup does not repeat the failure.
+            Assert.False(SqlQueryMetadataCache.GetInstance().TryGetCachedQueryMetadata(command, out _));
+        }
+
+        /// <summary>
+        /// The synchronous lookup is now expressed in terms of the same probe, so guard that it still
+        /// uses the synchronous key store provider API and still reports a hit.
+        /// </summary>
+        [Fact]
+        public void GetQueryMetadataIfExists_StillUsesSyncKeyStoreProviderApi()
+        {
+            TestKeyStoreProvider provider = new TestKeyStoreProvider { PlaintextKey = NewPlaintextKey(seed: 47) };
+            SqlCommand command = NewCachedCommand(provider);
+
+            Assert.True(SqlQueryMetadataCache.GetInstance().GetQueryMetadataIfExists(command));
+
+            Assert.Equal(1, provider.DecryptCallCount);
+            Assert.Equal(0, provider.DecryptAsyncCallCount);
+            Assert.True(command.Parameters[0].CipherMetadata.IsAlgorithmInitialized());
+        }
+
+        [Fact]
+        public async Task CompleteCachedQueryMetadataAsync_WhenCancelled_DoesNotReportHit()
+        {
+            TestKeyStoreProvider provider = new TestKeyStoreProvider { PlaintextKey = NewPlaintextKey(seed: 43) };
+            SqlCommand command = NewCachedCommand(provider);
+
+            Assert.True(SqlQueryMetadataCache.GetInstance()
+                .TryGetCachedQueryMetadata(command, out SqlQueryMetadataCache.CachedQueryMetadata metadata));
+
+            using CancellationTokenSource cts = new();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => SqlQueryMetadataCache.GetInstance()
+                    .CompleteCachedQueryMetadataAsync(command, metadata, cts.Token));
+        }
+
+        /// <summary>
+        /// A key store provider whose sync and async paths are separately observable, so that tests can
+        /// assert which path was taken and how many times.
+        /// </summary>
+        private sealed class TestKeyStoreProvider : SqlColumnEncryptionKeyStoreProvider
+        {
+            private int _decryptCallCount;
+            private int _decryptAsyncCallCount;
+
+            internal byte[] PlaintextKey { get; set; } = new byte[32];
+
+            internal Func<CancellationToken, Task<byte[]>> DecryptAsyncCallback { get; set; }
+
+            internal int DecryptCallCount => _decryptCallCount;
+
+            internal int DecryptAsyncCallCount => _decryptAsyncCallCount;
+
+            public override byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey)
+            {
+                Interlocked.Increment(ref _decryptCallCount);
+                return PlaintextKey;
+            }
+
+            public override Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey, CancellationToken cancellationToken = default)
+            {
+                Interlocked.Increment(ref _decryptAsyncCallCount);
+                cancellationToken.ThrowIfCancellationRequested();
+                Func<CancellationToken, Task<byte[]>> callback = DecryptAsyncCallback;
+                return callback is not null ? callback(cancellationToken) : Task.FromResult(PlaintextKey);
+            }
+
+            public override byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey)
+                => throw new NotSupportedException();
+
+            public override byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations)
+                => throw new NotSupportedException();
+
+            public override bool VerifyColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations, byte[] signature)
+                => throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/SqlQueryMetadataCacheAsyncShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/SqlQueryMetadataCacheAsyncShould.cs
@@ -67,9 +67,9 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
             parameter.CipherMetadata = new SqlCipherMetadata(
                 entry,
                 ordinal: 0,
-                cipherAlgorithmId: 2, // AEAD_AES_256_CBC_HMAC_SHA256
+                cipherAlgorithmId: TdsEnums.AEAD_AES_256_CBC_HMAC_SHA256,
                 cipherAlgorithmName: null,
-                encryptionType: 1, // Deterministic
+                encryptionType: (byte)SqlClientEncryptionType.Deterministic,
                 normalizationRuleVersion: 1);
 
             return command;

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/SqlSecurityUtilityAsyncShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/SqlSecurityUtilityAsyncShould.cs
@@ -384,6 +384,41 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
         }
 
         /// <summary>
+        /// A decryption that has already succeeded must not be thrown away just because the caller
+        /// cancelled while the result was being published. The remote work is done at that point, so
+        /// discarding it would only force the next caller to repeat it.
+        /// </summary>
+        [Fact]
+        public async Task GetKeyAsync_WhenCancelledAfterDecryptSucceeds_StillPublishesTheKey()
+        {
+            SqlSymmetricKeyCache cache = SqlSymmetricKeyCache.GetInstance();
+
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            TestKeyStoreProvider provider = new TestKeyStoreProvider
+            {
+                DecryptAsyncCallback = _ =>
+                {
+                    // Cancel between a successful provider call and the cache insertion.
+                    cts.Cancel();
+                    return Task.FromResult(NewPlaintextKey(seed: 57));
+                }
+            };
+
+            using SqlConnection connection = NewConnection((ProviderName, provider));
+            SqlEncryptionKeyInfo keyInfo = NewKeyInfo();
+
+            SqlClientSymmetricKey key = await cache.GetKeyAsync(keyInfo, connection, command: null, cts.Token);
+
+            Assert.NotNull(key);
+            Assert.Equal(1, provider.DecryptAsyncCallCount);
+
+            // The key was published despite the cancellation, so no second decryption is needed.
+            Assert.Same(key, cache.GetKey(keyInfo, connection, command: null));
+            Assert.Equal(1, provider.DecryptAsyncCallCount);
+            Assert.Equal(0, provider.DecryptCallCount);
+        }
+
+        /// <summary>
         /// Verifies that cancellation of GetKeyAsync is observed before the provider call and while it
         /// is in flight, and that nothing is published to the cache in either case.
         /// </summary>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/SqlSecurityUtilityAsyncShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/SqlSecurityUtilityAsyncShould.cs
@@ -1,0 +1,486 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// The Always Encrypted utility layer is internal and nullable-oblivious, and several of its members
+// legitimately accept or produce nulls. Nullable analysis is disabled for this file so the tests can
+// mirror those signatures exactly.
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
+{
+    /// <summary>
+    /// Tests for the async counterparts of the Always Encrypted utility layer:
+    /// <see cref="SqlSecurityUtility"/>.DecryptSymmetricKeyAsync / VerifyColumnMasterKeySignatureAsync
+    /// and <see cref="SqlSymmetricKeyCache"/>.GetKeyAsync.
+    /// </summary>
+    public class SqlSecurityUtilityAsyncShould
+    {
+        private const string ProviderName = "TEST_ASYNC_PROVIDER";
+        private const string SecondProviderName = "TEST_ASYNC_PROVIDER_2";
+        private const string KeyPath = "test-key-path";
+        private const string SecondKeyPath = "test-key-path-2";
+        private const string EncryptionAlgorithm = "RSA_OAEP";
+
+        // The AEAD_AES_256_CBC_HMAC_SHA256 algorithm requires a 256 bit root key.
+        private static byte[] NewPlaintextKey(byte seed)
+        {
+            byte[] key = new byte[32];
+            for (int i = 0; i < key.Length; i++)
+            {
+                key[i] = (byte)(seed + i);
+            }
+            return key;
+        }
+
+        /// <summary>
+        /// Produces key material whose cache lookup key cannot collide with any other test. The CEK
+        /// cache is a process-wide singleton shared by every test in this assembly.
+        /// </summary>
+        private static SqlEncryptionKeyInfo NewKeyInfo(string providerName = ProviderName, string keyPath = KeyPath)
+            => new SqlEncryptionKeyInfo
+            {
+                encryptedKey = Guid.NewGuid().ToByteArray(),
+                databaseId = 1,
+                cekId = 1,
+                cekVersion = 1,
+                cekMdVersion = 1,
+                keyPath = keyPath,
+                keyStoreName = providerName,
+                algorithmName = EncryptionAlgorithm,
+            };
+
+        private static SqlConnection NewConnection(params (string Name, SqlColumnEncryptionKeyStoreProvider Provider)[] providers)
+        {
+            SqlConnection connection = new SqlConnection("Data Source=async-ae-unit-test;Column Encryption Setting=Enabled");
+            Dictionary<string, SqlColumnEncryptionKeyStoreProvider> map = new();
+            foreach ((string name, SqlColumnEncryptionKeyStoreProvider provider) in providers)
+            {
+                map[name] = provider;
+            }
+            connection.RegisterColumnEncryptionKeyStoreProvidersOnConnection(map);
+            return connection;
+        }
+
+        private static SqlTceCipherInfoEntry NewCipherInfoEntry(params SqlEncryptionKeyInfo[] keyInfos)
+        {
+            SqlTceCipherInfoEntry entry = new SqlTceCipherInfoEntry(ordinal: 0);
+            foreach (SqlEncryptionKeyInfo keyInfo in keyInfos)
+            {
+                entry.Add(keyInfo.encryptedKey, keyInfo.databaseId, keyInfo.cekId, keyInfo.cekVersion,
+                    keyInfo.cekMdVersion, keyInfo.keyPath, keyInfo.keyStoreName, keyInfo.algorithmName);
+            }
+            return entry;
+        }
+
+        #region DecryptSymmetricKeyAsync - multi key fallback
+
+        /// <summary>
+        /// Verifies that the per-key fallback loop of the sync overload is preserved: when the first
+        /// candidate key fails, the next one is attempted and its key info is the one reported.
+        /// </summary>
+        [Fact]
+        public async Task DecryptSymmetricKeyAsync_WhenFirstKeyFails_FallsBackToSecondKey()
+        {
+            byte[] expectedKey = NewPlaintextKey(seed: 7);
+            TestKeyStoreProvider failing = new TestKeyStoreProvider { DecryptAsyncCallback = _ => throw new InvalidOperationException("first key unavailable") };
+            TestKeyStoreProvider succeeding = new TestKeyStoreProvider { PlaintextKey = expectedKey };
+
+            using SqlConnection connection = NewConnection((ProviderName, failing), (SecondProviderName, succeeding));
+
+            SqlTceCipherInfoEntry entry = NewCipherInfoEntry(
+                NewKeyInfo(ProviderName, KeyPath),
+                NewKeyInfo(SecondProviderName, SecondKeyPath));
+
+            (SqlClientSymmetricKey key, SqlEncryptionKeyInfo keyInfoChosen) =
+                await SqlSecurityUtility.DecryptSymmetricKeyAsync(entry, connection, command: null, CancellationToken.None);
+
+            Assert.NotNull(key);
+            Assert.Equal(expectedKey, key.RootKey);
+            Assert.Equal(SecondProviderName, keyInfoChosen.keyStoreName);
+            Assert.Equal(1, failing.DecryptAsyncCallCount);
+            Assert.Equal(1, succeeding.DecryptAsyncCallCount);
+        }
+
+        /// <summary>
+        /// Verifies that when every candidate key fails, the last exception is rethrown, matching the
+        /// sync overload.
+        /// </summary>
+        [Fact]
+        public async Task DecryptSymmetricKeyAsync_WhenAllKeysFail_ThrowsLastException()
+        {
+            TestKeyStoreProvider failing = new TestKeyStoreProvider { DecryptAsyncCallback = _ => throw new InvalidOperationException("boom") };
+            using SqlConnection connection = NewConnection((ProviderName, failing));
+
+            SqlTceCipherInfoEntry entry = NewCipherInfoEntry(NewKeyInfo(), NewKeyInfo());
+
+            // Failures from the provider are reported as SQL.KeyDecryptionFailed.
+            SqlException exception = await Assert.ThrowsAsync<SqlException>(
+                () => SqlSecurityUtility.DecryptSymmetricKeyAsync(entry, connection, command: null, CancellationToken.None));
+
+            Assert.Contains("boom", exception.ToString());
+            Assert.Equal(2, failing.DecryptAsyncCallCount);
+        }
+
+        /// <summary>
+        /// Verifies that the SqlCipherMetadata overload mutates the metadata exactly as the sync overload does.
+        /// </summary>
+        [Fact]
+        public async Task DecryptSymmetricKeyAsync_WithCipherMetadata_PopulatesAlgorithmAndKeyInfo()
+        {
+            TestKeyStoreProvider provider = new TestKeyStoreProvider { PlaintextKey = NewPlaintextKey(seed: 3) };
+            using SqlConnection connection = NewConnection((ProviderName, provider));
+
+            SqlEncryptionKeyInfo keyInfo = NewKeyInfo();
+            SqlCipherMetadata metadata = new SqlCipherMetadata(
+                NewCipherInfoEntry(keyInfo),
+                ordinal: 0,
+                cipherAlgorithmId: (byte)TdsEnums.AEAD_AES_256_CBC_HMAC_SHA256,
+                cipherAlgorithmName: null,
+                encryptionType: (byte)SqlClientEncryptionType.Deterministic,
+                normalizationRuleVersion: 0x01);
+
+            await SqlSecurityUtility.DecryptSymmetricKeyAsync(metadata, connection, command: null, CancellationToken.None);
+
+            Assert.True(metadata.IsAlgorithmInitialized());
+            Assert.NotNull(metadata.EncryptionKeyInfo);
+            Assert.Equal(keyInfo.keyStoreName, metadata.EncryptionKeyInfo.keyStoreName);
+        }
+
+        #endregion
+
+        #region DecryptSymmetricKeyAsync - cancellation
+
+        /// <summary>
+        /// Verifies that a token cancelled before the call is observed without invoking the provider.
+        /// </summary>
+        [Fact]
+        public async Task DecryptSymmetricKeyAsync_WithCancelledToken_CancelsWithoutInvokingProvider()
+        {
+            TestKeyStoreProvider provider = new TestKeyStoreProvider { PlaintextKey = NewPlaintextKey(seed: 1) };
+            using SqlConnection connection = NewConnection((ProviderName, provider));
+            SqlTceCipherInfoEntry entry = NewCipherInfoEntry(NewKeyInfo());
+
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => SqlSecurityUtility.DecryptSymmetricKeyAsync(entry, connection, command: null, cts.Token));
+
+            Assert.Equal(0, provider.DecryptAsyncCallCount);
+        }
+
+        /// <summary>
+        /// Verifies that a cancellation observed mid-flight is neither swallowed by the per-key fallback
+        /// loop nor wrapped in SQL.KeyDecryptionFailed, and that the remaining candidate keys are not tried.
+        /// </summary>
+        [Fact]
+        public async Task DecryptSymmetricKeyAsync_WhenCancelledMidFlight_DoesNotAttemptRemainingKeys()
+        {
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            TaskCompletionSource<bool> providerEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            TestKeyStoreProvider provider = new TestKeyStoreProvider
+            {
+                DecryptAsyncCallback = async token =>
+                {
+                    providerEntered.TrySetResult(true);
+                    await Task.Delay(Timeout.Infinite, token);
+                    return NewPlaintextKey(seed: 2);
+                }
+            };
+
+            using SqlConnection connection = NewConnection((ProviderName, provider));
+            SqlTceCipherInfoEntry entry = NewCipherInfoEntry(NewKeyInfo(), NewKeyInfo());
+
+            Task decryptTask = SqlSecurityUtility.DecryptSymmetricKeyAsync(entry, connection, command: null, cts.Token);
+            await providerEntered.Task;
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => decryptTask);
+            Assert.True(decryptTask.IsCanceled);
+
+            // The second key was never attempted: cancellation abandons the loop.
+            Assert.Equal(1, provider.DecryptAsyncCallCount);
+        }
+
+        #endregion
+
+        #region VerifyColumnMasterKeySignatureAsync
+
+        /// <summary>
+        /// Verifies that a valid signature completes and an invalid one is reported the same way the
+        /// sync path reports it.
+        /// </summary>
+        [Fact]
+        public async Task VerifyColumnMasterKeySignatureAsync_ReportsProviderResult()
+        {
+            TestKeyStoreProvider provider = new TestKeyStoreProvider { VerifyResult = true };
+            using SqlConnection connection = NewConnection((ProviderName, provider));
+
+            await SqlSecurityUtility.VerifyColumnMasterKeySignatureAsync(
+                ProviderName, KeyPath, isEnclaveEnabled: false, CMKSignature: new byte[] { 1, 2, 3 },
+                connection, command: null, CancellationToken.None);
+
+            Assert.Equal(1, provider.VerifyAsyncCallCount);
+
+            provider.VerifyResult = false;
+            await Assert.ThrowsAsync<InvalidOperationException>(() => SqlSecurityUtility.VerifyColumnMasterKeySignatureAsync(
+                ProviderName, KeyPath, isEnclaveEnabled: false, CMKSignature: new byte[] { 1, 2, 3 },
+                connection, command: null, CancellationToken.None));
+        }
+
+        /// <summary>
+        /// Verifies that provider failures are still wrapped in SQL.UnableToVerifyColumnMasterKeySignature.
+        /// </summary>
+        [Fact]
+        public async Task VerifyColumnMasterKeySignatureAsync_WhenProviderThrows_WrapsException()
+        {
+            TestKeyStoreProvider provider = new TestKeyStoreProvider
+            {
+                VerifyAsyncCallback = _ => throw new InvalidOperationException("verification exploded")
+            };
+            using SqlConnection connection = NewConnection((ProviderName, provider));
+
+            InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => SqlSecurityUtility.VerifyColumnMasterKeySignatureAsync(
+                    ProviderName, KeyPath, isEnclaveEnabled: false, CMKSignature: new byte[] { 1, 2, 3 },
+                    connection, command: null, CancellationToken.None));
+
+            Assert.Contains("verification exploded", exception.ToString());
+        }
+
+        /// <summary>
+        /// Verifies that cancellation surfaces as a cancelled Task rather than being wrapped in
+        /// SQL.UnableToVerifyColumnMasterKeySignature, both before and during the provider call.
+        /// </summary>
+        [Fact]
+        public async Task VerifyColumnMasterKeySignatureAsync_WhenCancelled_ProducesCancelledTask()
+        {
+            TestKeyStoreProvider provider = new TestKeyStoreProvider { VerifyResult = true };
+            using SqlConnection connection = NewConnection((ProviderName, provider));
+
+            using CancellationTokenSource preCancelled = new CancellationTokenSource();
+            preCancelled.Cancel();
+
+            Task preCancelledTask = SqlSecurityUtility.VerifyColumnMasterKeySignatureAsync(
+                ProviderName, KeyPath, isEnclaveEnabled: false, CMKSignature: new byte[] { 1, 2, 3 },
+                connection, command: null, preCancelled.Token);
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => preCancelledTask);
+            Assert.True(preCancelledTask.IsCanceled);
+            Assert.Equal(0, provider.VerifyAsyncCallCount);
+
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            TaskCompletionSource<bool> providerEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            provider.VerifyAsyncCallback = async token =>
+            {
+                providerEntered.TrySetResult(true);
+                await Task.Delay(Timeout.Infinite, token);
+                return true;
+            };
+
+            Task verifyTask = SqlSecurityUtility.VerifyColumnMasterKeySignatureAsync(
+                ProviderName, "unique-" + Guid.NewGuid(), isEnclaveEnabled: false, CMKSignature: new byte[] { 4, 5, 6 },
+                connection, command: null, cts.Token);
+
+            await providerEntered.Task;
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => verifyTask);
+            Assert.True(verifyTask.IsCanceled);
+        }
+
+        #endregion
+
+        #region SqlSymmetricKeyCache.GetKeyAsync
+
+        /// <summary>
+        /// Verifies that a key cached by the sync path is reused by the async path without a second
+        /// provider call, and vice versa.
+        /// </summary>
+        [Fact]
+        public async Task GetKeyAsync_ReusesEntriesCachedBySyncPath_AndViceVersa()
+        {
+            SqlSymmetricKeyCache cache = SqlSymmetricKeyCache.GetInstance();
+
+            TestKeyStoreProvider provider = new TestKeyStoreProvider { PlaintextKey = NewPlaintextKey(seed: 11) };
+            using SqlConnection connection = NewConnection((ProviderName, provider));
+
+            // Sync first, then async.
+            SqlEncryptionKeyInfo syncFirst = NewKeyInfo();
+            SqlClientSymmetricKey fromSync = cache.GetKey(syncFirst, connection, command: null);
+            SqlClientSymmetricKey fromAsync = await cache.GetKeyAsync(syncFirst, connection, command: null, CancellationToken.None);
+
+            Assert.Same(fromSync, fromAsync);
+            Assert.Equal(1, provider.DecryptCallCount);
+            Assert.Equal(0, provider.DecryptAsyncCallCount);
+
+            // Async first, then sync.
+            SqlEncryptionKeyInfo asyncFirst = NewKeyInfo();
+            SqlClientSymmetricKey asyncKey = await cache.GetKeyAsync(asyncFirst, connection, command: null, CancellationToken.None);
+            SqlClientSymmetricKey syncKey = cache.GetKey(asyncFirst, connection, command: null);
+
+            Assert.Same(asyncKey, syncKey);
+            Assert.Equal(1, provider.DecryptCallCount);
+            Assert.Equal(1, provider.DecryptAsyncCallCount);
+        }
+
+        /// <summary>
+        /// Verifies the documented consequence of check-release-fetch-relock (FR-012/FR-014): concurrent
+        /// async cache misses for the same key may each decrypt it, but all callers end up observing the
+        /// same cached key instance, and neither caller deadlocks behind the process-wide cache gate.
+        /// </summary>
+        [Fact]
+        public async Task GetKeyAsync_WithConcurrentCacheMisses_FetchesTwiceButPublishesOneKey()
+        {
+            SqlSymmetricKeyCache cache = SqlSymmetricKeyCache.GetInstance();
+
+            TaskCompletionSource<bool> release = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            int entered = 0;
+            TaskCompletionSource<bool> bothEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            TestKeyStoreProvider provider = new TestKeyStoreProvider
+            {
+                DecryptAsyncCallback = async _ =>
+                {
+                    if (Interlocked.Increment(ref entered) == 2)
+                    {
+                        bothEntered.TrySetResult(true);
+                    }
+                    await release.Task;
+                    return NewPlaintextKey(seed: 21);
+                }
+            };
+
+            using SqlConnection connection = NewConnection((ProviderName, provider));
+            SqlEncryptionKeyInfo keyInfo = NewKeyInfo();
+
+            Task<SqlClientSymmetricKey> first = cache.GetKeyAsync(keyInfo, connection, command: null, CancellationToken.None);
+            Task<SqlClientSymmetricKey> second = cache.GetKeyAsync(keyInfo, connection, command: null, CancellationToken.None);
+
+            // Both callers reach the provider concurrently, which proves the cache gate is not held
+            // across the awaited decryption.
+            await bothEntered.Task;
+            release.TrySetResult(true);
+
+            SqlClientSymmetricKey firstKey = await first;
+            SqlClientSymmetricKey secondKey = await second;
+
+            Assert.Equal(2, provider.DecryptAsyncCallCount);
+            Assert.Same(firstKey, secondKey);
+
+            // Subsequent callers, sync or async, see the published instance without another fetch.
+            Assert.Same(firstKey, cache.GetKey(keyInfo, connection, command: null));
+            Assert.Same(firstKey, await cache.GetKeyAsync(keyInfo, connection, command: null, CancellationToken.None));
+            Assert.Equal(2, provider.DecryptAsyncCallCount);
+            Assert.Equal(0, provider.DecryptCallCount);
+        }
+
+        /// <summary>
+        /// Verifies that cancellation of GetKeyAsync is observed before the provider call and while it
+        /// is in flight, and that nothing is published to the cache in either case.
+        /// </summary>
+        [Fact]
+        public async Task GetKeyAsync_WhenCancelled_ProducesCancelledTaskAndDoesNotCache()
+        {
+            SqlSymmetricKeyCache cache = SqlSymmetricKeyCache.GetInstance();
+
+            TestKeyStoreProvider provider = new TestKeyStoreProvider { PlaintextKey = NewPlaintextKey(seed: 31) };
+            using SqlConnection connection = NewConnection((ProviderName, provider));
+            SqlEncryptionKeyInfo keyInfo = NewKeyInfo();
+
+            using CancellationTokenSource preCancelled = new CancellationTokenSource();
+            preCancelled.Cancel();
+
+            Task preCancelledTask = cache.GetKeyAsync(keyInfo, connection, command: null, preCancelled.Token);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => preCancelledTask);
+            Assert.True(preCancelledTask.IsCanceled);
+            Assert.Equal(0, provider.DecryptAsyncCallCount);
+
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            TaskCompletionSource<bool> providerEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            provider.DecryptAsyncCallback = async token =>
+            {
+                providerEntered.TrySetResult(true);
+                await Task.Delay(Timeout.Infinite, token);
+                return NewPlaintextKey(seed: 32);
+            };
+
+            Task inFlight = cache.GetKeyAsync(keyInfo, connection, command: null, cts.Token);
+            await providerEntered.Task;
+            cts.Cancel();
+
+            // Cancellation is not wrapped in SQL.KeyDecryptionFailed.
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => inFlight);
+            Assert.True(inFlight.IsCanceled);
+
+            // Nothing was cached, so a subsequent successful call still reaches the provider.
+            provider.DecryptAsyncCallback = null;
+            SqlClientSymmetricKey key = await cache.GetKeyAsync(keyInfo, connection, command: null, CancellationToken.None);
+            Assert.Equal(provider.PlaintextKey, key.RootKey);
+        }
+
+        #endregion
+
+        /// <summary>
+        /// A key store provider whose sync and async paths are separately observable, so that tests can
+        /// assert which path was taken and how many times.
+        /// </summary>
+        private sealed class TestKeyStoreProvider : SqlColumnEncryptionKeyStoreProvider
+        {
+            private int _decryptCallCount;
+            private int _decryptAsyncCallCount;
+            private int _verifyAsyncCallCount;
+
+            internal byte[] PlaintextKey { get; set; } = new byte[32];
+
+            internal bool VerifyResult { get; set; }
+
+            internal Func<CancellationToken, Task<byte[]>> DecryptAsyncCallback { get; set; }
+
+            internal Func<CancellationToken, Task<bool>> VerifyAsyncCallback { get; set; }
+
+            internal int DecryptCallCount => _decryptCallCount;
+
+            internal int DecryptAsyncCallCount => _decryptAsyncCallCount;
+
+            internal int VerifyAsyncCallCount => _verifyAsyncCallCount;
+
+            public override byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey)
+            {
+                Interlocked.Increment(ref _decryptCallCount);
+                return PlaintextKey;
+            }
+
+            public override Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey, CancellationToken cancellationToken = default)
+            {
+                Interlocked.Increment(ref _decryptAsyncCallCount);
+                Func<CancellationToken, Task<byte[]>> callback = DecryptAsyncCallback;
+                return callback is not null ? callback(cancellationToken) : Task.FromResult(PlaintextKey);
+            }
+
+            public override byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey)
+                => throw new NotSupportedException();
+
+            public override byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations)
+                => throw new NotSupportedException();
+
+            public override bool VerifyColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations, byte[] signature)
+                => VerifyResult;
+
+            public override Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature, CancellationToken cancellationToken = default)
+            {
+                Interlocked.Increment(ref _verifyAsyncCallCount);
+                Func<CancellationToken, Task<bool>> callback = VerifyAsyncCallback;
+                return callback is not null ? callback(cancellationToken) : Task.FromResult(VerifyResult);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

`SqlColumnEncryptionKeyStoreProvider` gained async APIs in #4540, but nothing in the driver called them. Every Always Encrypted key store operation still went through the synchronous overloads, so an `ExecuteReaderAsync` against a key store that performs network I/O (Azure Key Vault, for example) blocked a thread for the duration of the round trip. This PR wires the async APIs into the Always Encrypted execution paths so async callers get a genuine end-to-end async experience.

### Async utility layer

Adds async counterparts to the Always Encrypted utility layer, mirroring their synchronous versions:

- `SqlSecurityUtility.DecryptSymmetricKeyAsync` (both the `SqlCipherMetadata` and `SqlTceCipherInfoEntry` overloads), `GetKeyFromLocalProvidersAsync`, `VerifyColumnMasterKeySignatureAsync`
- `SqlSymmetricKeyCache.GetKeyAsync`, which never holds the cache lock across provider I/O. Concurrent decryptions of the same key are allowed to race, and the first writer wins.
- `EnclaveDelegate.GetDecryptedKeysToBeSentToEnclaveAsync` and `GenerateEnclavePackageAsync`

Each async method shares its parsing, validation, and error-wrapping logic with the existing synchronous version, so provider failures still surface as the same wrapped `SqlException` and multi-key fallback still behaves identically. The one deliberate divergence: `DecryptSymmetricKeyAsync` rethrows `OperationCanceledException` immediately instead of continuing to try the remaining candidate keys.

### Call site integration

The describe-parameter-encryption pipeline was restructured so that sync and async share one parser. `ReadDescribeEncryptionParameterResultsCore` now records the signature verifications and key decryptions it discovers into a `PendingColumnEncryptionKeyOperations` list rather than performing them inline; thin sync and async wrappers then execute that work. This avoids duplicating roughly 350 lines of TDS token parsing, and has a useful side effect: no key store call now happens while the describe reader is mid-result-set.

`GenerateEnclavePackage` and the post-describe execution continuation gained async counterparts built on shared helpers (`TryPrepareEnclavePackageGeneration`, `BuildEnclavePackage`, `CreateColumnEncryptionKeyInfo`), so both modes perform identical validation and throw identical exceptions.

### Cancellation

The async provider APIs all accept a `CancellationToken`, but the Always Encrypted call sites had no way to reach the token supplied to `ExecuteReaderAsync` / `ExecuteNonQueryAsync` / `ExecuteXmlReaderAsync`. The token is now captured in a per-execution field on `SqlCommand`, set at each async entry point and cleared by the matching cleanup continuation, and passed down into the key operations and enclave package generation.

A field is used rather than signature plumbing because the token would otherwise have to thread through several sync-only overloads of `RunExecuteReader` and `PrepareForTransparentEncryption`. This mirrors how existing per-execution mutable state such as `_cachedAsyncState` is handled.

### Query metadata cache

On a metadata cache hit the driver still loaded every column encryption key synchronously on the caller's thread. The lookup is now split into an in-memory probe (`TryGetCachedQueryMetadata`), which matches cached cipher metadata onto the parameters and reports which keys still need decrypting, and a completion step that loads them. The synchronous lookup is expressed in terms of the same probe, so its behaviour, including stale-key fallback and the hit/miss counters, is unchanged.

## Notes for reviewers

A few things worth a careful look:

- **`usedCache` is over-reported on the async cache-hit path.** When cached key information turns out to be stale, the returned task falls back to a full describe round trip, but the command has already reported `usedCache = true` because the caller returned before the fallback was discovered. This is deliberately conservative: over-reporting a cache hit can only cost one extra retry of an already-failing execution, whereas under-reporting it would suppress the `TCE_CONVERSION_ERROR_CLIENT_RETRY` retry that a genuine cache hit depends on.
- **`Task.Run` is retained on purpose** in `GetParameterEncryptionDataReader` and `RunExecuteReaderTdsWithTransparentParameterEncryption`. Removing it would be a regression rather than a simplification: `PrepareForTransparentEncryption` runs synchronously on the caller's thread under `ExecuteReaderAsync`, and both bodies issue blocking TDS writes before their first await. `Task.Run` reproduces the thread pool hand-off the previous `ContinueWith` chain provided and keeps continuations off network callback threads.
- **Error semantics were preserved precisely.** `AsyncHelper.CreateContinuationTaskWithState` invokes its failure callback only when the antecedent actually faulted, not on cancellation, hence the explicit `catch (OperationCanceledException) { throw; }` ahead of the `ResetAsyncState()` handler.
- **Side-effect ordering changed slightly** in the describe pipeline: `keysToBeSentToEnclave` and `requiresEnclaveComputations` are now populated before a failing signature check rather than after. This is safe because `ResetEncryptionState()` runs at the start of every execution.
- **Async cache hits now cost one extra thread pool dispatch.** That is the price of not issuing the command's TDS write from the caller's thread. Sync callers are unaffected, and when the CEK is already in the symmetric key cache the completion runs synchronously anyway.
- A duplicated `#if DEBUG` failpoint block was replaced with a `[Conditional("DEBUG")]` method. The call is elided in Release exactly as before, and the static fields that ManualTests reflect on are untouched.

No public API changes. No behaviour change for synchronous callers.

## Behaviour notes worth a careful look

**Exception ordering on malformed describe results.** Key store work is now deferred until
after the `sp_describe_parameter_encryption` result set has been fully read, so that no key
store HTTP happens while the describe reader is mid-result-set. A side effect is that if a
result set is both malformed *and* contains a bad key, the parsing error now surfaces first
where the key store error used to. Both cases still throw; only which exception wins has
changed.

**`Task.Run` in `GetParameterEncryptionDataReaderAsync` is deliberate.** It looks like a
removable thread-pool hop, but the task being waited on is completed by the SNI network write
callback, so an inline continuation would run blocking TDS reads on a callback thread. There
is a comment on the method saying so.

**Column encryption key decryption stays sequential.** Distinct cipher metadata entries often
share a key, and `GetKeyAsync` does not hold its gate across provider I/O, so decrypting in
parallel would let concurrent misses for the same key each issue their own key store call.
Sequential decryption lets the first result warm the cache.

## Scope

Async enclave *attestation* is not in this PR. It adds `virtual` async members to the public
`SqlColumnEncryptionEnclaveProvider` hierarchy, so it needs reference assembly updates and API
review, and ships separately. The one remaining blocking call on the async path,
`GetEnclaveSession`, is marked with a `@TODO` pointing at that work.

## Issues

Part of the async Always Encrypted work tracked by #3672, following on from #4540.

## Testing

**Unit tests** (`src/Microsoft.Data.SqlClient/tests/UnitTests/`):

- `SqlSecurityUtilityAsyncShould` (12 tests) covers `DecryptSymmetricKeyAsync` multi-key fallback, cancellation, provider failure wrapping, `VerifyColumnMasterKeySignatureAsync`, and `SqlSymmetricKeyCache.GetKeyAsync` cache behaviour.
- `EnclaveDelegateAsyncShould` (5 tests) proves the enclave path uses the async provider API, the sync path still uses the sync API, cancellation produces a cancelled task with no provider call, and failures wrap correctly.
- `SqlQueryMetadataCacheAsyncShould` (4 tests) covers async API usage on cache completion, stale-key degradation to a miss, cancellation, and a regression guard that the sync lookup still uses the sync provider API.

**Manual test** (`AsyncKeyStoreProviderTests`): registers a recording key store provider and asserts that sync execution hits the sync overload, that `ExecuteReaderAsync` / `ExecuteNonQueryAsync` hit the async overload and never the sync one, and that cancelling the caller's token cancels the key store operation. This test requires a live SQL Server plus key store, so it is not part of local verification.

**Verified locally:** Debug and Release builds of the driver on net8.0 with 0 warnings, ManualTests and FunctionalTests compile, and 160 targeted unit tests pass. Three failures in `NativeColumnEncryptionKeyBaseline` are pre-existing on macOS and unrelated (they fail in `Interop.AppleCrypto.X509StoreAddCertificate` against the system keychain).

**Not verified locally:** end-to-end Always Encrypted behaviour against a real server and Azure Key Vault. That validation is being done separately, which is why this is a draft.

## Guidelines

Please review the contribution guidelines before submitting a pull request:

- [Contributing](/CONTRIBUTING.md)
- [Code of Conduct](/CODE_OF_CONDUCT.md)
- [Best Practices](/policy/coding-best-practices.md)
- [Coding Style](/policy/coding-style.md)
- [Review Process](/policy/review-process.md)

