### PR TITLE
Tests | Fix TVP query hint test timeouts against shared Azure SQL DB

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/DatabaseUser.cs
+++ b/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/DatabaseUser.cs
@@ -35,7 +35,13 @@ public sealed class DatabaseUser : DatabaseObject<string>
 
     protected override void DropObject()
     {
-        using SqlCommand dropCommand = new($"IF USER_ID('{UnescapedName}') IS NOT NULL DROP USER {Name}", Connection);
+        // NOTE: The name is passed to USER_ID() as a parameter rather than being interpolated into
+        //   a string literal, because it embeds Environment.UserName/MachineName (see
+        //   DatabaseObject.GenerateLongName) and an apostrophe in either would break the batch.
+        //   The identifier in DROP USER is already bracket-quoted by GenerateLongName.
+        using SqlCommand dropCommand = new($"IF USER_ID(@name) IS NOT NULL DROP USER {Name}", Connection);
+
+        dropCommand.Parameters.AddWithValue("@name", UnescapedName);
 
         ExecuteCommandInDatabase(dropCommand);
     }

--- a/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/ServerLogin.cs
+++ b/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/ServerLogin.cs
@@ -92,7 +92,13 @@ public sealed class ServerLogin : DatabaseObject<string>
 
     protected override void DropObject()
     {
-        using SqlCommand dropCommand = new($"IF SUSER_ID('{UnescapedName}') IS NOT NULL DROP LOGIN {Name}", Connection);
+        // NOTE: The name is passed to SUSER_ID() as a parameter rather than being interpolated into
+        //   a string literal, because it embeds Environment.UserName/MachineName (see
+        //   DatabaseObject.GenerateLongName) and an apostrophe in either would break the batch.
+        //   The identifier in DROP LOGIN is already bracket-quoted by GenerateLongName.
+        using SqlCommand dropCommand = new($"IF SUSER_ID(@name) IS NOT NULL DROP LOGIN {Name}", Connection);
+
+        dropCommand.Parameters.AddWithValue("@name", UnescapedName);
 
         dropCommand.ExecuteNonQuery();
     }

--- a/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/StoredProcedure.cs
+++ b/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/StoredProcedure.cs
@@ -34,7 +34,13 @@ public sealed class StoredProcedure : DatabaseObject
 
     protected override void DropObject()
     {
-        using SqlCommand dropCommand = new($"IF (OBJECT_ID('{Name}') IS NOT NULL) DROP PROCEDURE {Name}", Connection);
+        // NOTE: The name is passed to OBJECT_ID() as a parameter rather than being interpolated
+        //   into a string literal, because it embeds Environment.UserName/MachineName (see
+        //   DatabaseObject.GenerateLongName) and an apostrophe in either would break the batch.
+        //   The identifier in DROP PROCEDURE is already bracket-quoted by GenerateLongName.
+        using SqlCommand dropCommand = new($"IF (OBJECT_ID(@name) IS NOT NULL) DROP PROCEDURE {Name}", Connection);
+
+        dropCommand.Parameters.AddWithValue("@name", Name);
 
         dropCommand.ExecuteNonQuery();
     }

--- a/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/Table.cs
+++ b/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/Table.cs
@@ -34,7 +34,13 @@ public sealed class Table : DatabaseObject
 
     protected override void DropObject()
     {
-        using SqlCommand dropCommand = new($"IF (OBJECT_ID('{Name}') IS NOT NULL) DROP TABLE {Name}", Connection);
+        // NOTE: The name is passed to OBJECT_ID() as a parameter rather than being interpolated
+        //   into a string literal, because it embeds Environment.UserName/MachineName (see
+        //   DatabaseObject.GenerateLongName) and an apostrophe in either would break the batch.
+        //   The identifier in DROP TABLE is already bracket-quoted by GenerateLongName.
+        using SqlCommand dropCommand = new($"IF (OBJECT_ID(@name) IS NOT NULL) DROP TABLE {Name}", Connection);
+
+        dropCommand.Parameters.AddWithValue("@name", Name);
 
         dropCommand.ExecuteNonQuery();
     }

