### PR TITLE
Fix | TransactionTest read committed timeout assertion under READ_COMMITTED_SNAPSHOT

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionTest.cs
@@ -449,9 +449,15 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                     using (SqlConnection connection2 = new SqlConnection(_connectionString))
                     {
+                        // The READCOMMITTEDLOCK hint guarantees locking read committed semantics even when the
+                        // target database has READ_COMMITTED_SNAPSHOT enabled (the default for Azure SQL Database),
+                        // where the reader would otherwise return the last committed row version without blocking.
                         SqlCommand command2 =
-                            new SqlCommand("select * from " + _tempTableName1 + " where CustomerID='ZYXWV'",
-                                connection2);
+                            new SqlCommand("select * from " + _tempTableName1 + " with (readcommittedlock) where CustomerID='ZYXWV'",
+                                connection2)
+                            {
+                                CommandTimeout = 5
+                            };
 
                         connection2.Open();
                         SqlTransaction tx2 = connection2.BeginTransaction(IsolationLevel.ReadCommitted);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionTest.cs
@@ -452,20 +452,22 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         // The READCOMMITTEDLOCK hint guarantees locking read committed semantics even when the
                         // target database has READ_COMMITTED_SNAPSHOT enabled (the default for Azure SQL Database),
                         // where the reader would otherwise return the last committed row version without blocking.
-                        SqlCommand command2 =
+                        using (SqlCommand command2 =
                             new SqlCommand("select * from " + _tempTableName1 + " with (readcommittedlock) where CustomerID='ZYXWV'",
                                 connection2)
                             {
                                 CommandTimeout = 5
-                            };
+                            })
+                        {
+                            connection2.Open();
+                            SqlTransaction tx2 = connection2.BeginTransaction(IsolationLevel.ReadCommitted);
+                            command2.Transaction = tx2;
 
-                        connection2.Open();
-                        SqlTransaction tx2 = connection2.BeginTransaction(IsolationLevel.ReadCommitted);
-                        command2.Transaction = tx2;
+                            DataTestUtility.AssertThrows<SqlException>(() => command2.ExecuteReader(), SystemDataResourceManager.Instance.SQL_Timeout_Execution as string);
 
-                        DataTestUtility.AssertThrows<SqlException>(() => command2.ExecuteReader(), SystemDataResourceManager.Instance.SQL_Timeout_Execution as string);
+                            tx2.Rollback();
+                        }
 
-                        tx2.Rollback();
                         connection2.Close();
                     }
 


### PR DESCRIPTION
Fixes #4596

### Summary

`TransactionTest.TestMain` fails with `Assert.Throws() Failure: No exception was thrown` when the target database has `READ_COMMITTED_SNAPSHOT` enabled (default for Azure SQL Database).

`ReadCommitedIsolationLevel_ShouldReceiveTimeoutExceptionBecauseItWaitsForUncommitedTransaction` assumed locking read committed semantics: the second connection's `SELECT` should block on the first connection's uncommitted `INSERT` and time out. Under RCSI the reader instead returns the last committed row version immediately, so no timeout `SqlException` is raised.

### Changes

- Added the `WITH (READCOMMITTEDLOCK)` table hint to the blocked `SELECT`, forcing locking read committed semantics regardless of the database's `READ_COMMITTED_SNAPSHOT` setting.
- Set `CommandTimeout = 5` on that command so the expected timeout fires quickly and deterministically instead of waiting the default 30 seconds.

Test-only change; no product code is affected. The test is already skipped for Azure Synapse, which does not support the hint.

### Checklist

- [x] Tests added or updated (test-only fix)
- [x] Public API changes documented (n/a)
- [x] Verified against customer repro (n/a — CI failure)
- [x] Ensure no breaking changes introduced
