### PR TITLE
[v7.0.3] Bump SNI dependency to 6.0.3

### DIFF
--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -82,7 +82,7 @@
       - https://learn.microsoft.com/nuget/consume-packages/central-package-management
   -->
   <PropertyGroup>
-    <SniVersion>6.0.2</SniVersion>
+    <SniVersion>6.0.3</SniVersion>
     <SniVersionRange>[$(SniVersion), $([MSBuild]::Add($(SniVersion.Split('.')[0]), 1)).0.0)</SniVersionRange>
     <SqlServerVersionRange>[1.0.0, 2.0.0)</SqlServerVersionRange>
     <AbstractionsVersionRange>[$(AbstractionsPackageVersion), $([MSBuild]::Add($(AbstractionsPackageVersion.Trim().Split('.')[0]), 1)).0.0)</AbstractionsVersionRange>


### PR DESCRIPTION
## Description
Does what it says on the tin - bumps SNI package dependency from 6.0.2 to 6.0.3 on the release/7.0 branch.

## Issues
N/A

## Testing
PR/CI pipelines will sufficiently validate change.