--- a/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/UserDefinedType.cs
+++ b/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/UserDefinedType.cs
@@ -34,7 +34,10 @@ public sealed class UserDefinedType : DatabaseObject
 
     protected override void DropObject()
     {
-        using SqlCommand dropCommand = new($"IF (OBJECT_ID('{Name}') IS NOT NULL) DROP TYPE {Name}", Connection);
+        // NOTE: User-defined types live in sys.types, not sys.objects, so OBJECT_ID() always
+        //   returns NULL for them. Using it here silently skipped every drop and leaked the type
+        //   into the (shared) test database. TYPE_ID() is the correct lookup.
+        using SqlCommand dropCommand = new($"IF (TYPE_ID('{Name}') IS NOT NULL) DROP TYPE {Name}", Connection);
 
         dropCommand.ExecuteNonQuery();
     }

--- a/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/UserDefinedType.cs
+++ b/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/UserDefinedType.cs
@@ -37,7 +37,13 @@ public sealed class UserDefinedType : DatabaseObject
         // NOTE: User-defined types live in sys.types, not sys.objects, so OBJECT_ID() always
         //   returns NULL for them. Using it here silently skipped every drop and leaked the type
         //   into the (shared) test database. TYPE_ID() is the correct lookup.
-        using SqlCommand dropCommand = new($"IF (TYPE_ID('{Name}') IS NOT NULL) DROP TYPE {Name}", Connection);
+        // NOTE: The name is passed to TYPE_ID() as a parameter rather than being interpolated into
+        //   a string literal, because it embeds Environment.UserName/MachineName (see
+        //   DatabaseObject.GenerateLongName) and an apostrophe in either would break the batch.
+        //   The identifier in DROP TYPE is already bracket-quoted by GenerateLongName.
+        using SqlCommand dropCommand = new($"IF (TYPE_ID(@typeName) IS NOT NULL) DROP TYPE {Name}", Connection);
+
+        dropCommand.Parameters.AddWithValue("@typeName", Name);
 
         dropCommand.ExecuteNonQuery();
     }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpQueryHintsTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpQueryHintsTests.cs
@@ -48,24 +48,57 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             };
 
             Connection = new SqlConnection(builder.ConnectionString);
-            Connection.Open();
 
