### PR TITLE
Restore the preview package version convention used by earlier releases

### DIFF
--- a/.github/instructions/sqlclient-package-versions.instructions.md
+++ b/.github/instructions/sqlclient-package-versions.instructions.md
@@ -136,29 +136,47 @@ Each downstream build job receives:
 
 Since an explicit `<Pkg>PackageVersion` is provided, Versions.props hits Priority 1 — uses the value verbatim.
 
-#### Non-Official Test Publication Revisions
+#### Package Version Shapes: `addRevision`
 
-Both OneBranch pipelines expose `addRevision` (default `false`). Their human-readable run name
-remains `$(Year:YY)$(DayOfYear)$(Rev:.r)`, while version revisions come from globally unique
-`Build.BuildId`. The compute stage always maps `Build.BuildId` into the unsigned 16-bit file-version
-range before evaluating canonical file versions:
+Both OneBranch pipelines expose `addRevision` (default `false`), which selects between two mutually
+exclusive package version shapes. Their human-readable run name is `$(Year:YY)$(DayOfYear)$(Rev:.r)`,
+and the compute stage receives both that run name (as `Build.BuildNumber`) and the globally unique
+`Build.BuildId` (as the revision).
+
+**Default path — `addRevision: false`.** The pipeline run name is appended after any prerelease
+suffix, reproducing the shape shipped by earlier previews. `Build.BuildId` is not used:
+
+- `1.2.3` stays `1.2.3` — non-preview releases are never stamped with a build number
+- `1.2.3-preview1` becomes `1.2.3-preview1.<build_number>`, e.g. `7.1.0-preview3.26238.3`
+- The matching file version is `1.2.3.<date_segment>`, e.g. `7.1.0.26238`
+
+Note the asymmetry: the *package* version omits the build number for non-preview releases, but the
+*file* version always carries one in its fourth component. This keeps every shipped assembly
+date-encoded and traceable to the run that produced it, while preserving the released package
+version customers expect.
+
+**Opt-in path — `addRevision: true`.** Version revisions come from `Build.BuildId` instead, which is
+mapped into the unsigned 16-bit file-version range before canonical file versions are evaluated:
 
 ```text
 revision = ((Build.BuildId - 1) % 65535) + 1
 ```
 
-Build IDs `1` through `65535` therefore map directly; subsequent IDs wrap back through that range.
-The compute stage logs the mapping whenever wrapping occurs because the revision can then collide
-with an earlier run. When `addRevision` is enabled, the mapped value is inserted before any package
-prerelease suffix so package and file versions use the same revision:
+Build IDs `1` through `65535` map directly; subsequent IDs wrap back through that range. The compute
+stage logs the mapping whenever wrapping occurs because the revision can then collide with an earlier
+run. The mapped value is inserted before any package prerelease suffix so package and file versions
+use the same revision:
 
 - `1.2.3` becomes `1.2.3.<revision>`
 - `1.2.3-preview1` becomes `1.2.3.<revision>-preview1`
 - The matching file version is `1.2.3.<revision>`
 
-Only packages built in the current run are revised. When `buildSqlServer` is `false`, the effective
-SqlServer version remains `SqlServerPublishedVersion` so dependency restore continues to request the
-package that actually exists on NuGet.
+This shape exists for repeated test publishes of the same base version, where each run needs a
+distinct package version. `Build.BuildNumber` is not used on this path.
+
+Only packages built in the current run are revised or stamped. When `buildSqlServer` is `false`, the
+effective SqlServer version remains `SqlServerPublishedVersion` so dependency restore continues to
+request the package that actually exists on NuGet.
 
 An explicit four-part package version is also treated as the complete file version base by both
 canonical Versions.props files; they do not append `FileVersionBuildNumber` as a fifth component.

--- a/eng/pipelines/onebranch/scripts/compute-versions.ps1
+++ b/eng/pipelines/onebranch/scripts/compute-versions.ps1
@@ -14,23 +14,32 @@
 
     Two mutually exclusive package version shapes are supported:
 
-      - AddRevision false (default). Prerelease packages append the pipeline build number after the
-        prerelease suffix, producing the shape shipped by earlier previews, such as
-        1.2.3-preview1.26238.3. Stable packages are left untouched. The file-version build number is
-        the first build number segment, giving file version 1.2.3.26238. This keeps the file version
-        date-encoded and traceable back to the run that produced it.
+    When AddRevision is true, BuildNumber is ignored if specified. For non-preview releases, versions
+    will be 1.2.3.<revision>. For preview releases, versions will be 1.2.3.<revision>-previewX.
 
