### PR TITLE
Improve connection pool failure diagnostics

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlException.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlException.xml
@@ -307,6 +307,41 @@
       <seealso cref="T:Microsoft.Data.SqlClient.SqlErrorCollection" />
       <seealso cref="T:Microsoft.Data.SqlClient.SqlError" />
     </Errors>
+    <ConnectionOpenRetryFailures>
+      <summary>
+        Gets the transient failures that caused retries before this connection open operation ultimately failed.
+      </summary>
+      <value>
+        A read-only list in retry order. The list is empty when the exception was not produced by a retried connection open operation.
+      </value>
+      <remarks>
+        <para>
+          The terminal failure is represented by this <see cref="T:Microsoft.Data.SqlClient.SqlException" />. This property contains only earlier failures that caused the driver to retry the same connection open operation.
+        </para>
+        <para>
+          The list is scoped to one call to <see cref="M:Microsoft.Data.SqlClient.SqlConnection.Open" /> or <see cref="M:Microsoft.Data.SqlClient.SqlConnection.OpenAsync(System.Threading.CancellationToken)" /> and is discarded when the connection opens successfully.
+        </para>
+        <para>
+          Formatter-based serialization does not preserve this diagnostic list.
+        </para>
+      </remarks>
+      <example>
+        <code language="c#">
+          try
+          {
+              connection.Open();
+          }
+          catch (SqlException ex)
+          {
+              Console.WriteLine($"Final failure: {ex.Message}");
+              foreach (SqlException retryFailure in ex.ConnectionOpenRetryFailures)
+              {
+                  Console.WriteLine($"Earlier retry failure: {retryFailure.Message}");
+              }
+          }
+        </code>
+      </example>
+    </ConnectionOpenRetryFailures>
     <GetObjectData>
       <summary>To be added</summary>
     </GetObjectData>

