### PR TITLE
Reduce Azure SQL test scope in PR pipelines

### DIFF
--- a/eng/pipelines/common/templates/jobs/ci-run-tests-job.yml
+++ b/eng/pipelines/common/templates/jobs/ci-run-tests-job.yml
@@ -70,6 +70,15 @@ parameters:
   - name: jobDisplayName
     type: string
 
+  # VSTest expressions used for regular and quarantined manual-test runs.
+  - name: manualTestFilters
+    type: string
+    default: 'category!=failing&category!=flaky&category!=interactive'
+
+  - name: flakyManualTestFilters
+    type: string
+    default: 'category=flaky'
+
   # The name of the SqlClient pipeline artifacts to download.
   - name: mdsArtifactsName
     type: string
@@ -358,6 +367,8 @@ jobs:
         operatingSystem: ${{ parameters.operatingSystem }}
         packageVersion: ${{ parameters.packageVersion }}
         sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
+        manualTestFilters: ${{ parameters.manualTestFilters }}
+        flakyManualTestFilters: ${{ parameters.flakyManualTestFilters }}
 
   - ${{ if and(eq(parameters.enableX86Test, true), eq(parameters.operatingSystem, 'Windows')) }}:
     - template: /eng/pipelines/common/templates/steps/run-all-tests-step.yml@self
@@ -372,6 +383,8 @@ jobs:
         operatingSystem: ${{ parameters.operatingSystem }}
         packageVersion: ${{ parameters.packageVersion }}
         sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
+        manualTestFilters: ${{ parameters.manualTestFilters }}
+        flakyManualTestFilters: ${{ parameters.flakyManualTestFilters }}
 
   - template: /eng/pipelines/common/templates/steps/publish-test-results-step.yml@self
     parameters:

--- a/eng/pipelines/common/templates/stages/ci-run-tests-stage.yml
+++ b/eng/pipelines/common/templates/stages/ci-run-tests-stage.yml
@@ -120,6 +120,8 @@ stages:
                   targetFramework: ${{ targetFramework }}
                   netcoreVersionTestUtils: ${{config.value.netcoreVersionTestUtils }}
                   testSet: ${{ testSet }}
+                  manualTestFilters: ${{ coalesce(config.value.manualTestFilters, 'category!=failing&category!=flaky&category!=interactive') }}
+                  flakyManualTestFilters: ${{ coalesce(config.value.flakyManualTestFilters, 'category=flaky') }}
                   configSqlFor: ${{ config.value.configSqlFor }}
                   operatingSystem: ${{ config.value.operatingSystem }}
                   saPassword: $(saPassword)
@@ -155,6 +157,8 @@ stages:
                     targetFramework: ${{ targetFramework }}
                     netcoreVersionTestUtils: ${{config.value.netcoreVersionTestUtils }}
                     testSet: ${{ testSet }}
+                    manualTestFilters: ${{ coalesce(config.value.manualTestFilters, 'category!=failing&category!=flaky&category!=interactive') }}
+                    flakyManualTestFilters: ${{ coalesce(config.value.flakyManualTestFilters, 'category=flaky') }}
                     configSqlFor: ${{ config.value.configSqlFor }}
                     operatingSystem: ${{ config.value.operatingSystem }}
                     saPassword: $(saPassword)

--- a/eng/pipelines/common/templates/steps/run-all-tests-step.yml
+++ b/eng/pipelines/common/templates/steps/run-all-tests-step.yml
@@ -68,6 +68,15 @@ parameters:
     type: number
     default: 2
 
+  # VSTest expressions used for regular and quarantined manual-test runs.
+  - name: manualTestFilters
+    type: string
+    default: 'category!=failing&category!=flaky&category!=interactive'
+
+  - name: flakyManualTestFilters
+    type: string
+    default: 'category=flaky'
+
 steps:
 - ${{ if parameters.debug }}:
   - powershell: 'dotnet sdk check'
@@ -204,6 +213,7 @@ steps:
           -p:Configuration=${{ parameters.buildConfiguration }}
           -p:PackageVersionSqlClient=${{ parameters.packageVersion }}
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+          -p:TestFilters="${{ parameters.manualTestFilters }}"
           -p:TestResultsFolderPath=TestResults
       ${{ else }}: # x86
         arguments: >-
@@ -215,6 +225,7 @@ steps:
           -p:PackageVersionSqlClient=${{ parameters.packageVersion }}
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
+          -p:TestFilters="${{ parameters.manualTestFilters }}"
           -p:TestResultsFolderPath=TestResults
     retryCountOnTaskFailure: ${{parameters.retryCountOnManualTests }}
 