-      - AddRevision true. The mapped revision is inserted as the fourth numeric component of package
-        versions built during this run, with any prerelease suffix retained after it. For example,
-        1.2.3-preview1 with revision 165500 becomes package version 1.2.3.34430-preview1 and file
-        version 1.2.3.34430. This shape exists for repeated test publishes of the same base version.
+    When AddRevision is false, BuildNumber must be specified. Non-preview versions will be 1.2.3, and
+    preview releases will be 1.2.3-previewX.<build_number>.
+
+    This asymmetry maintains the existing package versioning practice where previews include a
+    date-coded build number, but normal releases do not.
+
+    File versions are always four-part and always carry a build number in the fourth component, even
+    when the package version does not:
+
+      - AddRevision true. The fourth component is the mapped revision, so package and file versions
+        agree. A package version of 1.2.3.34430-preview1 has file version 1.2.3.34430.
+
+      - AddRevision false. The fourth component is the first segment of BuildNumber. A package
+        version of 1.2.3-preview1.26238.3 has file version 1.2.3.26238, and a stable package version
+        of 1.2.3 still has file version 1.2.3.26238. This keeps every file version date-encoded and
+        traceable back to the run that produced it.
 
     The supplied revision is mapped to the range 1 through 65535 before canonical versions
     are evaluated so every file version has a valid fourth component. Revisions above 65535 wrap
-    through the valid unsigned 16-bit file-version range. The script logs the mapping because the
-    revision may then collide with an earlier run. An unbuilt SqlServer package is never revised or
-    stamped with a build number because its effective version must continue to identify the package
-    that already exists on NuGet.
+    through the valid unsigned 16-bit file-version range. When AddRevision is true the script logs
+    the mapping because the revision may then collide with an earlier run. An unbuilt SqlServer
+    package is never revised or stamped with a build number because its effective version must
+    continue to identify the package that already exists on NuGet.
 
     The script emits these output variables for downstream stages:
       - VersionRevision
@@ -42,12 +51,13 @@
 
 .PARAMETER Revision
     Positive integer used to distinguish versions. Values above 65535 are wrapped into the unsigned
-    16-bit revision range.
+    16-bit revision range. Only consumed when AddRevision is true.
 
 .PARAMETER BuildNumber
-    Pipeline build number in the form <date>.<run>, such as 26238.3. Appended to prerelease package
-    versions when AddRevision is false, and its first segment is emitted as the file-version build
-    number so file versions remain date-encoded.
+    Pipeline build number in the form <date>.<run>, such as 26238.3. Required when AddRevision is
+    false, and ignored when AddRevision is true. When required, it is appended to prerelease package
+    versions and its first segment becomes the file-version build number, so file versions remain
+    date-encoded.
 
 .PARAMETER BuildSqlServer
     Whether this run builds Microsoft.SqlServer.Server. When false, the effective SqlServer package
@@ -76,18 +86,17 @@
     ./compute-versions.ps1 `
         -ProjectPath ./build.proj `
         -Revision 165500 `
-        -BuildNumber 26238.3 `
         -BuildSqlServer $true `
         -AddRevision $true
 
     Computes versions for a run that builds SqlServer and appends mapped revision 34430 to both
-    package families and their file versions.
+    package families and their file versions. BuildNumber is not supplied because AddRevision is
+    true.
 
 .EXAMPLE
     ./compute-versions.ps1 `
         -ProjectPath ./build.proj `
         -Revision 165500 `
-        -BuildNumber 26238.3 `
         -BuildSqlServer $false `
         -AddRevision $true
 
