### PR TITLE
Fix | Apply READ_COMMITTED_SNAPSHOT OFF automatically for Azure test DB

### DIFF
--- a/TESTGUIDE.md
+++ b/TESTGUIDE.md
@@ -184,7 +184,9 @@ For a basic local SQL Server run, prepare:
 - A SQL Server instance that the test machine can reach.
 - Shared Memory, TCP, and Named Pipes protocols enabled when testing local Windows SQL Server scenarios.
 - The `NORTHWIND` database created from [tools/testsql/createNorthwindDb.sql](tools/testsql/createNorthwindDb.sql). For
-  Azure SQL, use [tools/testsql/createNorthwindAzureDb.sql](tools/testsql/createNorthwindAzureDb.sql).
+  Azure SQL, use [tools/testsql/createNorthwindAzureDb.sql](tools/testsql/createNorthwindAzureDb.sql). Both scripts turn
+  `READ_COMMITTED_SNAPSHOT` and `ALLOW_SNAPSHOT_ISOLATION` off, which some transaction tests rely on. Azure SQL Database
+  enables `READ_COMMITTED_SNAPSHOT` by default, so run the script against the database rather than setting it up by hand.
 - The `UdtTestDb` database created from [tools/testsql/createUdtTestDb.sql](tools/testsql/createUdtTestDb.sql) if you
   want UDT tests to run.
 - A login or integrated-security principal with permissions to create and drop the temporary objects used by the tests.

--- a/tools/testsql/createNorthwindAzureDb.sql
+++ b/tools/testsql/createNorthwindAzureDb.sql
@@ -17,11 +17,6 @@ GO
 ALTER DATABASE CURRENT SET ALLOW_SNAPSHOT_ISOLATION OFF;
 GO
 /*********************************************************************************/
-ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT OFF WITH ROLLBACK IMMEDIATE;
-GO
-ALTER DATABASE CURRENT SET ALLOW_SNAPSHOT_ISOLATION OFF;
-GO
-/*********************************************************************************/
 
 ALTER DATABASE SCOPED CONFIGURATION SET MAXDOP = 0;
 GO

--- a/tools/testsql/createNorthwindAzureDb.sql
+++ b/tools/testsql/createNorthwindAzureDb.sql
@@ -1,7 +1,26 @@
-/******* RUN THIS SCRIPT MANUALLY *******/
-/******* IN order to run below script no other connection should exist with Azure DB *******/
---ALTER DATABASE [Northwind] SET READ_COMMITTED_SNAPSHOT OFF 
---GO
+/*********************************************************************************/
+/*
+    Azure SQL Database enables READ_COMMITTED_SNAPSHOT (RCSI) by default, unlike
+    SQL Server. Under RCSI a READ COMMITTED reader returns the last committed row
+    version instead of blocking on an uncommitted writer, which silently changes
+    the behaviour tests depend on. Turn it off to match createNorthwindDb.sql.
+
+    WITH ROLLBACK IMMEDIATE terminates other sessions, so this no longer requires
+    the database to be free of connections.
+
+    CURRENT is used so the statements apply to whichever database is being
+    provisioned, rather than a hard-coded name.
+*/
+/*********************************************************************************/
+ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT OFF WITH ROLLBACK IMMEDIATE;
+GO
+ALTER DATABASE CURRENT SET ALLOW_SNAPSHOT_ISOLATION OFF;
+GO
+/*********************************************************************************/
+ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT OFF WITH ROLLBACK IMMEDIATE;
+GO
+ALTER DATABASE CURRENT SET ALLOW_SNAPSHOT_ISOLATION OFF;
+GO
 /*********************************************************************************/
 
 ALTER DATABASE SCOPED CONFIGURATION SET MAXDOP = 0;


### PR DESCRIPTION
## Problem

`tools/testsql/createNorthwindAzureDb.sql` carried this statement **commented out**, behind a *"RUN THIS SCRIPT MANUALLY"* header, because it required the database to have no other connections:

```sql
--ALTER DATABASE [Northwind] SET READ_COMMITTED_SNAPSHOT OFF
```

Meanwhile `createNorthwindDb.sql` (on-prem) applies the equivalent settings unconditionally at lines 57 and 61.

Azure SQL Database enables `READ_COMMITTED_SNAPSHOT` (RCSI) **by default**. Under RCSI a `READ COMMITTED` reader returns the last committed row version instead of blocking on an uncommitted writer, so transaction tests that assert a lock timeout fail with `Assert.Throws() Failure: No exception was thrown`.

This surfaced when a new Azure test database was provisioned and the manual step was missed — the previous database had it applied by hand, the new one did not.

## Change

Make the statements live so a newly provisioned Azure database cannot drift:

```sql
ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT OFF WITH ROLLBACK IMMEDIATE;
GO
ALTER DATABASE CURRENT SET ALLOW_SNAPSHOT_ISOLATION OFF;
GO
```

| | Before | Now | Why |
|---|---|---|---|
| Execution | Commented out, manual | Live | The gap that caused this |
| Target | `[Northwind]` | `CURRENT` | A hard-coded name doesn't apply to a differently-named database |
| Connections | Required none | `WITH ROLLBACK IMMEDIATE` | Removes the caveat that made it a manual step |
| `ALLOW_SNAPSHOT_ISOLATION` | Absent | `OFF` | Parity with `createNorthwindDb.sql` (line 57) |

Also documents the requirement in `TESTGUIDE.md`.

## Verification

Re-ran internal CI against a database with these settings applied, on **unmodified test code**:

| | Before | After |
|---|---|---|
| `TransactionTest.TestMain` failures | **78** (100% on Azure legs, 0 on-prem) | **0** |
| Azure test runs passing | — | **15 / 15** |

Same commit, same tests — only the database configuration changed.

## Checklist

- [x] Tests added or updated — n/a, test scripts only; verified against existing tests in CI
- [x] Public API changes documented — n/a, no API change
- [x] Verified against customer repro — verified against the CI failure
- [x] Ensure no breaking changes introduced — test-infrastructure only; aligns Azure setup with existing on-prem behaviour
