### PR TITLE
[v6.1.7] Bump SNI dependency to 6.0.3

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="Azure.Core" Version="1.50.0" />
     <PackageVersion Include="Azure.Identity" Version="1.17.1" />
     <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.Data.SqlClient.SNI" Version="6.0.2" />
+    <PackageVersion Include="Microsoft.Data.SqlClient.SNI" Version="6.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.84.2" />
     <PackageVersion Include="Microsoft.Identity.Client.Broker" Version="4.84.2" />
@@ -30,7 +30,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageVersion Include="Azure.Core" Version="1.50.0" />
     <PackageVersion Include="Azure.Identity" Version="1.17.1" />
-    <PackageVersion Include="Microsoft.Data.SqlClient.SNI.runtime" Version="6.0.2" />
+    <PackageVersion Include="Microsoft.Data.SqlClient.SNI.runtime" Version="6.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.84.2" />
     <PackageVersion Include="Microsoft.Identity.Client.Broker" Version="4.84.2" />
@@ -50,7 +50,7 @@
     <PackageVersion Include="Azure.Core" Version="1.50.0" />
     <PackageVersion Include="Azure.Identity" Version="1.17.1" />
     <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.Data.SqlClient.SNI.runtime" Version="6.0.2" />
+    <PackageVersion Include="Microsoft.Data.SqlClient.SNI.runtime" Version="6.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.84.2" />
     <PackageVersion Include="Microsoft.Identity.Client.Broker" Version="4.84.2" />
@@ -69,7 +69,7 @@
     <PackageVersion Include="Azure.Core" Version="1.50.0" />
     <PackageVersion Include="Azure.Identity" Version="1.17.1" />
     <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.Data.SqlClient.SNI.runtime" Version="6.0.2" />
+    <PackageVersion Include="Microsoft.Data.SqlClient.SNI.runtime" Version="6.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.11" /> 
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.84.2" />
     <PackageVersion Include="Microsoft.Identity.Client.Broker" Version="4.84.2" />

--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -31,7 +31,7 @@
       <group targetFramework="net462">
         <dependency id="Azure.Core" version="1.50.0" />
         <dependency id="Azure.Identity" version="1.17.1" />
-        <dependency id="Microsoft.Data.SqlClient.SNI" version="6.0.2" />
+        <dependency id="Microsoft.Data.SqlClient.SNI" version="6.0.3" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.1" exclude="Compile" />
         <dependency id="Microsoft.Identity.Client" version="4.84.2" />
         <dependency id="Microsoft.Identity.Client.Broker" version="4.84.2" />
@@ -49,7 +49,7 @@
       <group targetFramework="net8.0">
         <dependency id="Azure.Core" version="1.50.0" />
         <dependency id="Azure.Identity" version="1.17.1" />
-        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="6.0.2" exclude="Compile" />
+        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="6.0.3" exclude="Compile" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.1" exclude="Compile" />
         <dependency id="Microsoft.Identity.Client" version="4.84.2" />
         <dependency id="Microsoft.Identity.Client.Broker" version="4.84.2" />
@@ -64,7 +64,7 @@
       <group targetFramework="net9.0">
         <dependency id="Azure.Core" version="1.50.0" />
         <dependency id="Azure.Identity" version="1.17.1" />
-        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="6.0.2" exclude="Compile" />
+        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="6.0.3" exclude="Compile" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="9.0.11" exclude="Compile" />
         <dependency id="Microsoft.Identity.Client" version="4.84.2" />
         <dependency id="Microsoft.Identity.Client.Broker" version="4.84.2" />
@@ -79,7 +79,7 @@
       <group targetFramework="netstandard2.0">
         <dependency id="Azure.Core" version="1.50.0" />
         <dependency id="Azure.Identity" version="1.17.1" />
-        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="6.0.2" exclude="Compile" />
+        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="6.0.3" exclude="Compile" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.1" exclude="Compile" />
         <dependency id="Microsoft.Identity.Client" version="4.84.2" />
         <dependency id="Microsoft.Identity.Client.Broker" version="4.84.2" />


### PR DESCRIPTION
## Description
Does what it says on the tin - bumps SNI dependency from 6.0.2 to 6.0.3, the latest package version on the release/6.1 branch. 

## Issues
N/A

## Testing
PR/CI pipelines will validate sufficiently