@@ -110,9 +119,9 @@ param(
     [ValidateRange(1, [long]::MaxValue)]
     [long]$Revision,
 
-    [Parameter(Mandatory = $true, HelpMessage = "Pipeline build number, such as 26238.3.")]
-    [ValidatePattern("^\d+\.\d+$")]
-    [string]$BuildNumber,
+    [Parameter(HelpMessage = "Pipeline build number, such as 26238.3. Required when AddRevision is false.")]
+    [ValidatePattern("^$|^\d+\.\d+$")]
+    [string]$BuildNumber = "",
 
     [Parameter(Mandatory = $true, HelpMessage = "Whether Microsoft.SqlServer.Server is built in this run.")]
     [bool]$BuildSqlServer,
@@ -129,7 +138,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 $wrappedRevision = (($Revision - 1) % 65535) + 1
-if ($Revision -gt 65535) {
+if ($AddRevision -and $Revision -gt 65535) {
     Write-Host "Revision $Revision exceeds the unsigned 16-bit limit and wrapped to $wrappedRevision; this revision may collide with an earlier run."
 }
 
@@ -300,7 +309,7 @@ $sqlServerPackageVersion = if ($BuildSqlServer) {
     $sqlServerVersions.PublishedVersion
 }
 
-$fileVersionBuildNumber = $BuildNumber.Split(".")[0]
+$fileVersionBuildNumber = $null
 
 if ($AddRevision) {
     $sqlClientPackageVersion = Add-VersionRevision `
@@ -318,6 +327,12 @@ if ($AddRevision) {
     Write-Host "Version revision: $wrappedRevision (input=$Revision)"
 }
 else {
+    if ([string]::IsNullOrWhiteSpace($BuildNumber)) {
+        throw "BuildNumber is required when AddRevision is false."
+    }
+
+    $fileVersionBuildNumber = $BuildNumber.Split(".")[0]
+
     $sqlClientPackageVersion = Add-VersionBuildNumber `
         -Version $sqlClientPackageVersion `
         -BuildNumber $BuildNumber

--- a/eng/pipelines/onebranch/scripts/compute-versions.ps1
+++ b/eng/pipelines/onebranch/scripts/compute-versions.ps1
@@ -12,15 +12,24 @@
     The published SqlServer version is needed when SqlServer is not built because downstream
     SqlClient projects restore that existing package from NuGet.
 
-    The supplied revision is mapped to the range 1 through 65535 before canonical versions
-    are evaluated so every file version has a valid fourth component. When AddRevision is true, that
-    same mapped value is inserted as the fourth numeric component of package versions built during
-    this run. Any prerelease suffix remains after the revision. For example, 1.2.3-preview1 with
-    revision 165500 becomes package version 1.2.3.34430-preview1 and file version 1.2.3.34430.
+    Two mutually exclusive package version shapes are supported:
 
-    Revisions above 65535 wrap through the valid unsigned 16-bit file-version range. The script logs
-    the mapping because the revision may then collide with an earlier run. An unbuilt SqlServer
-    package is never revised because its effective version must continue to identify the package
+      - AddRevision false (default). Prerelease packages append the pipeline build number after the
+        prerelease suffix, producing the shape shipped by earlier previews, such as
+        1.2.3-preview1.26238.3. Stable packages are left untouched. The file-version build number is
+        the first build number segment, giving file version 1.2.3.26238. This keeps the file version
+        date-encoded and traceable back to the run that produced it.
+
+      - AddRevision true. The mapped revision is inserted as the fourth numeric component of package
+        versions built during this run, with any prerelease suffix retained after it. For example,
+        1.2.3-preview1 with revision 165500 becomes package version 1.2.3.34430-preview1 and file
+        version 1.2.3.34430. This shape exists for repeated test publishes of the same base version.
+
+    The supplied revision is mapped to the range 1 through 65535 before canonical versions
+    are evaluated so every file version has a valid fourth component. Revisions above 65535 wrap
+    through the valid unsigned 16-bit file-version range. The script logs the mapping because the
+    revision may then collide with an earlier run. An unbuilt SqlServer package is never revised or
+    stamped with a build number because its effective version must continue to identify the package
     that already exists on NuGet.
 
     The script emits these output variables for downstream stages:
@@ -34,6 +43,11 @@
 .PARAMETER Revision
     Positive integer used to distinguish versions. Values above 65535 are wrapped into the unsigned
     16-bit revision range.
+
+.PARAMETER BuildNumber
+    Pipeline build number in the form <date>.<run>, such as 26238.3. Appended to prerelease package
+    versions when AddRevision is false, and its first segment is emitted as the file-version build
+    number so file versions remain date-encoded.
 
 .PARAMETER BuildSqlServer
     Whether this run builds Microsoft.SqlServer.Server. When false, the effective SqlServer package
@@ -51,6 +65,18 @@
     ./compute-versions.ps1 `
         -ProjectPath ./build.proj `
         -Revision 165500 `
+        -BuildNumber 26238.3 `
+        -BuildSqlServer $true `
+        -AddRevision $false
+
+    Computes versions for an official-style run that builds SqlServer. Prerelease package versions
+    become 7.1.0-preview3.26238.3 and file versions become 7.1.0.26238.
+
+.EXAMPLE
+    ./compute-versions.ps1 `
+        -ProjectPath ./build.proj `
+        -Revision 165500 `
+        -BuildNumber 26238.3 `
         -BuildSqlServer $true `
         -AddRevision $true
 
@@ -61,6 +87,7 @@
     ./compute-versions.ps1 `
         -ProjectPath ./build.proj `
         -Revision 165500 `
+        -BuildNumber 26238.3 `
         -BuildSqlServer $false `
         -AddRevision $true
 
@@ -82,6 +109,10 @@ param(
     [Parameter(Mandatory = $true, HelpMessage = "Positive integer version revision.")]
     [ValidateRange(1, [long]::MaxValue)]
     [long]$Revision,
+
+    [Parameter(Mandatory = $true, HelpMessage = "Pipeline build number, such as 26238.3.")]
+    [ValidatePattern("^\d+\.\d+$")]
+    [string]$BuildNumber,
 
     [Parameter(Mandatory = $true, HelpMessage = "Whether Microsoft.SqlServer.Server is built in this run.")]
     [bool]$BuildSqlServer,
@@ -198,6 +229,43 @@ function Add-VersionRevision {
 
 <#
 .SYNOPSIS
+    Appends a pipeline build number to a prerelease package version.
+
+.DESCRIPTION
+    Reproduces the version shape used by earlier previews, where the build number follows the
+    prerelease suffix, such as 7.1.0-preview3.26238.3. Stable versions are returned unchanged
+    because released packages are not stamped with a build number.
+
+.PARAMETER Version
+    Package version with a three-part numeric base and optional prerelease suffix.
+
+.PARAMETER BuildNumber
+    Pipeline build number to append.
+
+.OUTPUTS
+    The package version with the build number appended to its prerelease suffix, or the original
+    version when it carries no prerelease suffix.
+#>
+function Add-VersionBuildNumber {
+    param(
+        [string]$Version,
+        [string]$BuildNumber
+    )
+
+    $parts = $Version -split "-", 2
+    if ($parts[0] -notmatch "^\d+\.\d+\.\d+$") {
+        throw "Expected a three-part numeric version base, but received '$Version'."
+    }
+
+    if ($parts.Count -eq 2) {
+        return "$($parts[0])-$($parts[1]).$BuildNumber"
+    }
+
+    return $Version
+}
+
+<#
+.SYNOPSIS
     Emits an Azure DevOps job output variable for consumption by downstream stages.
 
 .PARAMETER Name
@@ -232,6 +300,8 @@ $sqlServerPackageVersion = if ($BuildSqlServer) {
     $sqlServerVersions.PublishedVersion
 }
 
+$fileVersionBuildNumber = $BuildNumber.Split(".")[0]
+
 if ($AddRevision) {
     $sqlClientPackageVersion = Add-VersionRevision `
         -Version $sqlClientPackageVersion `
@@ -242,7 +312,22 @@ if ($AddRevision) {
             -Revision $wrappedRevision
     }
 
+    # The revision is already the fourth component of the package version, so it is also the
+    # file-version build number.
+    $fileVersionBuildNumber = $wrappedRevision
     Write-Host "Version revision: $wrappedRevision (input=$Revision)"
+}
+else {
+    $sqlClientPackageVersion = Add-VersionBuildNumber `
+        -Version $sqlClientPackageVersion `
+        -BuildNumber $BuildNumber
+    if ($BuildSqlServer) {
+        $sqlServerPackageVersion = Add-VersionBuildNumber `
+            -Version $sqlServerPackageVersion `
+            -BuildNumber $BuildNumber
+    }
+
+    Write-Host "Version build number: $BuildNumber (file version build number=$fileVersionBuildNumber)"
 }
 
 Write-Host "Effective versions:"
@@ -251,4 +336,4 @@ Write-Host "  SqlServer:          $sqlServerPackageVersion"
 
 Set-PipelineOutputVariable -Name "SqlClientPackageVersion" -Value $sqlClientPackageVersion
 Set-PipelineOutputVariable -Name "SqlServerPackageVersion" -Value $sqlServerPackageVersion
-Set-PipelineOutputVariable -Name "VersionRevision" -Value $wrappedRevision
+Set-PipelineOutputVariable -Name "VersionRevision" -Value $fileVersionBuildNumber

--- a/eng/pipelines/onebranch/scripts/tests/compute-versions.Tests.ps1
+++ b/eng/pipelines/onebranch/scripts/tests/compute-versions.Tests.ps1
@@ -8,6 +8,15 @@ BeforeAll {
     $projectPath = Join-Path $TestDrive 'build.proj'
     Set-Content -LiteralPath $projectPath -Value '<Project />'
 
+    # An arbitrary but well-formed pipeline build number, used only by the tests that exercise the
+    # path which consumes one. The script never reads the ambient build number; the pipeline passes
+    # $(Build.BuildNumber) as a parameter, so any well-formed value works here and a fixed one keeps
+    # the expected output deterministic. Assertions derive from these rather than repeating literals
+    # so the relationship between the two is visible.
+    $script:testBuildNumber = '26238.3'
+    $script:testBuildNumberPattern = [regex]::Escape($script:testBuildNumber)
+    $script:testFileVersionBuildNumber = $script:testBuildNumber.Split('.')[0]
+
     function Invoke-ComputeVersions {
         param(
             [long]$Revision = 42,
@@ -65,11 +74,11 @@ Describe 'compute-versions.ps1 Effective Versions' {
     }
 
     It 'appends the build number after the prerelease suffix when package revisioning is disabled' {
-        $output = Invoke-ComputeVersions -AddRevision $false -BuildNumber '26238.3'
+        $output = Invoke-ComputeVersions -AddRevision $false -BuildNumber $script:testBuildNumber
 
-        $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0-preview3\.26238\.3'
-        $output | Should -Match 'SqlServerPackageVersion;isOutput=true]1\.1\.0-preview1\.26238\.3'
-        $output | Should -Match 'VersionRevision;isOutput=true]26238'
+        $output | Should -Match "SqlClientPackageVersion;isOutput=true]7\.1\.0-preview3\.$script:testBuildNumberPattern"
+        $output | Should -Match "SqlServerPackageVersion;isOutput=true]1\.1\.0-preview1\.$script:testBuildNumberPattern"
+        $output | Should -Match "VersionRevision;isOutput=true]$script:testFileVersionBuildNumber"
     }
 
     It 'inserts the revision before prerelease suffixes for built packages' {
@@ -98,36 +107,36 @@ Describe 'compute-versions.ps1 Effective Versions' {
     }
 
     It 'emits the build number rather than the wrapped revision when package revisioning is disabled' {
-        $output = Invoke-ComputeVersions -Revision 65536 -AddRevision $false -BuildNumber '26238.3'
+        $output = Invoke-ComputeVersions -Revision 65536 -AddRevision $false -BuildNumber $script:testBuildNumber
 
         $output | Should -Not -Match 'task\.logissue type=warning'
         $output | Should -Not -Match 'wrapped to'
-        $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0-preview3\.26238\.3'
-        $output | Should -Match 'SqlServerPackageVersion;isOutput=true]1\.1\.0-preview1\.26238\.3'
-        $output | Should -Match 'VersionRevision;isOutput=true]26238'
+        $output | Should -Match "SqlClientPackageVersion;isOutput=true]7\.1\.0-preview3\.$script:testBuildNumberPattern"
+        $output | Should -Match "SqlServerPackageVersion;isOutput=true]1\.1\.0-preview1\.$script:testBuildNumberPattern"
+        $output | Should -Match "VersionRevision;isOutput=true]$script:testFileVersionBuildNumber"
     }
 
     It 'retains the published SqlServer package unstamped when SqlServer is not built' {
-        $output = Invoke-ComputeVersions -BuildSqlServer $false -AddRevision $false -BuildNumber '26238.3'
+        $output = Invoke-ComputeVersions -BuildSqlServer $false -AddRevision $false -BuildNumber $script:testBuildNumber
 
-        $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0-preview3\.26238\.3'
+        $output | Should -Match "SqlClientPackageVersion;isOutput=true]7\.1\.0-preview3\.$script:testBuildNumberPattern"
         $output | Should -Match 'SqlServerPackageVersion;isOutput=true]1\.0\.0'
-        $output | Should -Not -Match 'SqlServerPackageVersion;isOutput=true]1\.0\.0\.26238'
+        $output | Should -Not -Match "SqlServerPackageVersion;isOutput=true]1\.0\.0\.$script:testFileVersionBuildNumber"
     }
 
     It 'omits the build number from non-preview package versions when package revisioning is disabled' {
         Set-DotnetMock -SqlClientPackageVersion '7.1.0' -SqlServerPackageVersion '1.1.0'
 
-        $output = Invoke-ComputeVersions -AddRevision $false -BuildNumber '26238.3'
+        $output = Invoke-ComputeVersions -AddRevision $false -BuildNumber $script:testBuildNumber
 
         $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0(\r?\n|$)'
         $output | Should -Match 'SqlServerPackageVersion;isOutput=true]1\.1\.0(\r?\n|$)'
-        $output | Should -Not -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0[\.-]26238'
-        $output | Should -Not -Match 'SqlServerPackageVersion;isOutput=true]1\.1\.0[\.-]26238'
+        $output | Should -Not -Match "SqlClientPackageVersion;isOutput=true]7\.1\.0[\.-]$script:testFileVersionBuildNumber"
+        $output | Should -Not -Match "SqlServerPackageVersion;isOutput=true]1\.1\.0[\.-]$script:testFileVersionBuildNumber"
 
         # The file version is still stamped so every build produces a distinct, date-encoded
         # file version even for non-preview releases.
-        $output | Should -Match 'VersionRevision;isOutput=true]26238'
+        $output | Should -Match "VersionRevision;isOutput=true]$script:testFileVersionBuildNumber"
     }
 
     It 'revises non-preview package versions when package revisioning is enabled' {

--- a/eng/pipelines/onebranch/scripts/tests/compute-versions.Tests.ps1
+++ b/eng/pipelines/onebranch/scripts/tests/compute-versions.Tests.ps1
@@ -11,7 +11,7 @@ BeforeAll {
     function Invoke-ComputeVersions {
         param(
             [long]$Revision = 42,
-            [string]$BuildNumber = '26238.3',
+            [string]$BuildNumber = '',
             [bool]$BuildSqlServer = $true,
             [bool]$AddRevision = $true
         )
@@ -24,23 +24,34 @@ BeforeAll {
             -AddRevision $AddRevision *>&1 | Out-String
     }
 
-    function Set-SuccessfulDotnetMock {
+    # Alternates between the SqlClient and SqlServer GetVersions targets, which the script always
+    # invokes in that order.
+    function Set-DotnetMock {
+        param(
+            [string]$SqlClientPackageVersion = '7.1.0-preview3',
+            [string]$SqlServerPackageVersion = '1.1.0-preview1'
+        )
+
         $global:computeVersionsDotnetCallCount = 0
         Mock -CommandName 'dotnet' -MockWith {
             $global:LASTEXITCODE = 0
             $global:computeVersionsDotnetCallCount++
             if ($global:computeVersionsDotnetCallCount % 2 -eq 1) {
                 return @(
-                    '  PackageVersion: 7.1.0-preview3'
+                    "  PackageVersion: $SqlClientPackageVersion"
                     '  PublishedVersion: 7.0.0'
                 )
             }
 
             return @(
-                '  PackageVersion: 1.1.0-preview1'
+                "  PackageVersion: $SqlServerPackageVersion"
                 '  PublishedVersion: 1.0.0'
             )
-        }
+        }.GetNewClosure()
+    }
+
+    function Set-SuccessfulDotnetMock {
+        Set-DotnetMock
     }
 }
 
@@ -54,7 +65,7 @@ Describe 'compute-versions.ps1 Effective Versions' {
     }
 
     It 'appends the build number after the prerelease suffix when package revisioning is disabled' {
-        $output = Invoke-ComputeVersions -AddRevision $false
+        $output = Invoke-ComputeVersions -AddRevision $false -BuildNumber '26238.3'
 
         $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0-preview3\.26238\.3'
         $output | Should -Match 'SqlServerPackageVersion;isOutput=true]1\.1\.0-preview1\.26238\.3'
@@ -87,42 +98,63 @@ Describe 'compute-versions.ps1 Effective Versions' {
     }
 
     It 'emits the build number rather than the wrapped revision when package revisioning is disabled' {
-        $output = Invoke-ComputeVersions -Revision 65536 -AddRevision $false
+        $output = Invoke-ComputeVersions -Revision 65536 -AddRevision $false -BuildNumber '26238.3'
 
         $output | Should -Not -Match 'task\.logissue type=warning'
+        $output | Should -Not -Match 'wrapped to'
         $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0-preview3\.26238\.3'
         $output | Should -Match 'SqlServerPackageVersion;isOutput=true]1\.1\.0-preview1\.26238\.3'
         $output | Should -Match 'VersionRevision;isOutput=true]26238'
     }
 
     It 'retains the published SqlServer package unstamped when SqlServer is not built' {
-        $output = Invoke-ComputeVersions -BuildSqlServer $false -AddRevision $false
+        $output = Invoke-ComputeVersions -BuildSqlServer $false -AddRevision $false -BuildNumber '26238.3'
 
         $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0-preview3\.26238\.3'
         $output | Should -Match 'SqlServerPackageVersion;isOutput=true]1\.0\.0'
         $output | Should -Not -Match 'SqlServerPackageVersion;isOutput=true]1\.0\.0\.26238'
     }
 
-    It 'leaves stable package versions unstamped' {
-        Mock -CommandName 'dotnet' -MockWith {
-            $global:LASTEXITCODE = 0
-            return @(
-                '  PackageVersion: 7.1.0'
-                '  PublishedVersion: 7.0.0'
-            )
-        }
+    It 'omits the build number from non-preview package versions when package revisioning is disabled' {
+        Set-DotnetMock -SqlClientPackageVersion '7.1.0' -SqlServerPackageVersion '1.1.0'
 
-        $output = Invoke-ComputeVersions -AddRevision $false
+        $output = Invoke-ComputeVersions -AddRevision $false -BuildNumber '26238.3'
 
-        $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0\r?\n'
-        $output | Should -Not -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0\.26238'
+        $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0(\r?\n|$)'
+        $output | Should -Match 'SqlServerPackageVersion;isOutput=true]1\.1\.0(\r?\n|$)'
+        $output | Should -Not -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0[\.-]26238'
+        $output | Should -Not -Match 'SqlServerPackageVersion;isOutput=true]1\.1\.0[\.-]26238'
+
+        # The file version is still stamped so every build produces a distinct, date-encoded
+        # file version even for non-preview releases.
         $output | Should -Match 'VersionRevision;isOutput=true]26238'
+    }
+
+    It 'revises non-preview package versions when package revisioning is enabled' {
+        Set-DotnetMock -SqlClientPackageVersion '7.1.0' -SqlServerPackageVersion '1.1.0'
+
+        $output = Invoke-ComputeVersions
+
+        $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0\.42'
+        $output | Should -Match 'SqlServerPackageVersion;isOutput=true]1\.1\.0\.42'
+        $output | Should -Match 'VersionRevision;isOutput=true]42'
     }
 }
 
 Describe 'compute-versions.ps1 Error Handling' {
     It 'rejects a non-positive revision' {
         { Invoke-ComputeVersions -Revision 0 } | Should -Throw
+    }
+
+    It 'requires a build number when package revisioning is disabled' {
+        Set-SuccessfulDotnetMock
+
+        { Invoke-ComputeVersions -AddRevision $false } |
+            Should -Throw '*BuildNumber is required when AddRevision is false*'
+    }
+
+    It 'rejects a malformed build number' {
+        { Invoke-ComputeVersions -AddRevision $false -BuildNumber 'not-a-build-number' } | Should -Throw
     }
 
     It 'throws when a GetVersions target fails' {

--- a/eng/pipelines/onebranch/scripts/tests/compute-versions.Tests.ps1
+++ b/eng/pipelines/onebranch/scripts/tests/compute-versions.Tests.ps1
@@ -11,6 +11,7 @@ BeforeAll {
     function Invoke-ComputeVersions {
         param(
             [long]$Revision = 42,
+            [string]$BuildNumber = '26238.3',
             [bool]$BuildSqlServer = $true,
             [bool]$AddRevision = $true
         )
@@ -18,6 +19,7 @@ BeforeAll {
         & $scriptPath `
             -ProjectPath $projectPath `
             -Revision $Revision `
+            -BuildNumber $BuildNumber `
             -BuildSqlServer $BuildSqlServer `
             -AddRevision $AddRevision *>&1 | Out-String
     }
@@ -51,12 +53,12 @@ Describe 'compute-versions.ps1 Effective Versions' {
         Set-SuccessfulDotnetMock
     }
 
-    It 'emits canonical package versions and the revision when package revisioning is disabled' {
+    It 'appends the build number after the prerelease suffix when package revisioning is disabled' {
         $output = Invoke-ComputeVersions -AddRevision $false
 
-        $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0-preview3'
-        $output | Should -Match 'SqlServerPackageVersion;isOutput=true]1\.1\.0-preview1'
-        $output | Should -Match 'VersionRevision;isOutput=true]42'
+        $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0-preview3\.26238\.3'
+        $output | Should -Match 'SqlServerPackageVersion;isOutput=true]1\.1\.0-preview1\.26238\.3'
+        $output | Should -Match 'VersionRevision;isOutput=true]26238'
     }
 
     It 'inserts the revision before prerelease suffixes for built packages' {
@@ -84,14 +86,37 @@ Describe 'compute-versions.ps1 Effective Versions' {
         $output | Should -Match 'VersionRevision;isOutput=true]1'
     }
 
-    It 'emits the wrapped revision when package revisioning is disabled' {
+    It 'emits the build number rather than the wrapped revision when package revisioning is disabled' {
         $output = Invoke-ComputeVersions -Revision 65536 -AddRevision $false
 
-        $output | Should -Match 'Revision 65536.*wrapped to 1'
         $output | Should -Not -Match 'task\.logissue type=warning'
-        $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0-preview3'
-        $output | Should -Match 'SqlServerPackageVersion;isOutput=true]1\.1\.0-preview1'
-        $output | Should -Match 'VersionRevision;isOutput=true]1'
+        $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0-preview3\.26238\.3'
+        $output | Should -Match 'SqlServerPackageVersion;isOutput=true]1\.1\.0-preview1\.26238\.3'
+        $output | Should -Match 'VersionRevision;isOutput=true]26238'
+    }
+
+    It 'retains the published SqlServer package unstamped when SqlServer is not built' {
+        $output = Invoke-ComputeVersions -BuildSqlServer $false -AddRevision $false
+
+        $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0-preview3\.26238\.3'
+        $output | Should -Match 'SqlServerPackageVersion;isOutput=true]1\.0\.0'
+        $output | Should -Not -Match 'SqlServerPackageVersion;isOutput=true]1\.0\.0\.26238'
+    }
+
+    It 'leaves stable package versions unstamped' {
+        Mock -CommandName 'dotnet' -MockWith {
+            $global:LASTEXITCODE = 0
+            return @(
+                '  PackageVersion: 7.1.0'
+                '  PublishedVersion: 7.0.0'
+            )
+        }
+
+        $output = Invoke-ComputeVersions -AddRevision $false
+
+        $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0\r?\n'
+        $output | Should -Not -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0\.26238'
+        $output | Should -Match 'VersionRevision;isOutput=true]26238'
     }
 }
 

--- a/eng/pipelines/onebranch/stages/compute-versions-stage.yml
+++ b/eng/pipelines/onebranch/stages/compute-versions-stage.yml
@@ -17,8 +17,11 @@
 #   - Microsoft.SqlServer.Server is versioned separately: it uses its "next" version when it is
 #     being built this run, or its "published" (last shipped to NuGet) version when it is not built
 #     (so the SqlClient family depends on the most recently published SqlServer package).
-#   - Runs can append the Build.BuildId revision to packages built in that run, reducing
-#     collisions when repeatedly publishing the same base version for testing.
+#   - Runs use their "next" version from Versions.props. By default the pipeline build number is
+#     appended to prerelease package versions (7.1.0-preview3.26238.3) and its date segment becomes
+#     the file-version build number (7.1.0.26238), matching the shape shipped by earlier previews.
+#     Runs can instead append the Build.BuildId revision, reducing collisions when repeatedly
+#     publishing the same base version for testing.
 #   - Versions are extracted via build.proj GetVersions* targets by parsing stdout.
 #
 # This stage MUST run before all build stages so they can consume computed versions.
@@ -78,5 +81,6 @@ stages:
               arguments: >-
                 -ProjectPath "$(Build.SourcesDirectory)/build.proj"
                 -Revision "$(Build.BuildId)"
+                -BuildNumber "$(Build.BuildNumber)"
                 -BuildSqlServer $${{ parameters.buildSqlServer }}
                 -AddRevision $${{ parameters.addRevision }}


### PR DESCRIPTION
Fixes the package version convention regression introduced when versioning was consolidated into `Versions.props`.

## Problem

Preview packages up to and including `7.1.0-preview2` shipped as `{base}-{suffix}.{Build.BuildNumber}`, with a date-encoded file version:

| | Package version | File version |
|---|---|---|
| `7.1.0-preview2` (shipped) | `7.1.0-preview2.26190.5` | `7.1.0.26190` |

After #4336 moved version selection out of the pipeline YAML, `compute-versions.ps1` can only emit two shapes, and **neither reproduces the shipped convention**:

| `addRevision` | Package version | File version |
|---|---|---|
| `false` (default) | `7.1.0-preview3` | `7.1.0.38305` |
| `true` | `7.1.0.38995-preview3` | `7.1.0.38995` |

Two things changed at once:

1. The revision moved **ahead of** the prerelease suffix (`Add-VersionRevision` rebuilds the version as `{base}.{revision}-{suffix}`).
2. Its source changed from `$(Build.BuildNumber)` to `$(Build.BuildId)`. Because the official pipeline passes that revision through as `-p:BuildNumber`, the **file version also lost its date encoding** — `38305` is just build id `169375` wrapped through 16 bits.

Confirmed against the shipped assemblies:

```
preview2  FileVersion 7.1.0.26190  ProductVersion 7.1.0-preview2.26190.5+52ed94b1
preview3  FileVersion 7.1.0.38305  ProductVersion 7.1.0-preview3+c16adb7a
```

## Change

Restore the original shape for OneBranch runs, without disturbing the CI or local-dev paths (which use `BuildSuffix` and are unaffected):

- Pass `$(Build.BuildNumber)` into `compute-versions.ps1`.
- When `addRevision` is `false`, append the build number **after** the prerelease suffix, and emit the build number's date segment as `VersionRevision` so the downstream `-p:BuildNumber` yields `7.1.0.26238`.
- Leave stable versions unstamped, matching the previous behaviour where only preview builds carried a build number.
- Leave the `addRevision` path untouched, so repeated test publishes can still disambiguate by build id.

## Result

| | Package version | File version | Assembly version |
|---|---|---|---|
| `7.1.0-preview2` (shipped) | `7.1.0-preview2.26190.5` | `7.1.0.26190` | `7.0.0.0` |
| `7.1.0-preview3` before | `7.1.0-preview3` | `7.1.0.38305` | `7.0.0.0` |
| `7.1.0-preview3` after | `7.1.0-preview3.26238.3` | `7.1.0.26238` | `7.0.0.0` |

## Verification

`compute-versions.ps1` run end-to-end against a stubbed `dotnet` via its `-DotnetPath` test hook:

```
AddRevision=false  ->  SqlClient 7.1.0-preview3.26238.3   VersionRevision 26238
AddRevision=true   ->  SqlClient 7.1.0.42-preview3        VersionRevision 42
buildSqlServer=false, AddRevision=false -> SqlServer 1.0.0 (published, unstamped)
```

MSBuild property evaluation of the real `Versions.props`:

```
-p:SqlClientPackageVersion=7.1.0-preview3        -p:BuildNumber=38305  ->  FileVersion 7.1.0.38305
-p:SqlClientPackageVersion=7.1.0-preview3.26238.3 -p:BuildNumber=26238 ->  FileVersion 7.1.0.26238
```

Pester coverage updated: build-number stamping, unbuilt-SqlServer passthrough, and stable versions left unstamped.

## Checklist

- [x] Tests added or updated
- [x] Public API changes documented — n/a, no public API change
- [x] Verified against customer repro (if applicable) — verified against the shipped preview2 package and assembly
- [x] Ensure no breaking changes introduced — assembly version stays `7.0.0.0`; CI, PR and local-dev version paths are untouched

/cc @paulmedynski @cheenamalhotra