@@ -233,7 +244,7 @@ steps:
           -p:Configuration=${{ parameters.buildConfiguration }}
           -p:PackageVersionSqlClient=${{ parameters.packageVersion }}
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
-          -p:TestFilters="category=flaky"
+          -p:TestFilters="${{ parameters.flakyManualTestFilters }}"
           -p:TestResultsFolderPath=TestResults
           -p:TestCodeCoverage=false
       ${{ else }}: # x86
@@ -246,7 +257,7 @@ steps:
           -p:PackageVersionSqlClient=${{ parameters.packageVersion }}
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
-          -p:TestFilters="category=flaky"
+          -p:TestFilters="${{ parameters.flakyManualTestFilters }}"
           -p:TestResultsFolderPath=TestResults
           -p:TestCodeCoverage=false
     continueOnError: true
@@ -331,6 +342,7 @@ steps:
         -p:Configuration=${{ parameters.buildConfiguration }}
         -p:PackageVersionSqlClient=${{ parameters.packageVersion }}
         -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+        -p:TestFilters="${{ parameters.manualTestFilters }}"
         -p:TestResultsFolderPath=TestResults
     retryCountOnTaskFailure: ${{parameters.retryCountOnManualTests }}
 
@@ -348,7 +360,7 @@ steps:
         -p:Configuration=${{ parameters.buildConfiguration }}
         -p:PackageVersionSqlClient=${{ parameters.packageVersion }}
         -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
-        -p:TestFilters="category=flaky"
+        -p:TestFilters="${{ parameters.flakyManualTestFilters }}"
         -p:TestResultsFolderPath=TestResults
         -p:TestCodeCoverage=false
     continueOnError: true

--- a/eng/pipelines/common/variables/azure-sql-test-filters.yml
+++ b/eng/pipelines/common/variables/azure-sql-test-filters.yml
@@ -1,0 +1,14 @@
+#################################################################################
+# Licensed to the .NET Foundation under one or more agreements.                 #
+# The .NET Foundation licenses this file to you under the MIT license.          #
+# See the LICENSE file in the project root for more information.                #
+#################################################################################
+
+variables:
+  # Keep Azure SQL PR coverage focused on the connectivity test group and the core BulkCopy suite.
+  # These tests all belong to manual test set 2.
+  - name: azureSqlConnectionAndBulkCopyTestsFilter
+    value: '(FullyQualifiedName~Microsoft.Data.SqlClient.ManualTests.BulkCopy|FullyQualifiedName~Microsoft.Data.SqlClient.ManualTesting.Tests.SqlBulkCopyTests|FullyQualifiedName~Microsoft.Data.SqlClient.ManualTesting.Tests.AADConnectionTest|FullyQualifiedName~Microsoft.Data.SqlClient.ManualTesting.Tests.ConnectionBehaviorTest|FullyQualifiedName~Microsoft.Data.SqlClient.ManualTesting.Tests.ConnectivityTest|FullyQualifiedName~Microsoft.Data.SqlClient.ManualTesting.Tests.TcpDefaultForAzureTest)&category!=failing&category!=flaky&category!=interactive'
+
+  - name: azureSqlConnectionAndBulkCopyFlakyTestsFilter
+    value: '(FullyQualifiedName~Microsoft.Data.SqlClient.ManualTests.BulkCopy|FullyQualifiedName~Microsoft.Data.SqlClient.ManualTesting.Tests.SqlBulkCopyTests|FullyQualifiedName~Microsoft.Data.SqlClient.ManualTesting.Tests.AADConnectionTest|FullyQualifiedName~Microsoft.Data.SqlClient.ManualTesting.Tests.ConnectionBehaviorTest|FullyQualifiedName~Microsoft.Data.SqlClient.ManualTesting.Tests.ConnectivityTest|FullyQualifiedName~Microsoft.Data.SqlClient.ManualTesting.Tests.TcpDefaultForAzureTest)&category=flaky'

--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -88,6 +88,12 @@ parameters:
     type: boolean
     default: true
 
+  # If true, Azure SQL manual-test legs run only connectivity and core BulkCopy tests from set 2.
+  # PR pipelines enable this; scheduled CI retains the full configured test sets.
+  - name: runFocusedAzureSqlTests
+    type: boolean
+    default: false
+
   # If true, run manual tests against legacy SQL Server versions (2016, 2017).
   # Enabled for CI pipelines; disabled for PR pipelines to keep validation fast.
   - name: runLegacySqlTests