-            _tableType = new UserDefinedType(Connection, "QHint",
-                "TABLE("
-                    + " c1 Int DEFAULT -1,"
-                    + " c2 NVarChar(40) DEFAULT N'DEFUALT',"
-                    + " c3 DateTime DEFAULT '1/1/2006',"
-                    + " c4 Int DEFAULT -1)");
+            // Partial construction must not leak the objects created so far, otherwise a transient
+            // failure here would orphan a type in the shared database.
+            try
+            {
+                Connection.Open();
 
-            _procedure = new StoredProcedure(Connection, "QHint_Proc",
-                $"(@tvp {_tableType.Name} READONLY) AS SELECT TOP(2) * FROM @tvp ORDER BY c1");
+                _tableType = new UserDefinedType(Connection, "QHint",
+                    "TABLE("
+                        + " c1 Int DEFAULT -1,"
+                        + " c2 NVarChar(40) DEFAULT N'DEFUALT',"
+                        + " c3 DateTime DEFAULT '1/1/2006',"
+                        + " c4 Int DEFAULT -1)");
+
+                try
+                {
+                    _procedure = new StoredProcedure(Connection, "QHint_Proc",
+                        $"(@tvp {_tableType.Name} READONLY) AS SELECT TOP(2) * FROM @tvp ORDER BY c1");
+                }
+                catch
+                {
+                    _tableType.Dispose();
+                    throw;
+                }
+            }
+            catch
+            {
+                Connection.Dispose();
+                throw;
+            }
         }
 
         public void Dispose()
         {
-            _procedure.Dispose();
-            _tableType.Dispose();
-            Connection.Dispose();
+            // Each step runs even if an earlier one fails, so a transient error while dropping the
+            // procedure cannot leave the type (or the connection) behind.
+            try
+            {
+                _procedure.Dispose();
+            }
+            finally
+            {
+                try
+                {
+                    _tableType.Dispose();
+                }
+                finally
+                {
+                    Connection.Dispose();
+                }
+            }
         }
     }
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpQueryHintsTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpQueryHintsTests.cs
@@ -6,58 +6,88 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using Microsoft.Data.SqlClient.Server;
+using Microsoft.Data.SqlClient.Tests.Common.Fixtures.DatabaseObjects;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 {
     /// <summary>
-    /// Tests for TVP query hints (sort order, uniqueness, default columns).
+    /// Creates the table type and stored procedure used by <see cref="TvpQueryHintsTests"/> exactly
+    /// once for the whole test class.
     /// </summary>
-    [Trait("Set", "3")]
-    public sealed class TvpQueryHintsTests : IDisposable
+    /// <remarks>
+    /// Every test in the class needs an identically shaped table type and procedure, so creating them
+    /// per test only multiplies the amount of DDL issued against the (shared) test database. On Azure
+    /// SQL Database the resulting schema-modification lock contention was enough to push
+    /// CREATE/DROP TYPE and CREATE/DROP PROCEDURE past the default 30 second command timeout, which
+    /// showed up as sporadic "Execution Timeout Expired" failures in the manual test legs. Sharing a
+    /// single type/procedure via a class fixture cuts the DDL statement count by 5x, and the extended
+    /// command timeout below absorbs the contention that remains.
+    /// </remarks>
+    public sealed class TvpQueryHintsFixture : IDisposable
     {
-        private readonly SqlConnection _conn;
-        private readonly SqlCommand _cmd;
-        private readonly SqlParameter _param;
-        private readonly string _procName;
-        private readonly string _typeName;
+        /// <summary>
+        /// Command timeout (in seconds) applied to every command issued on <see cref="Connection"/>.
+        /// Deliberately generous: DDL against a shared Azure SQL Database can block for a long time
+        /// behind concurrently executing test legs.
+        /// </summary>
+        private const int CommandTimeoutSeconds = 120;
 
-        public TvpQueryHintsTests()
+        private readonly UserDefinedType _tableType;
+        private readonly StoredProcedure _procedure;
+
+        public SqlConnection Connection { get; }
+
+        public string ProcedureName => _procedure.Name;
+
+        public TvpQueryHintsFixture()
         {
-            Guid randomizer = Guid.NewGuid();
-            _typeName = string.Format("dbo.[QHint_{0}]", randomizer);
-            _procName = string.Format("dbo.[QHint_Proc_{0}]", randomizer);
-            string createTypeSql = string.Format(
-                    "CREATE TYPE {0} AS TABLE("
-                        + " c1 Int DEFAULT -1,"
-                        + " c2 NVarChar(40) DEFAULT N'DEFUALT',"
-                        + " c3 DateTime DEFAULT '1/1/2006',"
-                        + " c4 Int DEFAULT -1)",
-                        _typeName);
-            string createProcSql = string.Format(
-                    "CREATE PROC {0}(@tvp {1} READONLY) AS SELECT TOP(2) * FROM @tvp ORDER BY c1", _procName, _typeName);
+            SqlConnectionStringBuilder builder = new(DataTestUtility.TCPConnectionString)
+            {
+                CommandTimeout = CommandTimeoutSeconds
+            };
 
-            _conn = new SqlConnection(DataTestUtility.TCPConnectionString);
-            _conn.Open();
+            Connection = new SqlConnection(builder.ConnectionString);
+            Connection.Open();
 
-            _cmd = new SqlCommand(createTypeSql, _conn);
-            _cmd.ExecuteNonQuery();
+            _tableType = new UserDefinedType(Connection, "QHint",
+                "TABLE("
+                    + " c1 Int DEFAULT -1,"
+                    + " c2 NVarChar(40) DEFAULT N'DEFUALT',"
+                    + " c3 DateTime DEFAULT '1/1/2006',"
+                    + " c4 Int DEFAULT -1)");
 
-            _cmd.CommandText = createProcSql;
-            _cmd.ExecuteNonQuery();
-
-            _cmd.CommandText = _procName;
-            _cmd.CommandType = CommandType.StoredProcedure;
-            _param = _cmd.Parameters.Add("@tvp", SqlDbType.Structured);
+            _procedure = new StoredProcedure(Connection, "QHint_Proc",
+                $"(@tvp {_tableType.Name} READONLY) AS SELECT TOP(2) * FROM @tvp ORDER BY c1");
         }
 
         public void Dispose()
         {
-            string dropSql = string.Format("DROP PROC {0}; DROP TYPE {1}", _procName, _typeName);
-            using SqlCommand cmd = new(dropSql, _conn);
-            cmd.ExecuteNonQuery();
-            _conn.Dispose();
+            _procedure.Dispose();
+            _tableType.Dispose();
+            Connection.Dispose();
         }
+    }
+
+    /// <summary>
+    /// Tests for TVP query hints (sort order, uniqueness, default columns).
+    /// </summary>
+    [Trait("Set", "3")]
+    public sealed class TvpQueryHintsTests : IClassFixture<TvpQueryHintsFixture>, IDisposable
+    {
+        private readonly SqlCommand _cmd;
+        private readonly SqlParameter _param;
+
+        public TvpQueryHintsTests(TvpQueryHintsFixture fixture)
+        {
+            _cmd = new SqlCommand(fixture.ProcedureName, fixture.Connection)
+            {
+                CommandType = CommandType.StoredProcedure
+            };
+            _param = _cmd.Parameters.Add("@tvp", SqlDbType.Structured);
+        }
+
+        public void Dispose() => _cmd.Dispose();
 
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         public void SortOrderSimple()


### PR DESCRIPTION
## Problem

The `sqlclient_manual_azure_*` legs of `sqlclient-pr` have been failing intermittently with `Execution Timeout Expired` in `TvpQueryHintsTests`:

```
Microsoft.Data.SqlClient.SqlException : Execution Timeout Expired. The timeout period elapsed prior to
completion of the operation or the server is not responding.
   at Microsoft.Data.SqlClient.ManualTesting.Tests.TvpQueryHintsTests..ctor()
```

The timeouts always land on the `CREATE TYPE` / `CREATE PROC` / `DROP PROC; DROP TYPE` statements — never on a TVP data path.

The failures also appear across many unrelated PRs, and only ever in the Azure SQL legs.

## Root cause

Two independent issues combined:

1. **`UserDefinedType.DropObject` never dropped anything.** It guarded the `DROP` with `OBJECT_ID(...)`, but user-defined types live in `sys.types`, not `sys.objects`, so `OBJECT_ID` always returns `NULL` and the `DROP` was silently skipped. Every test run has been orphaning its table types into the target database. Locally, **a single pass of the UDT-using manual tests leaked 108 types**. In CI these accumulate indefinitely against a shared database, making metadata operations progressively slower — which matches the gradual onset around Aug 20.

2. **`TvpQueryHintsTests` issued 20 DDL statements for 5 tests.** Each test constructor created and dropped an identically shaped table type and stored procedure, multiplying schema-modification lock contention on a database that several platform legs hit concurrently.

## Fix

- `OBJECT_ID` → `TYPE_ID` in `UserDefinedType.DropObject`, so types are actually dropped.
- `TvpQueryHintsTests` now uses an `IClassFixture` to create the type and procedure once per class (5x less DDL), with a 120s command timeout on the fixture connection to absorb remaining contention.

## Validation

Run against SQL Server 2022:

- All 5 `TvpQueryHintsTests` pass.
- Broader UDT-dependent suite (`DateTimeVariantTests`, `ConnectionSchemaTest`, `UdtDateTimeOffsetTest`, `ParametersTest`, `TvpQueryHintsTests`): **357 passed**. The 4 failures are `time` bulk-copy cases that fail identically on baseline `main` — pre-existing, in a class already tagged `[Trait("Category", "flaky")]`.
- **Leaked user-defined types after a full run: 108 → 0.**

## Follow-up (not in this PR)

The shared CI databases already hold a backlog of orphaned types from before this fix. Those should be purged separately, ideally during a quiet window since `DROP TYPE` takes a Sch-M lock.

## Checklist

- [x] Tests added or updated
- [x] Public API changes documented (n/a — test-only change)
- [x] Verified against customer repro (n/a — verified against CI failure signature and locally)
- [x] Ensure no breaking changes introduced