--- a/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs
@@ -1860,6 +1860,8 @@ public sealed class SqlException : System.Data.Common.DbException
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlException.xml' path='docs/members[@name="SqlException"]/Errors/*'/>
     [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Content)]
     public Microsoft.Data.SqlClient.SqlErrorCollection Errors { get { throw null; } }
+    /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlException.xml' path='docs/members[@name="SqlException"]/ConnectionOpenRetryFailures/*'/>
+    public System.Collections.Generic.IReadOnlyList<Microsoft.Data.SqlClient.SqlException> ConnectionOpenRetryFailures { get { throw null; } }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlException.xml' path='docs/members[@name="SqlException"]/LineNumber/*'/>
     public int LineNumber { get { throw null; } }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlException.xml' path='docs/members[@name="SqlException"]/Number/*'/>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -21,6 +21,7 @@ using System.Transactions;
 using Microsoft.Data.Common.ConnectionString;
 using Microsoft.Data.SqlClient;
 using Microsoft.Data.SqlClient.Connection;
+using Microsoft.Data.SqlClient.ConnectionPool;
 using Microsoft.SqlServer.Server;
 using Microsoft.Win32;
 using IsolationLevel = System.Data.IsolationLevel;
@@ -1336,6 +1337,17 @@ namespace Microsoft.Data.Common
 #region DbConnectionPool and related
         internal static Exception PooledOpenTimeout()
             => ADP.InvalidOperation(StringsHelper.GetString(Strings.ADP_PooledOpenTimeout));
+
+        internal static Exception PooledOpenTimeout(PoolAcquisitionDiagnostics diagnostics)
+        {
+            Exception exception = ADP.InvalidOperation(
+                string.Concat(
+                    StringsHelper.GetString(Strings.ADP_PooledOpenTimeout),
+                    " ",
+                    diagnostics.GetMessage()));
+            diagnostics.AddTo(exception.Data);
+            return exception;
+        }
 
         internal static Exception NonPooledOpenTimeout()
             => ADP.TimeoutException(StringsHelper.GetString(Strings.ADP_NonPooledOpenTimeout));

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -38,6 +38,12 @@ namespace Microsoft.Data.ProviderBase
         private readonly int _objectId = Interlocked.Increment(ref _objectTypeCount);
 
         /// <summary>
+        /// UTC time at which this internal connection was most recently handed to an owning
+        /// <see cref="DbConnection"/>. Cleared when it returns to the pool.
+        /// </summary>
+        private DateTime _checkoutTime;
+
+        /// <summary>
         /// [usage must be thread safe] the owning object, when not in the pool. (both Pooled and Non-Pooled connections)
         /// </summary>
         private readonly WeakReference<DbConnection> _owningObject = new WeakReference<DbConnection>(null, false);
@@ -118,6 +124,17 @@ namespace Microsoft.Data.ProviderBase
         /// The pool reads this value to decide whether the connection has sat idle longer than the configured idle timeout.
         /// </summary>
         internal DateTime ReturnedTime { get; set; }
+
+        /// <summary>
+        /// UTC timestamp of the current checkout, or <see cref="DateTime.MinValue"/> while the
+        /// connection is not owned by an application connection. The internal setter supports
+        /// deterministic timeout diagnostics tests.
+        /// </summary>
+        internal DateTime CheckoutTime
+        {
+            get => _checkoutTime;
+            set => _checkoutTime = value;
+        }
 
         /// <summary>
         /// The pool generation at the time this connection was created or added to the pool.
@@ -730,8 +747,10 @@ namespace Microsoft.Data.ProviderBase
             Pool = connectionPool;
         }
 
-        internal void PostPop(DbConnection newOwner)
+        internal void PostPop(DbConnection newOwner, DateTime checkoutTime)
         {
+            Debug.Assert(checkoutTime.Kind == DateTimeKind.Utc);
+
             // Called by IDbConnectionPool right after it pulls this from its pool, we take this
             // opportunity to ensure ownership and pool counts are legit.
             Debug.Assert(!IsEmancipated, "pooled object not in pool");
@@ -746,6 +765,7 @@ namespace Microsoft.Data.ProviderBase
 
             _owningObject.SetTarget(newOwner);
             _pooledCount--;
+            _checkoutTime = checkoutTime;
 
             SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.PostPop|RES|CPOOL> {0}, Preparing to pop from pool,  owning connection {1}, pooledCount={2}", ObjectID, 0, _pooledCount);
 
@@ -819,11 +839,59 @@ namespace Microsoft.Data.ProviderBase
             SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.PrePush|RES|CPOOL> {0}, Preparing to push into pool, owning connection {1}, pooledCount={2}", ObjectID, 0, _pooledCount);
 
             _pooledCount++;
+            _checkoutTime = DateTime.MinValue;
 
             // NOTE: doing this and checking for InternalError.PooledObjectHasOwner degrades the
             //    close by 2%
             _owningObject.SetTarget(null);
         }
+
+        /// <summary>
+        /// Classifies the connection for a timeout-only pool diagnostics snapshot.
+        /// The caller must hold this connection's monitor.
+        /// </summary>
+        /// <param name="utcNow">Current UTC time used to calculate checkout duration.</param>
+        /// <param name="checkoutDuration">How long the current or abandoned checkout has lasted.</param>
+        /// <returns>The connection's current pool usage state.</returns>
+        internal PoolConnectionUsageState GetPoolUsageState(
+            DateTime utcNow,
+            out TimeSpan checkoutDuration)
+        {
+            Debug.Assert(Monitor.IsEntered(this));
+            Debug.Assert(utcNow.Kind == DateTimeKind.Utc);
+
+            checkoutDuration = TimeSpan.Zero;
+
+            if (IsTxRootWaitingForTxEnd ||
+                (IsInPool && EnlistedTransaction is not null))
+            {
+                return PoolConnectionUsageState.TransactionHeld;
+            }
+
+            if (IsInPool)
+            {
+                return PoolConnectionUsageState.Idle;
+            }
+
+            if (_owningObject.TryGetTarget(out _))
+            {
+                checkoutDuration = GetCheckoutDuration(utcNow);
+                return PoolConnectionUsageState.CheckedOut;
+            }
+
+            if (_checkoutTime != DateTime.MinValue && IsEmancipated)
+            {
+                checkoutDuration = GetCheckoutDuration(utcNow);
+                return PoolConnectionUsageState.Abandoned;
+            }
+
+            return PoolConnectionUsageState.Unclassified;
+        }
+
+        private TimeSpan GetCheckoutDuration(DateTime utcNow) =>
+            utcNow > _checkoutTime
+                ? utcNow - _checkoutTime
+                : TimeSpan.Zero;
 
         internal void RemoveWeakReference(object value) =>
             ReferenceCollection?.Remove(value);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -314,6 +314,12 @@ namespace Microsoft.Data.SqlClient.Connection
         private readonly SqlConnectionTimeoutErrorInternal _timeoutErrorInternal;
 
         /// <summary>
+        /// Transient failures that caused this physical connection open to retry. The list exists
+        /// only while the constructor's open operation is in progress and is cleared on success.
+        /// </summary>
+        private List<SqlException> _connectionOpenRetryFailures;
+
+        /// <summary>
         /// Cache the whereabouts (DTC Address) for exporting.
         /// </summary>
         // @TODO: This name ... doesn't make a whole lot of sense.
@@ -452,9 +458,17 @@ namespace Microsoft.Data.SqlClient.Connection
                             && _timeout.MillisecondsRemaining >= transientRetryIntervalInMilliSeconds
                             && IsTransientError(sqlex))
                     {
+                        RecordConnectionOpenRetryFailure(sqlex);
                         Thread.Sleep(transientRetryIntervalInMilliSeconds);
                     }
+                    catch (SqlException sqlex)
+                    {
+                        AttachConnectionOpenRetryFailures(sqlex);
+                        throw;
+                    }
                 }
+
+                _connectionOpenRetryFailures = null;
             }
             // @TODO: CER Exception Handling was removed here (see GH#3581)
             finally
@@ -3407,6 +3421,7 @@ namespace Microsoft.Data.SqlClient.Connection
                 {
                     if (AttemptRetryADAuthWithTimeoutError(sqlex, timeout))
                     {
+                        RecordConnectionOpenRetryFailure(sqlex);
                         continue;
                     }
 
@@ -3429,6 +3444,8 @@ namespace Microsoft.Data.SqlClient.Connection
                     {
                         throw;
                     }
+
+                    RecordConnectionOpenRetryFailure(sqlex);
                 }
 
                 // We only get here when we failed to connect, but are going to re-try
@@ -3731,6 +3748,7 @@ namespace Microsoft.Data.SqlClient.Connection
                 {
                     if (AttemptRetryADAuthWithTimeoutError(sqlex, timeout))
                     {
+                        RecordConnectionOpenRetryFailure(sqlex);
                         continue;
                     }
 
@@ -3768,6 +3786,8 @@ namespace Microsoft.Data.SqlClient.Connection
                             throw;
                         }
                     }
+
+                    RecordConnectionOpenRetryFailure(sqlex);
                 }
 
                 // We only get here when we failed to connect, but are going to re-try
@@ -3836,6 +3856,26 @@ namespace Microsoft.Data.SqlClient.Connection
                                                or TdsEnums.PASSWORD_EXPIRED      // Actual login failed, ie expired password
                                                or TdsEnums.IMPERSONATION_FAILED; // Insufficient privilege for named pipe, etc
             return errorNumberMatch || exc._doNotReconnect;
+        }
+
+        /// <summary>
+        /// Records a transient failure immediately before the same connection open is retried.
+        /// </summary>
+        private void RecordConnectionOpenRetryFailure(SqlException exception) =>
+            (_connectionOpenRetryFailures ??= new List<SqlException>()).Add(exception);
+
+        /// <summary>
+        /// Attaches the retry ledger to the terminal failure without changing its errors or inner
+        /// exception.
+        /// </summary>
+        private void AttachConnectionOpenRetryFailures(
+            SqlException terminalException)
+        {
+            if (_connectionOpenRetryFailures is { Count: > 0 })
+            {
+                terminalException.SetConnectionOpenRetryFailures(
+                    _connectionOpenRetryFailures);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/BlockingPeriodErrorState.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/BlockingPeriodErrorState.cs
@@ -122,7 +122,10 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             lock (_lock)
             {
                 _inElevatedState = true;
-                _cachedException = ex;
+                _cachedException = ex is SqlException sqlException
+                    ? sqlException.InternalClone(
+                        includeConnectionOpenRetryFailures: false)
+                    : ex;
                 wait = _nextWait;
 
                 ITimer newTimer = ADP.UnsafeCreateTimer(

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
@@ -161,6 +161,12 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         /// requester to start the loop, and reset to 0 by the loop when it drains.
         /// </summary>
         private int _warmupLoopRunning;
+
+        /// <summary>
+        /// Number of abandoned connections this pool has reclaimed. Acquisition requests sample
+        /// this counter so a timeout can report reclamation that occurred while that request waited.
+        /// </summary>
+        private long _reclaimedConnectionCount;
         #endregion
 
         /// <summary>
@@ -490,7 +496,9 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                     lock (newConnection)
                     {
                         // PostPop requires a lock on the connection.
-                        newConnection.PostPop(owningObject);
+                        newConnection.PostPop(
+                            owningObject,
+                            _timeProvider.GetUtcNow().UtcDateTime);
                     }
 
                     // Carry the old connection's enlistment over to the replacement so that a
@@ -1049,6 +1057,8 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <param name="timeout">The overall timeout budget. Passed through to the physical connection
         /// so it uses the remaining budget rather than starting a fresh timeout.</param>
+        /// <param name="waitReason">Receives why no connection could be created when the method
+        /// returns null.</param>
         /// <returns>The new internal connection, or null if the pool has no available slot or the
         /// rate limiter is currently saturated. In the latter case the caller should fall back to
         /// the idle-channel wait; the rate limiter will write a null to the idle channel when a
@@ -1059,8 +1069,10 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         private DbConnectionInternal? OpenNewInternalConnection(
             DbConnection? owningConnection,
             CancellationToken cancellationToken,
-            TimeoutTimer timeout)
+            TimeoutTimer timeout,
+            out PoolAcquisitionWaitReason waitReason)
         {
+            waitReason = PoolAcquisitionWaitReason.Unknown;
             cancellationToken.ThrowIfCancellationRequested();
 
             // Fast-fail if the pool is in the blocking-period error state. FR-006. Warmup goes
@@ -1081,6 +1093,8 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
 
             try
             {
+                bool rateLimited = false;
+
                 // Reserve a pool slot up front so we don't pay the rate-limit cost only to
                 // discover the pool is full. Add() reserves synchronously and returns null
                 // immediately if no slot is available; the rate-limit check only happens inside
@@ -1112,6 +1126,8 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                         {
                             if (!lease.IsAcquired)
                             {
+                                rateLimited = true;
+
                                 // TODO: When we fail to acquire a lease, surface the lease metadata
                                 // (e.g. RateLimitMetadataName.RetryAfter, ReasonPhrase) in the error
                                 // path so the user can identify why the lease was denied.
@@ -1218,6 +1234,10 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 }
                 else
                 {
+                    waitReason = rateLimited
+                        ? PoolAcquisitionWaitReason.ConnectionCreationRateLimited
+                        : PoolAcquisitionWaitReason.PoolFull;
+
                     SqlClientEventSource.Log.TryPoolerTraceEvent(
                         "ChannelDbConnectionPool.OpenNewInternalConnection | INFO | {0}, No connection created; pool is full or creation is rate limited.",
                         Id);
@@ -1458,6 +1478,10 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             Transaction? ambientTransaction)
         {
             DbConnectionInternal? connection = null;
+            PoolAcquisitionWaitReason waitReason = PoolAcquisitionWaitReason.Unknown;
+            long reclaimedConnectionCountAtStart =
+                Interlocked.Read(ref _reclaimedConnectionCount);
+            bool enteredParkedWait = false;
 
             SqlClientEventSource.Log.TryPoolerTraceEvent(
                 "ChannelDbConnectionPool.GetInternalConnection | INFO | {0}, Getting connection.", Id);
@@ -1505,10 +1529,19 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                     // If we didn't find an idle connection, try to open a new one. This may
                     // return null if the pool is full or the rate limiter is currently saturated;
                     // in either case the caller falls through to the idle-channel wait below.
-                    connection ??= OpenNewInternalConnection(
-                        owningConnection,
-                        cancellationToken,
-                        timeout);
+                    if (connection is null)
+                    {
+                        connection = OpenNewInternalConnection(
+                            owningConnection,
+                            cancellationToken,
+                            timeout,
+                            out PoolAcquisitionWaitReason currentWaitReason);
+
+                        if (connection is null)
+                        {
+                            waitReason = currentWaitReason;
+                        }
+                    }
 
                     // If we're at max capacity and couldn't open a connection. Block on the idle channel with a
                     // timeout. Note that Channels guarantee fair FIFO behavior to callers of ReadAsync
@@ -1520,6 +1553,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                     // O(MaxPoolSize) walk on every saturated acquire in applications that never leak.
                     if (connection is null)
                     {
+                        enteredParkedWait = true;
                         Reclaimer.EnterParkedWait();
                         try
                         {
@@ -1538,7 +1572,14 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                     SqlClientEventSource.Log.TryPoolerTraceEvent(
                         "ChannelDbConnectionPool.GetInternalConnection | INFO | {0}, Wait timed out.", Id);
 
-                    throw ADP.PooledOpenTimeout();
+                    int waitingRequestCount =
+                        Reclaimer.ParkedWaiters + (enteredParkedWait ? 1 : 0);
+                    PoolAcquisitionDiagnostics diagnostics =
+                        CaptureAcquisitionDiagnostics(
+                            waitReason,
+                            reclaimedConnectionCountAtStart,
+                            Math.Max(1, waitingRequestCount));
+                    throw ADP.PooledOpenTimeout(diagnostics);
                 }
                 catch (ChannelClosedException)
                 {
@@ -1662,6 +1703,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 }
 
                 Metrics.ReclaimedConnectionRequest();
+                Interlocked.Increment(ref _reclaimedConnectionCount);
                 returned++;
             }
 
@@ -1672,6 +1714,72 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                     Id,
                     returned);
             }
+        }
+
+        /// <summary>
+        /// Captures a best-effort pool snapshot on the timeout path.
+        /// </summary>
+        private PoolAcquisitionDiagnostics CaptureAcquisitionDiagnostics(
+            PoolAcquisitionWaitReason waitReason,
+            long reclaimedConnectionCountAtStart,
+            int waitingRequestCount)
+        {
+            int connectionCount = Count;
+            int reservationCount = _connectionSlots.ReservationCount;
+
+            if (waitReason == PoolAcquisitionWaitReason.Unknown)
+            {
+                waitReason = reservationCount >= checked((int)MaxPoolSize)
+                    ? PoolAcquisitionWaitReason.PoolFull
+                    : PoolAcquisitionWaitReason.ConnectionCreationInProgress;
+            }
+
+            var builder = new PoolAcquisitionDiagnosticsBuilder(
+                _timeProvider.GetUtcNow().UtcDateTime);
+
+            foreach (DbConnectionInternal connection in _connectionSlots)
+            {
+                bool locked = false;
+                try
+                {
+                    Monitor.TryEnter(connection, ref locked);
+                    if (locked)
+                    {
+                        builder.Observe(connection);
+                    }
+                    else
+                    {
+                        builder.ObserveLockContention();
+                    }
+                }
+                finally
+                {
+                    if (locked)
+                    {
+                        Monitor.Exit(connection);
+                    }
+                }
+            }
+
+            long reclaimedConnectionCount =
+                Math.Max(
+                    0,
+                    Interlocked.Read(ref _reclaimedConnectionCount) -
+                    reclaimedConnectionCountAtStart);
+
+            return new PoolAcquisitionDiagnostics(
+                waitReason,
+                checked((int)MaxPoolSize),
+                connectionCount,
+                builder.IdleConnectionCount,
+                Math.Max(0, reservationCount - connectionCount),
+                waitingRequestCount,
+                builder.CheckedOutConnectionCount,
+                builder.TransactionConnectionCount,
+                builder.AbandonedConnectionCount,
+                builder.UnclassifiedConnectionCount,
+                builder.LongestCheckoutDuration,
+                reclaimedConnectionCount);
         }
 
         /// <summary>
@@ -1722,7 +1830,9 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             lock (connection)
             {
                 // Protect against Clear which calls IsEmancipated, which is affected by PrePush and PostPop
-                connection.PostPop(owningObject);
+                connection.PostPop(
+                    owningObject,
+                    _timeProvider.GetUtcNow().UtcDateTime);
             }
 
             try
@@ -1940,7 +2050,8 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                         connection = OpenNewInternalConnection(
                             owningConnection: null,
                             cancellationToken: token,
-                            timeout: timeout);
+                            timeout: timeout,
+                            waitReason: out _);
                     }
                     catch (OperationCanceledException)
                     {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/PoolAcquisitionDiagnostics.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/PoolAcquisitionDiagnostics.cs
@@ -1,0 +1,211 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Diagnostics;
+using Microsoft.Data.ProviderBase;
+using Microsoft.Data.SqlClient.Internal;
+
+#nullable enable
+
+namespace Microsoft.Data.SqlClient.ConnectionPool
+{
+    /// <summary>
+    /// Describes why a connection acquisition entered its final wait.
+    /// </summary>
+    internal enum PoolAcquisitionWaitReason
+    {
+        Unknown,
+        PoolFull,
+        ConnectionCreationInProgress,
+        ConnectionCreationRateLimited,
+    }
+
+    /// <summary>
+    /// Classifies how one physical connection is currently held by the pool.
+    /// </summary>
+    internal enum PoolConnectionUsageState
+    {
+        Idle,
+        CheckedOut,
+        TransactionHeld,
+        Abandoned,
+        Unclassified,
+    }
+
+    /// <summary>
+    /// Best-effort snapshot captured only when a pooled connection request times out.
+    /// </summary>
+    internal readonly struct PoolAcquisitionDiagnostics
+    {
+        internal const string DataKeyPrefix = "Microsoft.Data.SqlClient.ConnectionPool.";
+        internal const string WaitReasonDataKey = DataKeyPrefix + "WaitReason";
+        internal const string MaxPoolSizeDataKey = DataKeyPrefix + "MaxPoolSize";
+        internal const string ConnectionCountDataKey = DataKeyPrefix + "ConnectionCount";
+        internal const string IdleConnectionCountDataKey = DataKeyPrefix + "IdleConnectionCount";
+        internal const string PendingConnectionOpenCountDataKey = DataKeyPrefix + "PendingConnectionOpenCount";
+        internal const string WaitingRequestCountDataKey = DataKeyPrefix + "WaitingRequestCount";
+        internal const string CheckedOutConnectionCountDataKey = DataKeyPrefix + "CheckedOutConnectionCount";
+        internal const string TransactionConnectionCountDataKey = DataKeyPrefix + "TransactionConnectionCount";
+        internal const string AbandonedConnectionCountDataKey = DataKeyPrefix + "AbandonedConnectionCount";
+        internal const string UnclassifiedConnectionCountDataKey = DataKeyPrefix + "UnclassifiedConnectionCount";
+        internal const string LongestCheckoutDurationDataKey = DataKeyPrefix + "LongestCheckoutDuration";
+        internal const string ReclaimedConnectionCountDataKey = DataKeyPrefix + "ReclaimedConnectionCount";
+
+        internal PoolAcquisitionDiagnostics(
+            PoolAcquisitionWaitReason waitReason,
+            int maxPoolSize,
+            int connectionCount,
+            int idleConnectionCount,
+            int pendingConnectionOpenCount,
+            int waitingRequestCount,
+            int checkedOutConnectionCount,
+            int transactionConnectionCount,
+            int abandonedConnectionCount,
+            int unclassifiedConnectionCount,
+            TimeSpan longestCheckoutDuration,
+            long reclaimedConnectionCount)
+        {
+            WaitReason = waitReason;
+            MaxPoolSize = maxPoolSize;
+            ConnectionCount = connectionCount;
+            IdleConnectionCount = idleConnectionCount;
+            PendingConnectionOpenCount = pendingConnectionOpenCount;
+            WaitingRequestCount = waitingRequestCount;
+            CheckedOutConnectionCount = checkedOutConnectionCount;
+            TransactionConnectionCount = transactionConnectionCount;
+            AbandonedConnectionCount = abandonedConnectionCount;
+            UnclassifiedConnectionCount = unclassifiedConnectionCount;
+            LongestCheckoutDuration = longestCheckoutDuration;
+            ReclaimedConnectionCount = reclaimedConnectionCount;
+        }
+
+        internal PoolAcquisitionWaitReason WaitReason { get; }
+
+        internal int MaxPoolSize { get; }
+
+        internal int ConnectionCount { get; }
+
+        internal int IdleConnectionCount { get; }
+
+        internal int PendingConnectionOpenCount { get; }
+
+        internal int WaitingRequestCount { get; }
+
+        internal int CheckedOutConnectionCount { get; }
+
+        internal int TransactionConnectionCount { get; }
+
+        internal int AbandonedConnectionCount { get; }
+
+        internal int UnclassifiedConnectionCount { get; }
+
+        internal TimeSpan LongestCheckoutDuration { get; }
+
+        internal long ReclaimedConnectionCount { get; }
+
+        /// <summary>
+        /// Adds structured values to the timeout's data dictionary.
+        /// </summary>
+        internal void AddTo(IDictionary data)
+        {
+            data[WaitReasonDataKey] = WaitReason.ToString();
+            data[MaxPoolSizeDataKey] = MaxPoolSize;
+            data[ConnectionCountDataKey] = ConnectionCount;
+            data[IdleConnectionCountDataKey] = IdleConnectionCount;
+            data[PendingConnectionOpenCountDataKey] = PendingConnectionOpenCount;
+            data[WaitingRequestCountDataKey] = WaitingRequestCount;
+            data[CheckedOutConnectionCountDataKey] = CheckedOutConnectionCount;
+            data[TransactionConnectionCountDataKey] = TransactionConnectionCount;
+            data[AbandonedConnectionCountDataKey] = AbandonedConnectionCount;
+            data[UnclassifiedConnectionCountDataKey] = UnclassifiedConnectionCount;
+            data[LongestCheckoutDurationDataKey] = LongestCheckoutDuration;
+            data[ReclaimedConnectionCountDataKey] = ReclaimedConnectionCount;
+        }
+
+        /// <summary>
+        /// Formats the snapshot for the user-visible pooled-open timeout.
+        /// </summary>
+        internal string GetMessage() =>
+            StringsHelper.GetString(
+                Strings.ADP_PooledOpenTimeoutDetails,
+                WaitReason,
+                MaxPoolSize,
+                ConnectionCount,
+                IdleConnectionCount,
+                PendingConnectionOpenCount,
+                WaitingRequestCount,
+                CheckedOutConnectionCount,
+                TransactionConnectionCount,
+                AbandonedConnectionCount,
+                UnclassifiedConnectionCount,
+                LongestCheckoutDuration,
+                ReclaimedConnectionCount);
+    }
+
+    /// <summary>
+    /// Collects connection ownership information during a timeout-only pool scan.
+    /// </summary>
+    internal sealed class PoolAcquisitionDiagnosticsBuilder
+    {
+        private readonly DateTime _utcNow;
+
+        internal PoolAcquisitionDiagnosticsBuilder(DateTime utcNow)
+        {
+            Debug.Assert(utcNow.Kind == DateTimeKind.Utc);
+            _utcNow = utcNow;
+        }
+
+        internal int CheckedOutConnectionCount { get; private set; }
+
+        internal int IdleConnectionCount { get; private set; }
+
+        internal int TransactionConnectionCount { get; private set; }
+
+        internal int AbandonedConnectionCount { get; private set; }
+
+        internal int UnclassifiedConnectionCount { get; private set; }
+
+        internal TimeSpan LongestCheckoutDuration { get; private set; }
+
+        /// <summary>
+        /// Records one connection while its monitor is held.
+        /// </summary>
+        internal void Observe(DbConnectionInternal connection)
+        {
+            switch (connection.GetPoolUsageState(_utcNow, out TimeSpan checkoutDuration))
+            {
+                case PoolConnectionUsageState.Idle:
+                    IdleConnectionCount++;
+                    break;
+
+                case PoolConnectionUsageState.CheckedOut:
+                    CheckedOutConnectionCount++;
+                    if (checkoutDuration > LongestCheckoutDuration)
+                    {
+                        LongestCheckoutDuration = checkoutDuration;
+                    }
+                    break;
+
+                case PoolConnectionUsageState.TransactionHeld:
+                    TransactionConnectionCount++;
+                    break;
+
+                case PoolConnectionUsageState.Abandoned:
+                    AbandonedConnectionCount++;
+                    if (checkoutDuration > LongestCheckoutDuration)
+                    {
+                        LongestCheckoutDuration = checkoutDuration;
+                    }
+                    break;
+
+                case PoolConnectionUsageState.Unclassified:
+                    UnclassifiedConnectionCount++;
+                    break;
+            }
+        }
+
+        internal void ObserveLockContention() => UnclassifiedConnectionCount++;
+    }
+}

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/WaitHandleDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/WaitHandleDbConnectionPool.cs
@@ -62,17 +62,24 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
 
         private sealed class PendingGetConnection
         {
-            public PendingGetConnection(long dueTime, DbConnection owner, TaskCompletionSource<DbConnectionInternal> completion, TimeoutTimer timeout)
+            public PendingGetConnection(
+                long dueTime,
+                DbConnection owner,
+                TaskCompletionSource<DbConnectionInternal> completion,
+                TimeoutTimer timeout,
+                long reclaimedConnectionCountAtStart)
             {
                 DueTime = dueTime;
                 Owner = owner;
                 Completion = completion;
                 Timeout = timeout;
+                ReclaimedConnectionCountAtStart = reclaimedConnectionCountAtStart;
             }
             public long DueTime { get; private set; }
             public DbConnection Owner { get; private set; }
             public TaskCompletionSource<DbConnectionInternal> Completion { get; private set; }
             public TimeoutTimer Timeout { get; private set; }
+            public long ReclaimedConnectionCountAtStart { get; }
         }
 
         private sealed class PoolWaitHandles
@@ -187,6 +194,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
 
         private readonly ConcurrentQueue<PendingGetConnection> _pendingOpens = new ConcurrentQueue<PendingGetConnection>();
         private int _pendingOpensWaiting = 0;
+        private int _pendingConnectionOpenCount;
 
         private readonly WaitCallback _poolCreateRequest;
 
@@ -202,6 +210,12 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
 
         private readonly List<DbConnectionInternal> _objectList;
         private int _totalObjects;
+
+        /// <summary>
+        /// Number of abandoned connections this pool has reclaimed. Acquisition requests sample
+        /// this counter so a timeout can report reclamation that occurred while that request waited.
+        /// </summary>
+        private long _reclaimedConnectionCount;
 
         // only created by DbConnectionPoolGroup.GetConnectionPool
         internal WaitHandleDbConnectionPool(
@@ -537,6 +551,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         private DbConnectionInternal CreateObject(DbConnection owningObject, DbConnectionInternal oldConnection, TimeoutTimer timeout)
         {
             DbConnectionInternal newObj = null;
+            Interlocked.Increment(ref _pendingConnectionOpenCount);
 
             try
             {
@@ -590,6 +605,10 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 _errorState.Enter(e);
 
                 throw;
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _pendingConnectionOpenCount);
             }
             return newObj;
         }
@@ -823,7 +842,13 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                         }
                         else if (timeout)
                         {
-                            next.Completion.TrySetException(ADP.ExceptionWithStackTrace(ADP.PooledOpenTimeout()));
+                            PoolAcquisitionDiagnostics diagnostics =
+                                CaptureAcquisitionDiagnostics(
+                                    next.ReclaimedConnectionCountAtStart,
+                                    Math.Max(1, Volatile.Read(ref _waitCount) + 1));
+                            next.Completion.TrySetException(
+                                ADP.ExceptionWithStackTrace(
+                                    ADP.PooledOpenTimeout(diagnostics)));
                         }
                         else
                         {
@@ -873,6 +898,8 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
 
         public bool TryGetConnection(DbConnection owningObject, TaskCompletionSource<DbConnectionInternal> taskCompletionSource, TimeoutTimer timeout, out DbConnectionInternal connection)
         {
+            long reclaimedConnectionCountAtStart =
+                Interlocked.Read(ref _reclaimedConnectionCount);
             uint waitForMultipleObjectsTimeout = 0;
             bool allowCreate = false;
 
@@ -896,8 +923,18 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             }
             else if (taskCompletionSource == null)
             {
+                if (State is not Running)
+                {
+                    connection = null;
+                    return true;
+                }
+
                 // timed out on a sync call
-                return true;
+                PoolAcquisitionDiagnostics diagnostics =
+                    CaptureAcquisitionDiagnostics(
+                        reclaimedConnectionCountAtStart,
+                        waitingRequestCount: Math.Max(1, Volatile.Read(ref _waitCount) + 1));
+                throw ADP.PooledOpenTimeout(diagnostics);
             }
 
             // Shutdown short-circuit for the async path. The inner TryGetConnection returns false
@@ -935,7 +972,8 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                     dueTime,
                     owningObject,
                     taskCompletionSource,
-                    timeout);
+                    timeout,
+                    reclaimedConnectionCountAtStart);
             _pendingOpens.Enqueue(pendingGetConnection);
 
             // it is better to StartNew too many times than not enough
@@ -1169,7 +1207,9 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         {
             lock (obj)
             {   // Protect against Clear and ReclaimEmancipatedObjects, which call IsEmancipated, which is affected by PrePush and PostPop
-                obj.PostPop(owningObject);
+                obj.PostPop(
+                    owningObject,
+                    _timeProvider.GetUtcNow().UtcDateTime);
             }
             try
             {
@@ -1556,6 +1596,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionPool.ReclaimEmancipatedObjects|RES|CPOOL> {0}, Connection {1}, Reclaiming.", Id, obj.ObjectID);
 
                 Metrics.ReclaimedConnectionRequest();
+                Interlocked.Increment(ref _reclaimedConnectionCount);
 
                 emancipatedObjectFound = true;
 
@@ -1563,6 +1604,74 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 DeactivateObject(obj);
             }
             return emancipatedObjectFound;
+        }
+
+        /// <summary>
+        /// Captures a best-effort pool snapshot on the timeout path.
+        /// </summary>
+        private PoolAcquisitionDiagnostics CaptureAcquisitionDiagnostics(
+            long reclaimedConnectionCountAtStart,
+            int waitingRequestCount)
+        {
+            var builder = new PoolAcquisitionDiagnosticsBuilder(
+                _timeProvider.GetUtcNow().UtcDateTime);
+            int connectionCount;
+
+            lock (_objectList)
+            {
+                connectionCount = _objectList.Count;
+                foreach (DbConnectionInternal connection in _objectList)
+                {
+                    bool locked = false;
+                    try
+                    {
+                        Monitor.TryEnter(connection, ref locked);
+                        if (locked)
+                        {
+                            builder.Observe(connection);
+                        }
+                        else
+                        {
+                            builder.ObserveLockContention();
+                        }
+                    }
+                    finally
+                    {
+                        if (locked)
+                        {
+                            Monitor.Exit(connection);
+                        }
+                    }
+                }
+            }
+
+            int pendingConnectionOpenCount =
+                Math.Max(0, Volatile.Read(ref _pendingConnectionOpenCount));
+            PoolAcquisitionWaitReason waitReason =
+                connectionCount >= MaxPoolSize
+                    ? PoolAcquisitionWaitReason.PoolFull
+                    : pendingConnectionOpenCount > 0
+                        ? PoolAcquisitionWaitReason.ConnectionCreationInProgress
+                        : PoolAcquisitionWaitReason.Unknown;
+            long reclaimedConnectionCount =
+                Math.Max(
+                    0,
+                    Interlocked.Read(ref _reclaimedConnectionCount) -
+                    reclaimedConnectionCountAtStart);
+
+            return new PoolAcquisitionDiagnostics(
+                waitReason,
+                MaxPoolSize,
+                connectionCount,
+                builder.IdleConnectionCount,
+                pendingConnectionOpenCount,
+                waitingRequestCount,
+                builder.CheckedOutConnectionCount,
+                builder.TransactionConnectionCount,
+                builder.AbandonedConnectionCount,
+                builder.UnclassifiedConnectionCount,
+                builder.LongestCheckoutDuration,
+                reclaimedConnectionCount);
         }
 
         public void Startup()

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlException.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlException.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Data.Common;
 using System.Diagnostics;
@@ -24,6 +26,10 @@ namespace Microsoft.Data.SqlClient
         private const int SqlExceptionHResult = unchecked((int)0x80131904);
 
         private readonly SqlErrorCollection _errors;
+        private static readonly ReadOnlyCollection<SqlException> s_emptyConnectionOpenRetryFailures =
+            Array.AsReadOnly(Array.Empty<SqlException>());
+        private IReadOnlyList<SqlException> _connectionOpenRetryFailures =
+            s_emptyConnectionOpenRetryFailures;
 #if NETFRAMEWORK
         [OptionalField(VersionAdded = 4)]
 #endif
@@ -49,6 +55,7 @@ namespace Microsoft.Data.SqlClient
 #endif
         private SqlException(SerializationInfo si, StreamingContext sc) : base(si, sc)
         {
+            _connectionOpenRetryFailures = s_emptyConnectionOpenRetryFailures;
 #if NETFRAMEWORK
             _errors = (SqlErrorCollection)si.GetValue("Errors", typeof(SqlErrorCollection));
 #endif
@@ -69,6 +76,8 @@ namespace Microsoft.Data.SqlClient
 #endif
         public override void GetObjectData(SerializationInfo si, StreamingContext context)
         {
+            // ConnectionOpenRetryFailures is request-scoped diagnostic context and is intentionally
+            // not carried through legacy formatter-based serialization.
             base.GetObjectData(si, context);
             si.AddValue("Errors", null); // Not specifying type to enable serialization of null value of non-serializable type
             si.AddValue("ClientConnectionId", _clientConnectionId, typeof(object));
@@ -91,6 +100,10 @@ namespace Microsoft.Data.SqlClient
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
 #endif
         public SqlErrorCollection Errors => _errors ?? new SqlErrorCollection();
+
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlException.xml' path='docs/members[@name="SqlException"]/ConnectionOpenRetryFailures/*' />
+        public IReadOnlyList<SqlException> ConnectionOpenRetryFailures =>
+            _connectionOpenRetryFailures ?? s_emptyConnectionOpenRetryFailures;
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlException.xml' path='docs/members[@name="SqlException"]/ClientConnectionId/*' />
         public Guid ClientConnectionId => _clientConnectionId;
@@ -162,6 +175,27 @@ namespace Microsoft.Data.SqlClient
             {
                 sb.AppendLine();
                 sb.AppendFormat(SQLMessage.ExRoutingDestination(), Data[RoutingDestinationKey]);
+            }
+
+            if (ConnectionOpenRetryFailures.Count > 0)
+            {
+                sb.AppendLine();
+                sb.Append(
+                    StringsHelper.GetString(
+                        Strings.SQL_ConnectionOpenRetryFailures,
+                        ConnectionOpenRetryFailures.Count));
+
+                for (int i = 0; i < ConnectionOpenRetryFailures.Count; i++)
+                {
+                    SqlException failure = ConnectionOpenRetryFailures[i];
+                    sb.AppendLine();
+                    sb.Append(
+                        StringsHelper.GetString(
+                            Strings.SQL_ConnectionOpenRetryFailure,
+                            i + 1,
+                            failure.GetType().FullName,
+                            failure.Message));
+                }
             }
 
             return sb.ToString();
@@ -294,6 +328,9 @@ namespace Microsoft.Data.SqlClient
         }
 
         internal SqlException InternalClone()
+            => InternalClone(includeConnectionOpenRetryFailures: true);
+
+        internal SqlException InternalClone(bool includeConnectionOpenRetryFailures)
         {
             SqlException exception = new(Message, _errors, InnerException, _clientConnectionId);
             if (Data != null)
@@ -305,7 +342,38 @@ namespace Microsoft.Data.SqlClient
             }
             exception._batchCommand = _batchCommand;
             exception._doNotReconnect = _doNotReconnect;
+            exception._connectionOpenRetryFailures = includeConnectionOpenRetryFailures
+                ? ConnectionOpenRetryFailures
+                : s_emptyConnectionOpenRetryFailures;
             return exception;
+        }
+
+        /// <summary>
+        /// Attaches the transient failures observed before this terminal connection open failure.
+        /// Existing failures on this exception are appended after the supplied list.
+        /// </summary>
+        internal void SetConnectionOpenRetryFailures(
+            IReadOnlyList<SqlException> retryFailures)
+        {
+            if (retryFailures is null || retryFailures.Count == 0)
+            {
+                return;
+            }
+
+            var combined = new SqlException[
+                retryFailures.Count + ConnectionOpenRetryFailures.Count];
+            for (int i = 0; i < retryFailures.Count; i++)
+            {
+                combined[i] = retryFailures[i];
+            }
+
+            for (int i = 0; i < ConnectionOpenRetryFailures.Count; i++)
+            {
+                combined[retryFailures.Count + i] =
+                    ConnectionOpenRetryFailures[i];
+            }
+
+            _connectionOpenRetryFailures = Array.AsReadOnly(combined);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
@@ -869,6 +869,15 @@ namespace System {
                 return ResourceManager.GetString("ADP_PooledOpenTimeout", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Pool diagnostics: wait reason={0}; max pool size={1}; total connections={2}; idle connections={3}; pending opens={4}; waiting requests={5}; checked-out connections={6}; transaction-held connections={7}; abandoned connections={8}; unclassified connections={9}; longest checkout={10}; abandoned connections reclaimed during this wait={11}..
+        /// </summary>
+        internal static string ADP_PooledOpenTimeoutDetails {
+            get {
+                return ResourceManager.GetString("ADP_PooledOpenTimeoutDetails", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to {0}.Prepare method requires parameters of type &apos;{1}&apos; have an explicitly set Precision and Scale..
@@ -3180,6 +3189,24 @@ namespace System {
         internal static string SQL_ConnectionPoolShutDown {
             get {
                 return ResourceManager.GetString("SQL_ConnectionPoolShutDown", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Retry {0}: {1}: {2}.
+        /// </summary>
+        internal static string SQL_ConnectionOpenRetryFailure {
+            get {
+                return ResourceManager.GetString("SQL_ConnectionOpenRetryFailure", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Connection open retry failures ({0}):.
+        /// </summary>
+        internal static string SQL_ConnectionOpenRetryFailures {
+            get {
+                return ResourceManager.GetString("SQL_ConnectionOpenRetryFailures", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
@@ -204,6 +204,9 @@
   <data name="ADP_PooledOpenTimeout" xml:space="preserve">
     <value>Timeout expired.  The timeout period elapsed prior to obtaining a connection from the pool.  This may have occurred because all pooled connections were in use and max pool size was reached.</value>
   </data>
+  <data name="ADP_PooledOpenTimeoutDetails" xml:space="preserve">
+    <value>Pool diagnostics: wait reason={0}; max pool size={1}; total connections={2}; idle connections={3}; pending opens={4}; waiting requests={5}; checked-out connections={6}; transaction-held connections={7}; abandoned connections={8}; unclassified connections={9}; longest checkout={10}; abandoned connections reclaimed during this wait={11}.</value>
+  </data>
   <data name="ADP_NonPooledOpenTimeout" xml:space="preserve">
     <value>Timeout attempting to open the connection.  The time period elapsed prior to attempting to open the connection has been exceeded.  This may have occurred because of too many simultaneous non-pooled connection attempts.</value>
   </data>
@@ -2177,6 +2180,12 @@
   </data>
   <data name="SQL_ConnectionPoolShutDown" xml:space="preserve">
     <value>The connection pool has been shut down.</value>
+  </data>
+  <data name="SQL_ConnectionOpenRetryFailures" xml:space="preserve">
+    <value>Connection open retry failures ({0}):</value>
+  </data>
+  <data name="SQL_ConnectionOpenRetryFailure" xml:space="preserve">
+    <value>Retry {0}: {1}: {2}</value>
   </data>
   <data name="SQL_Packet_RequiredLengthUnavailable" xml:space="preserve">
     <value>Cannot get RequiredLength when HasDataLength is false.</value>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTest.cs
@@ -183,9 +183,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
                     out DbConnectionInternal? extraConnection);
             });
 
-            Assert.Equal(
-                "Timeout expired.  The timeout period elapsed prior to obtaining a connection from the pool.  This may have occurred because all pooled connections were in use and max pool size was reached.",
-                ex.Message);
+            Assert.StartsWith(ADP.PooledOpenTimeout().Message, ex.Message);
             Assert.Equal(pool.PoolGroupOptions.MaxPoolSize, pool.Count);
         }
 
@@ -229,9 +227,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
 
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => taskCompletionSource.Task);
 
-            Assert.Equal(
-                "Timeout expired.  The timeout period elapsed prior to obtaining a connection from the pool.  This may have occurred because all pooled connections were in use and max pool size was reached.",
-                ex.Message);
+            Assert.StartsWith(ADP.PooledOpenTimeout().Message, ex.Message);
             Assert.Equal(pool.PoolGroupOptions.MaxPoolSize, pool.Count);
         }
 
@@ -2366,9 +2362,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
 
             // Assert: Caller A should observe the timeout
             var exA = await Assert.ThrowsAsync<InvalidOperationException>(() => callerATask);
-            Assert.Equal(
-                "Timeout expired.  The timeout period elapsed prior to obtaining a connection from the pool.  This may have occurred because all pooled connections were in use and max pool size was reached.",
-                exA.Message);
+            Assert.StartsWith(ADP.PooledOpenTimeout().Message, exA.Message);
 
             // Caller B should still be waiting (8s of virtual budget remain)
             Assert.False(callerBTask.IsCompleted, "Caller B should still be waiting");

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/PoolAcquisitionDiagnosticsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/PoolAcquisitionDiagnosticsTest.cs
@@ -1,0 +1,206 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Data.Common;
+using System.Threading.RateLimiting;
+using System.Threading.Tasks;
+using Microsoft.Data.Common;
+using Microsoft.Data.ProviderBase;
+using Microsoft.Data.SqlClient.ConnectionPool;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+using static Microsoft.Data.SqlClient.UnitTests.ConnectionPool.PoolTestHarness;
+
+namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
+{
+    /// <summary>
+    /// Verifies that a pooled-open timeout describes the request-local reason for waiting and
+    /// captures a cheap snapshot of pool usage for diagnosing capacity pressure and leaks.
+    /// </summary>
+    public sealed class PoolAcquisitionDiagnosticsTest
+    {
+        /// <summary>
+        /// Verifies both pool implementations report that every slot is occupied, including how
+        /// many connections remain checked out and how long the oldest checkout has been held.
+        /// </summary>
+        [Theory]
+        [InlineData(PoolImplementation.WaitHandle, false)]
+        [InlineData(PoolImplementation.WaitHandle, true)]
+        [InlineData(PoolImplementation.Channel, false)]
+        [InlineData(PoolImplementation.Channel, true)]
+        public async Task Timeout_FullPool_ReportsSaturationSnapshot(
+            PoolImplementation implementation,
+            bool async)
+        {
+            IDbConnectionPool pool = ConstructPool(
+                implementation,
+                timeProvider: TimeProvider.System,
+                maxPoolSize: 1,
+                creationTimeout: 100);
+            using SqlConnection checkedOutOwner = new();
+            using SqlConnection waitingOwner = new();
+
+            Assert.True(pool.TryGetConnection(
+                checkedOutOwner,
+                taskCompletionSource: null,
+                TimeoutTimer.StartNew(TimeSpan.FromSeconds(5)),
+                out DbConnectionInternal? checkedOutConnection));
+            Assert.NotNull(checkedOutConnection);
+
+            checkedOutConnection!.CheckoutTime = DateTime.UtcNow - TimeSpan.FromMinutes(5);
+
+            try
+            {
+                InvalidOperationException timeout = await AssertPoolTimeoutAsync(
+                    pool,
+                    waitingOwner,
+                    async);
+
+                Assert.Equal(
+                    PoolAcquisitionWaitReason.PoolFull.ToString(),
+                    timeout.Data[PoolAcquisitionDiagnostics.WaitReasonDataKey]);
+                Assert.Equal(1, timeout.Data[PoolAcquisitionDiagnostics.MaxPoolSizeDataKey]);
+                Assert.Equal(1, timeout.Data[PoolAcquisitionDiagnostics.ConnectionCountDataKey]);
+                Assert.Equal(0, timeout.Data[PoolAcquisitionDiagnostics.IdleConnectionCountDataKey]);
+                Assert.Equal(1, timeout.Data[PoolAcquisitionDiagnostics.CheckedOutConnectionCountDataKey]);
+                Assert.Equal(0, timeout.Data[PoolAcquisitionDiagnostics.AbandonedConnectionCountDataKey]);
+                Assert.Equal(0L, timeout.Data[PoolAcquisitionDiagnostics.ReclaimedConnectionCountDataKey]);
+
+                TimeSpan longestCheckout =
+                    Assert.IsType<TimeSpan>(
+                        timeout.Data[PoolAcquisitionDiagnostics.LongestCheckoutDurationDataKey]);
+                Assert.True(longestCheckout >= TimeSpan.FromMinutes(4));
+            }
+            finally
+            {
+                pool.ReturnInternalConnection(checkedOutConnection, checkedOutOwner);
+            }
+
+            GC.KeepAlive(checkedOutOwner);
+        }
+
+        /// <summary>
+        /// Verifies the channel pool identifies connection-creation throttling as the timeout cause
+        /// instead of incorrectly claiming that max pool size was reached.
+        /// </summary>
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Timeout_RateLimiterSaturated_ReportsRateLimiting(bool async)
+        {
+            using ConcurrencyLimiter limiter = new(
+                new ConcurrencyLimiterOptions
+                {
+                    PermitLimit = 1,
+                    QueueLimit = 0,
+                });
+            using RateLimitLease heldLease = limiter.AttemptAcquire(1);
+            Assert.True(heldLease.IsAcquired);
+
+            DbConnectionPoolGroup poolGroup = ConstructPoolGroup(
+                maxPoolSize: 4,
+                creationTimeout: 100);
+            var pool = new ChannelDbConnectionPool(
+                new ChannelDbConnectionPoolTest.SuccessfulSqlConnectionFactory(),
+                poolGroup,
+                DbConnectionPoolIdentity.NoIdentity,
+                new DbConnectionPoolProviderInfo(),
+                connectionCreationRateLimiter: limiter);
+            using SqlConnection waitingOwner = new();
+
+            InvalidOperationException timeout = await AssertPoolTimeoutAsync(
+                pool,
+                waitingOwner,
+                async,
+                TimeSpan.FromSeconds(1));
+
+            Assert.Equal(
+                PoolAcquisitionWaitReason.ConnectionCreationRateLimited.ToString(),
+                timeout.Data[PoolAcquisitionDiagnostics.WaitReasonDataKey]);
+            Assert.Equal(4, timeout.Data[PoolAcquisitionDiagnostics.MaxPoolSizeDataKey]);
+            Assert.Equal(0, timeout.Data[PoolAcquisitionDiagnostics.ConnectionCountDataKey]);
+            Assert.Equal(0, timeout.Data[PoolAcquisitionDiagnostics.CheckedOutConnectionCountDataKey]);
+        }
+
+        /// <summary>
+        /// Verifies a timeout snapshot identifies a connection whose owning application connection
+        /// was collected without being closed or disposed.
+        /// </summary>
+        [Fact]
+        public void Timeout_AbandonedOwner_ReportsAbandonedConnection()
+        {
+            var pool = (ChannelDbConnectionPool)ConstructPool(
+                PoolImplementation.Channel,
+                timeProvider: TimeProvider.System,
+                maxPoolSize: 1);
+            DbConnectionInternal abandonedConnection =
+                CheckOutAndAbandonOwner(pool);
+            abandonedConnection.CheckoutTime =
+                DateTime.UtcNow - TimeSpan.FromMinutes(5);
+            CollectAbandonedOwners();
+            Assert.True(abandonedConnection.IsEmancipated);
+            var timeoutProvider = new FakeTimeProvider();
+            TimeoutTimer expiredTimeout =
+                TimeoutTimer.StartNew(TimeSpan.FromSeconds(1), timeoutProvider);
+            timeoutProvider.Advance(TimeSpan.FromSeconds(2));
+
+            InvalidOperationException timeout =
+                Assert.Throws<InvalidOperationException>(() =>
+                    pool.TryGetConnection(
+                        new SqlConnection(),
+                        taskCompletionSource: null,
+                        expiredTimeout,
+                        out _));
+
+            Assert.Equal(
+                1,
+                timeout.Data[PoolAcquisitionDiagnostics.AbandonedConnectionCountDataKey]);
+            Assert.Equal(
+                0,
+                timeout.Data[PoolAcquisitionDiagnostics.CheckedOutConnectionCountDataKey]);
+
+            pool.ReclaimEmancipatedConnections();
+        }
+
+        /// <summary>
+        /// Requests a connection synchronously or asynchronously and returns the pooled-open timeout.
+        /// </summary>
+        /// <param name="pool">Pool from which to request a connection.</param>
+        /// <param name="owner">Connection that would own the acquired internal connection.</param>
+        /// <param name="async">Whether to use the pool's asynchronous completion path.</param>
+        /// <param name="timeoutDuration">Optional timeout budget for the acquisition.</param>
+        /// <returns>The pooled-open timeout surfaced to the caller.</returns>
+        private static async Task<InvalidOperationException> AssertPoolTimeoutAsync(
+            IDbConnectionPool pool,
+            DbConnection owner,
+            bool async,
+            TimeSpan? timeoutDuration = null)
+        {
+            TimeoutTimer timeout = TimeoutTimer.StartNew(
+                timeoutDuration ?? TimeSpan.FromMilliseconds(100));
+
+            if (!async)
+            {
+                return Assert.Throws<InvalidOperationException>(() =>
+                    pool.TryGetConnection(
+                        owner,
+                        taskCompletionSource: null,
+                        timeout,
+                        out _));
+            }
+
+            TaskCompletionSource<DbConnectionInternal> completion = new(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            Assert.False(pool.TryGetConnection(
+                owner,
+                completion,
+                timeout,
+                out _));
+
+            return await Assert.ThrowsAsync<InvalidOperationException>(
+                () => completion.Task);
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionTests.cs
@@ -281,9 +281,12 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
                 : Assert.Throws<SqlException>(() => connection.Open());
 
             Assert.Equal(TdsEnums.TIMEOUT_EXPIRED, terminal.Number);
-            SqlException retryFailure =
-                Assert.Single(terminal.ConnectionOpenRetryFailures);
+            Assert.NotEmpty(terminal.ConnectionOpenRetryFailures);
+            SqlException retryFailure = terminal.ConnectionOpenRetryFailures[0];
             Assert.Equal(transientErrorCode, retryFailure.Number);
+            Assert.All(
+                terminal.ConnectionOpenRetryFailures,
+                failure => Assert.Empty(failure.ConnectionOpenRetryFailures));
             Assert.Equal(ConnectionState.Closed, connection.State);
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionTests.cs
@@ -282,8 +282,9 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
 
             Assert.Equal(TdsEnums.TIMEOUT_EXPIRED, terminal.Number);
             Assert.NotEmpty(terminal.ConnectionOpenRetryFailures);
-            SqlException retryFailure = terminal.ConnectionOpenRetryFailures[0];
-            Assert.Equal(transientErrorCode, retryFailure.Number);
+            Assert.Contains(
+                terminal.ConnectionOpenRetryFailures,
+                failure => failure.Number == transientErrorCode);
             Assert.All(
                 terminal.ConnectionOpenRetryFailures,
                 failure => Assert.Empty(failure.ConnectionOpenRetryFailures));

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionTests.cs
@@ -204,6 +204,131 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             Assert.Equal(1, server.PreLoginCount - server.AbandonedPreLoginCount);
         }
 
+        /// <summary>
+        /// Verifies failed connection-open retries are preserved in chronological order on the
+        /// terminal exception without replacing that exception's own error details.
+        /// </summary>
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task TransientFault_RetriesExhausted_ExposesRetryFailures(bool async)
+        {
+            const int errorCode = 40613;
+            using TransientTdsErrorTdsServer server = new(
+                new TransientTdsErrorTdsServerArguments
+                {
+                    IsEnabledTransientError = true,
+                    Number = errorCode,
+                    RepeatCount = 2,
+                });
+            server.Start();
+            SqlConnectionStringBuilder builder = new()
+            {
+                DataSource = "localhost," + server.EndPoint.Port,
+                ConnectRetryCount = 1,
+                ConnectRetryInterval = 1,
+                ConnectTimeout = 10,
+                Encrypt = SqlConnectionEncryptOption.Optional,
+                Pooling = false,
+            };
+            using SqlConnection connection = new(builder.ConnectionString);
+
+            SqlException terminal = async
+                ? await Assert.ThrowsAsync<SqlException>(() => connection.OpenAsync())
+                : Assert.Throws<SqlException>(() => connection.Open());
+
+            Assert.Equal(errorCode, terminal.Number);
+            SqlException retryFailure =
+                Assert.Single(terminal.ConnectionOpenRetryFailures);
+            Assert.Equal(errorCode, retryFailure.Number);
+            Assert.Empty(retryFailure.ConnectionOpenRetryFailures);
+            Assert.Equal(ConnectionState.Closed, connection.State);
+            Assert.Equal(2, server.PreLoginCount - server.AbandonedPreLoginCount);
+        }
+
+        /// <summary>
+        /// Verifies a timeout on the final connection attempt retains the transient server error
+        /// that caused the preceding retry.
+        /// </summary>
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task TransientFault_FinalRetryTimesOut_ExposesRetryFailure(bool async)
+        {
+            const int transientErrorCode = 40613;
+            using TransientTdsErrorTdsServer server = new(
+                new TransientTdsErrorTdsServerArguments
+                {
+                    IsEnabledTransientError = true,
+                    Number = transientErrorCode,
+                    RepeatCount = 1,
+                    DelayAfterTransientErrors = TimeSpan.FromSeconds(10),
+                });
+            server.Start();
+            SqlConnectionStringBuilder builder = new()
+            {
+                DataSource = "localhost," + server.EndPoint.Port,
+                ConnectRetryCount = 1,
+                ConnectRetryInterval = 1,
+                ConnectTimeout = 3,
+                Encrypt = SqlConnectionEncryptOption.Optional,
+                Pooling = false,
+            };
+            using SqlConnection connection = new(builder.ConnectionString);
+
+            SqlException terminal = async
+                ? await Assert.ThrowsAsync<SqlException>(() => connection.OpenAsync())
+                : Assert.Throws<SqlException>(() => connection.Open());
+
+            Assert.Equal(TdsEnums.TIMEOUT_EXPIRED, terminal.Number);
+            SqlException retryFailure =
+                Assert.Single(terminal.ConnectionOpenRetryFailures);
+            Assert.Equal(transientErrorCode, retryFailure.Number);
+            Assert.Equal(ConnectionState.Closed, connection.State);
+        }
+
+        /// <summary>
+        /// Verifies failures from a connection open that eventually succeeds are released rather
+        /// than appearing on later, unrelated errors from that connection.
+        /// </summary>
+        [Fact]
+        public void TransientFault_RetrySucceeds_DoesNotLeakFailuresToLaterErrors()
+        {
+            const int transientErrorCode = 40613;
+            const int commandErrorCode = 50000;
+            using TransientTdsErrorTdsServer server = new(
+                new TransientTdsErrorTdsServerArguments
+                {
+                    IsEnabledTransientError = true,
+                    Number = transientErrorCode,
+                    RepeatCount = 1,
+                });
+            server.Start();
+            SqlConnectionStringBuilder builder = new()
+            {
+                DataSource = "localhost," + server.EndPoint.Port,
+                ConnectRetryCount = 1,
+                ConnectRetryInterval = 1,
+                ConnectTimeout = 10,
+                Encrypt = SqlConnectionEncryptOption.Optional,
+                Pooling = false,
+            };
+            using SqlConnection connection = new(builder.ConnectionString);
+            connection.Open();
+            server.SetErrorBehavior(
+                isEnabledTransientError: true,
+                errorNumber: commandErrorCode,
+                repeatCount: 2,
+                message: "later command failure");
+            using SqlCommand command = new("SELECT 1", connection);
+
+            SqlException commandFailure =
+                Assert.Throws<SqlException>(() => command.ExecuteNonQuery());
+
+            Assert.Equal(commandErrorCode, commandFailure.Number);
+            Assert.Empty(commandFailure.ConnectionOpenRetryFailures);
+        }
+
         // Flaky under CI load only (never reproduces locally): the retry login can exhaust
         // the connect-timeout budget on a slow agent and surface a post-login Connection
         // Timeout (observed pre-login handshake ~4.4s), so the async open propagates a

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SqlExceptionRetryFailuresTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SqlExceptionRetryFailuresTest.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.ComponentModel;
+using Microsoft.Data.SqlClient.ConnectionPool;
+using Microsoft.Data.SqlClient.UnitTests.ConnectionPool;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests
+{
+    /// <summary>
+    /// Verifies the public connection-open retry ledger on <see cref="SqlException"/>.
+    /// </summary>
+    public sealed class SqlExceptionRetryFailuresTest
+    {
+        /// <summary>
+        /// Verifies exceptions that did not pass through a connection-open retry expose an empty
+        /// immutable ledger.
+        /// </summary>
+        [Fact]
+        public void ConnectionOpenRetryFailures_NoRetries_IsEmpty()
+        {
+            SqlException exception = SqlExceptionHelper.CreateSqlException("terminal failure");
+
+            Assert.Empty(exception.ConnectionOpenRetryFailures);
+        }
+
+        /// <summary>
+        /// Verifies enriching a terminal failure retains its existing SQL errors, native inner
+        /// exception, connection metadata, and data entries.
+        /// </summary>
+        [Fact]
+        public void SetConnectionOpenRetryFailures_PreservesTerminalException()
+        {
+            var nativeTimeout = new Win32Exception(258);
+            var errors = new SqlErrorCollection();
+            errors.Add(new SqlError(-2, 0, 11, "server", "terminal timeout", "", 0, 258));
+            SqlException terminal = SqlException.CreateException(
+                errors,
+                serverVersion: "1.0",
+                conId: Guid.NewGuid(),
+                innerException: nativeTimeout);
+            terminal.Data["marker"] = "preserved";
+            SqlException first = SqlExceptionHelper.CreateSqlException("first {transient} failure");
+            SqlException second = SqlExceptionHelper.CreateSqlException("second transient failure");
+
+            terminal.SetConnectionOpenRetryFailures(
+                new[] { first, second });
+
+            Assert.Same(errors, terminal.Errors);
+            Assert.Same(nativeTimeout, terminal.InnerException);
+            Assert.Equal("preserved", terminal.Data["marker"]);
+            Assert.Collection(
+                terminal.ConnectionOpenRetryFailures,
+                failure => Assert.Same(first, failure),
+                failure => Assert.Same(second, failure));
+            Assert.Contains("first {transient} failure", terminal.ToString());
+            Assert.Contains("second transient failure", terminal.ToString());
+        }
+
+        /// <summary>
+        /// Verifies the blocking-period cache does not replay one Open call's retry ledger to later
+        /// callers that fast-fail against the cached connection error.
+        /// </summary>
+        [Fact]
+        public void BlockingPeriodCache_StripsConnectionOpenRetryFailures()
+        {
+            using var state = new BlockingPeriodErrorState(ownerPoolId: 1);
+            SqlException terminal =
+                SqlExceptionHelper.CreateSqlException("terminal failure");
+            terminal.SetConnectionOpenRetryFailures(
+                new[] { SqlExceptionHelper.CreateSqlException("transient failure") });
+
+            state.Enter(terminal);
+
+            SqlException replayed = Assert.Throws<SqlException>(
+                () => state.ThrowIfActive());
+            Assert.Empty(replayed.ConnectionOpenRetryFailures);
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/TransientTdsErrorTdsServer.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/TransientTdsErrorTdsServer.cs
@@ -17,6 +17,8 @@ namespace Microsoft.SqlServer.TDS.Servers
     public class TransientTdsErrorTdsServer : GenericTdsServer<TransientTdsErrorTdsServerArguments>, IDisposable
     {
         private int RequestCounter = 0;
+        private readonly CancellationTokenSource _disposeCts = new();
+        private bool _disposed;
 
         public void SetErrorBehavior(bool isEnabledTransientError, uint errorNumber, int repeatCount = 1, string message = null)
         {
@@ -63,6 +65,12 @@ namespace Microsoft.SqlServer.TDS.Servers
                 // Increment Login7 count since we won't call base.OnLogin7Request
                 Interlocked.Increment(ref _login7Count);
                 return GenerateErrorMessage(request);
+            }
+
+            if (Arguments.DelayAfterTransientErrors > TimeSpan.Zero)
+            {
+                _disposeCts.Token.WaitHandle.WaitOne(
+                    Arguments.DelayAfterTransientErrors);
             }
 
             // Return login response from the base class
@@ -112,9 +120,24 @@ namespace Microsoft.SqlServer.TDS.Servers
             return new TDSMessageCollection(responseMessage);
         }
 
-        public override void Dispose() {
-            base.Dispose();
-            RequestCounter = 0;
+        public override void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            try
+            {
+                _disposeCts.Cancel();
+                base.Dispose();
+                RequestCounter = 0;
+            }
+            finally
+            {
+                _disposeCts.Dispose();
+            }
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/TransientTdsErrorTdsServerArguments.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/TransientTdsErrorTdsServerArguments.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace Microsoft.SqlServer.TDS.Servers
 {
     public class TransientTdsErrorTdsServerArguments : TdsServerArguments
@@ -33,5 +35,11 @@ namespace Microsoft.SqlServer.TDS.Servers
         /// when a test needs to avoid automatic break/doom behavior in the client.
         /// </summary>
         public byte ErrorClass { get; set; } = 20;
+
+        /// <summary>
+        /// Optional delay applied to login responses after all configured transient errors have
+        /// been emitted. Tests use this to make a final retry exhaust the overall connect timeout.
+        /// </summary>
+        public TimeSpan DelayAfterTransientErrors { get; set; } = TimeSpan.Zero;
     }
 }


### PR DESCRIPTION
## Description

Connection acquisition failures can end as a generic pool timeout, hiding whether the request was blocked by pool capacity, connection creation throttling, abandoned connections, or failures consumed by connection-open retries.

This change:

- Adds timeout-only diagnostics to both pool implementations, including the wait reason, capacity and idle counts, pending opens, waiting callers, checked-out and transaction-held connections, abandoned connections, longest checkout duration, and reclamation during the request. The values are included in the timeout message and `Exception.Data`.
- Adds the public `SqlException.ConnectionOpenRetryFailures` property. It preserves transient failures in retry order while retaining the terminal exception's stack, `Errors`, and `InnerException`.
- Keeps retry history scoped to one `Open` call. Successful opens discard it, and pool blocking-period replays do not expose another request's ledger.
- Documents the new API and adds localized resource entries. Pool timeout messages now retain the existing text as a prefix and append the diagnostic snapshot.

## Issues

Fixes #3545

## Testing

- Added sync and async coverage for full-pool and rate-limited acquisition timeouts across both pool implementations.
- Added abandoned-owner and checkout-age diagnostics coverage.
- Added simulated-server coverage for exhausted retries, transient failure followed by a final timeout, and successful retry cleanup.
- Ran the connection-pool unit suite on `net9.0`, targeted diagnostics on `net8.0` and `net9.0`, portable simulated connection tests, and `SqlException` functional coverage.
- Built the implementation and reference assembly projects for `net8.0` and `net9.0`.
- The full unit-suite invocation did not complete within the available runner timeout. The affected suites completed successfully.

## Guidelines

Please review the contribution guidelines before submitting a pull request:

- [Contributing](/CONTRIBUTING.md)
- [Code of Conduct](/CODE_OF_CONDUCT.md)
- [Best Practices](/policy/coding-best-practices.md)
- [Coding Style](/policy/coding-style.md)
- [Review Process](/policy/review-process.md)

- [x] Tests added or updated
- [x] Public API changes documented
- [x] Verified against customer repro (not applicable)
- [x] Ensure no breaking changes introduced