@@ -111,6 +117,7 @@ parameters:
 
 variables:
   - template: /eng/pipelines/libraries/ci-build-variables.yml@self
+  - template: /eng/pipelines/common/variables/azure-sql-test-filters.yml@self
 
   - name: abstractionsArtifactsName
     value: Abstractions.Artifacts
@@ -488,7 +495,12 @@ stages:
           TargetFrameworks: ${{parameters.targetFrameworks }}
           netcoreVersionTestUtils: ${{parameters.netcoreVersionTestUtils }}
           buildPlatforms: ${{parameters.buildPlatforms }}
-          testSets: ${{parameters.testSets }}
+          ${{ if eq(parameters.runFocusedAzureSqlTests, true) }}:
+            testSets: [2]
+            manualTestFilters: $(azureSqlConnectionAndBulkCopyTestsFilter)
+            flakyManualTestFilters: $(azureSqlConnectionAndBulkCopyFlakyTestsFilter)
+          ${{ else }}:
+            testSets: ${{parameters.testSets }}
           useManagedSNI: ${{parameters.useManagedSNI }}
           configSqlFor: azure
           operatingSystem: Windows
@@ -518,7 +530,12 @@ stages:
           TargetFrameworks: ${{parameters.targetFrameworks }}
           netcoreVersionTestUtils: ${{parameters.netcoreVersionTestUtils }}
           buildPlatforms: ${{parameters.buildPlatforms }}
-          testSets: ${{parameters.testSets }}
+          ${{ if eq(parameters.runFocusedAzureSqlTests, true) }}:
+            testSets: [2]
+            manualTestFilters: $(azureSqlConnectionAndBulkCopyTestsFilter)
+            flakyManualTestFilters: $(azureSqlConnectionAndBulkCopyFlakyTestsFilter)
+          ${{ else }}:
+            testSets: ${{parameters.testSets }}
           useManagedSNI: ${{parameters.useManagedSNI }}
           configSqlFor: azure
           operatingSystem: Windows
@@ -569,7 +586,12 @@ stages:
           TargetFrameworks: ${{parameters.targetFrameworksUnix }}
           netcoreVersionTestUtils: ${{parameters.netcoreVersionTestUtils }}
           buildPlatforms: [AnyCPU]
-          testSets: ${{parameters.testSets }}
+          ${{ if eq(parameters.runFocusedAzureSqlTests, true) }}:
+            testSets: [2]
+            manualTestFilters: $(azureSqlConnectionAndBulkCopyTestsFilter)
+            flakyManualTestFilters: $(azureSqlConnectionAndBulkCopyFlakyTestsFilter)
+          ${{ else }}:
+            testSets: ${{parameters.testSets }}
           useManagedSNI: [true]
           configSqlFor: azure
           operatingSystem: Linux

--- a/eng/pipelines/pr/jobs/test-sqlclientmanual-job.yml
+++ b/eng/pipelines/pr/jobs/test-sqlclientmanual-job.yml
@@ -226,7 +226,7 @@ jobs:
             -p:BuildNumber='$(Build.BuildNumber)'
             -p:BuildSuffix='${{ parameters.buildSuffix }}'
             -p:TestFramework=${{ parameters.platformDotnet }}
-            -p:TestFilters='${{ parameters.testFilters }}'
+            -p:TestFilters="${{ parameters.testFilters }}"
             -p:TestSet=${{ parameters.testSet }}
             -p:TestResultsFolderPath=${{ variables.testResultsPath }}
 

--- a/eng/pipelines/pr/jobs/test-sqlclientmanual-job.yml
+++ b/eng/pipelines/pr/jobs/test-sqlclientmanual-job.yml
@@ -116,6 +116,11 @@ parameters:
   - name: testSet
     type: string
 
+  # VSTest expression used to select manual tests.
+  - name: testFilters
+    type: string
+    default: 'category!=failing&category!=flaky&category!=interactive'
+
   # Whether integrated security is supported by this test configuration.
   - name: supportsIntegratedSecurity
     type: boolean
@@ -221,6 +226,7 @@ jobs:
             -p:BuildNumber='$(Build.BuildNumber)'
             -p:BuildSuffix='${{ parameters.buildSuffix }}'
             -p:TestFramework=${{ parameters.platformDotnet }}
+            -p:TestFilters='${{ parameters.testFilters }}'
             -p:TestSet=${{ parameters.testSet }}
             -p:TestResultsFolderPath=${{ variables.testResultsPath }}
 

--- a/eng/pipelines/pr/sqlclient-pr-pipeline.yml
+++ b/eng/pipelines/pr/sqlclient-pr-pipeline.yml
@@ -100,6 +100,7 @@ parameters:
 
 variables:
   - template: /eng/pipelines/common/variables/common-variables.yml@self
+  - template: /eng/pipelines/common/variables/azure-sql-test-filters.yml@self
   - template: /eng/pipelines/pr/variables/pr-variables.yml@self
 
 stages:

--- a/eng/pipelines/pr/stages/test-stages.yml
+++ b/eng/pipelines/pr/stages/test-stages.yml
@@ -276,7 +276,8 @@ stages:
               localDbAppName: ${{ parameters.manualTestLocalDbAppName }}
               localDbSharedInstanceName: ${{ parameters.manualTestLocalDbSharedInstanceName }}
               supportsIntegratedSecurity: false
-              testSet: "123"
+              testFilters: $(azureSqlConnectionAndBulkCopyTestsFilter)
+              testSet: "2"
               userManagedIdentityClientId: ${{ parameters.manualTestUserManagedIdentityClientId }}
 
           # TestSqlClientManual - Localhost Always Encrypted

--- a/eng/pipelines/sqlclient-pr-package-ref-pipeline.yml
+++ b/eng/pipelines/sqlclient-pr-package-ref-pipeline.yml
@@ -138,6 +138,8 @@ extends:
     testJobTimeout: ${{ parameters.testJobTimeout }}
     testSets: ${{ parameters.testSets }}
     useManagedSNI: ${{ parameters.useManagedSNI }}
+    # Keep remote Azure SQL validation focused; scheduled CI retains the full test suite.
+    runFocusedAzureSqlTests: true
     # Legacy SQL Server tests (2016/2017) run in CI only, not on PRs.
     runLegacySqlTests: false
     # Don't run the AE tests in Debug mode; they rarely succeed.

--- a/eng/pipelines/sqlclient-pr-project-ref-pipeline.yml
+++ b/eng/pipelines/sqlclient-pr-project-ref-pipeline.yml
@@ -138,6 +138,8 @@ extends:
     testJobTimeout: ${{ parameters.testJobTimeout }}
     testSets: ${{ parameters.testSets }}
     useManagedSNI: ${{ parameters.useManagedSNI }}
+    # Keep remote Azure SQL validation focused; scheduled CI retains the full test suite.
+    runFocusedAzureSqlTests: true
     # Legacy SQL Server tests (2016/2017) run in CI only, not on PRs.
     runLegacySqlTests: false
     # Don't run the AE tests in Debug mode; they rarely succeed.


### PR DESCRIPTION
## Description

Limit Azure SQL Database manual-test legs in all three PR pipelines to:

- the four connection test classes under `SQL/ConnectivityTests`
- the core `ManualTests/BulkCopy` suite

The required `sqlclient-pr` pipeline now applies the focused filter to its Azure job. The Package- and Project-reference PR pipelines additionally reduce their Azure SQL matrix from test sets 1/2/3 to set 2, where all selected tests live, while retaining both regular and flaky runs.

Scheduled CI, local SQL Server, LocalDB, named-instance, unit, functional, Always Encrypted, and Azure extension-package coverage are unchanged. Each reference PR pipeline's Azure SQL matrix drops from 51 jobs to 17, removing 68 jobs across the two pipelines.

## Issues

N/A

## Testing

- Azure DevOps preview compilation succeeded for `sqlclient-pr`, `PR-SqlClient-Package`, and `PR-SqlClient-Project` from this branch.
- Expanded PR plans contain 17 Azure SQL jobs per reference pipeline; expanded scheduled CI plans remain at 51 and contain no focused filter.
- Test discovery with the final set-2 expressions selected 118 regular tests and 1 flaky test.
- All 10 changed YAML files parse successfully.
- Live Azure SQL tests were not run locally; PR validation will exercise them.

## Guidelines

- [x] Tests added or updated (pipeline test selection updated; no C# test changes)
- [x] Public API changes documented (N/A)
- [x] Verified against customer repro (N/A)
- [x] Ensure no breaking changes introduced

Please review the contribution guidelines before submitting a pull request:

- [Contributing](/CONTRIBUTING.md)
- [Code of Conduct](/CODE_OF_CONDUCT.md)
- [Best Practices](/policy/coding-best-practices.md)
- [Coding Style](/policy/coding-style.md)
- [Review Process](/policy/review-process.md)