### PR TITLE
Validate PR milestone against the target branch

### DIFF
--- a/.github/scripts/check-milestone-branch.sh
+++ b/.github/scripts/check-milestone-branch.sh
@@ -18,13 +18,17 @@
 #
 #     <major>.<minor>.<patch>  ->  release/<major>.<minor>
 #
-# Whether that branch already exists determines where the work belongs:
+# Release branches and open milestones determine where the work belongs:
 #
 #   * The branch EXISTS  -> that version has already forked off the default
 #     branch and is in servicing. Changes for it go to release/<major>.<minor>.
 #
-#   * The branch DOES NOT exist -> that version is still in development on the
-#     default branch. Changes for it go to the default branch.
+#   * The branch DOES NOT exist, and this is the earliest open milestone series
+#     without a release branch -> that version is in development on the default
+#     branch. Changes for it go to the default branch.
+#
+#   * An earlier open milestone series has no release branch -> the requested
+#     version is not active yet and cannot target the default branch.
 #
 # This rule is self-maintaining: no hard-coded version list needs updating when
 # a new release branch is cut.
@@ -35,7 +39,8 @@
 #   -----------------------  -----------------------  ----------------------
 #   release/<major>.<minor>  n/a (it is the target)   pass
 #   another release/*        n/a                      fail (mismatch)
-#   default branch           no                       pass
+#   default branch           no, earliest open line   pass
+#   default branch           no, later open line      fail (not active yet)
 #   default branch           yes                      fail (needs servicing branch)
 #   anything else            n/a                      skipped (integration branch)
 #
@@ -130,6 +135,43 @@ fi
 
 if grep -qxF "refs/heads/${RELEASE_BRANCH}" <<< "${RELEASE_REFS}"; then
   echo "::error::Milestone '${MILESTONE_TITLE}' is a servicing release owned by '${RELEASE_BRANCH}', but this PR targets '${DEFAULT_BRANCH}'. Either retarget the PR to '${RELEASE_BRANCH}', or assign an in-development milestone and add the 'Hotfix ${MAJOR}.${MINOR}.${PATCH}' label so the change is cherry-picked after merge."
+  exit 1
+fi
+
+if ! OPEN_MILESTONES=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/milestones?state=open&per_page=100" \
+    --jq '.[].title' 2>&1); then
+  echo "::error::Unable to list open milestones for '${GITHUB_REPOSITORY}': ${OPEN_MILESTONES}"
+  exit 1
+fi
+
+ACTIVE_MAJOR=""
+ACTIVE_MINOR=""
+ACTIVE_MILESTONE=""
+while IFS= read -r milestone; do
+  if [[ ! "${milestone}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)([-+].*)?$ ]]; then
+    continue
+  fi
+
+  candidate_major="${BASH_REMATCH[1]}"
+  candidate_minor="${BASH_REMATCH[2]}"
+  candidate_branch="release/${candidate_major}.${candidate_minor}"
+  if grep -qxF "refs/heads/${candidate_branch}" <<< "${RELEASE_REFS}"; then
+    continue
+  fi
+
+  if [[ -z "${ACTIVE_MAJOR}" ]] ||
+      (( 10#${candidate_major} < 10#${ACTIVE_MAJOR} )) ||
+      (( 10#${candidate_major} == 10#${ACTIVE_MAJOR} && 10#${candidate_minor} < 10#${ACTIVE_MINOR} )); then
+    ACTIVE_MAJOR="${candidate_major}"
+    ACTIVE_MINOR="${candidate_minor}"
+    ACTIVE_MILESTONE="${milestone}"
+  fi
+done <<< "${OPEN_MILESTONES}"
+
+if [[ -n "${ACTIVE_MAJOR}" ]] &&
+    { (( 10#${MAJOR} > 10#${ACTIVE_MAJOR} )) ||
+      (( 10#${MAJOR} == 10#${ACTIVE_MAJOR} && 10#${MINOR} > 10#${ACTIVE_MINOR} )); }; then
+  echo "::error::Milestone '${MILESTONE_TITLE}' is for a later development line, but '${ACTIVE_MILESTONE}' remains active on '${DEFAULT_BRANCH}' until 'release/${ACTIVE_MAJOR}.${ACTIVE_MINOR}' is cut. Assign a milestone from the active ${ACTIVE_MAJOR}.${ACTIVE_MINOR} line."
   exit 1
 fi
 

--- a/.github/scripts/check-milestone-branch.sh
+++ b/.github/scripts/check-milestone-branch.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#################################################################################
+# Licensed to the .NET Foundation under one or more agreements.                 #
+# The .NET Foundation licenses this file to you under the MIT license.          #
+# See the LICENSE file in the project root for more information.                #
+#################################################################################
+#
+# check-milestone-branch.sh
+#
+# Validates that a pull request's milestone is consistent with the branch the
+# pull request targets.
+#
+# OVERVIEW
+# --------
+# Milestones in this repository are named "<major>.<minor>.<patch>", optionally
+# with a pre-release suffix (e.g. "7.0.3", "8.0.0-preview1"). Every milestone
+# therefore maps to a candidate release branch:
+#
+#     <major>.<minor>.<patch>  ->  release/<major>.<minor>
+#
+# Whether that branch already exists determines where the work belongs:
+#
+#   * The branch EXISTS  -> that version has already forked off the default
+#     branch and is in servicing. Changes for it go to release/<major>.<minor>.
+#
+#   * The branch DOES NOT exist -> that version is still in development on the
+#     default branch. Changes for it go to the default branch.
+#
+# This rule is self-maintaining: no hard-coded version list needs updating when
+# a new release branch is cut.
+#
+# VALIDATION MATRIX
+# -----------------
+#   Target branch            Release branch exists?   Result
+#   -----------------------  -----------------------  ----------------------
+#   release/<major>.<minor>  n/a (it is the target)   pass
+#   another release/*        n/a                      fail (mismatch)
+#   default branch           no                       pass
+#   default branch           yes                      fail (needs servicing branch)
+#   anything else            n/a                      skipped (integration branch)
+#
+# Pull requests into long-lived integration branches (e.g. "dev/paul/foo") are
+# skipped, because the milestone is enforced when that branch is merged into
+# the default branch or a release branch.
+#
+# Milestones that don't parse as "<major>.<minor>.<patch>" are skipped with a
+# notice rather than failing the build.
+#
+# REQUIRED ENVIRONMENT VARIABLES
+# ------------------------------
+#   MILESTONE_TITLE    The PR's milestone title (e.g. "7.0.3").
+#   BASE_REF           The branch the PR targets (e.g. "main", "release/7.0").
+#   DEFAULT_BRANCH     The repository's default branch (e.g. "main").
+#   GITHUB_REPOSITORY  Owner/repo (e.g. "dotnet/SqlClient"). Set automatically by Actions.
+#   GH_TOKEN           GitHub token for API calls (gh CLI auth).
+#
+# OUTPUTS
+# -------
+#   Emits ::notice:: on success/skip and ::error:: on failure.
+#   Exits 0 when the milestone and target branch agree (or the check is
+#   skipped), and 1 when they conflict.
+#
+# USAGE
+#   Called from the check-milestone.yml workflow. Can also be run locally:
+#
+#     export MILESTONE_TITLE="7.0.3"
+#     export BASE_REF="main"
+#     export DEFAULT_BRANCH="main"
+#     export GITHUB_REPOSITORY="dotnet/SqlClient"
+#     bash .github/scripts/check-milestone-branch.sh
+#
+#################################################################################
+set -euo pipefail
+
+# -- Runtime help -------------------------------------------------------------
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  # Print the header comment block (between the license banner and the
+  # closing banner), stripping the leading '# ' prefix.
+  awk '/^#{2,}$/ { n++; next } n == 2 { sub(/^# ?/, ""); print }' "$0"
+  exit 0
+fi
+
+# -- Input validation ---------------------------------------------------------
+: "${MILESTONE_TITLE:?MILESTONE_TITLE environment variable is required}"
+: "${BASE_REF:?BASE_REF environment variable is required}"
+: "${DEFAULT_BRANCH:?DEFAULT_BRANCH environment variable is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY environment variable is required}"
+
+# -- Derive the candidate release branch from the milestone -------------------
+# Accepts "X.Y.Z" with an optional pre-release/build suffix, e.g. "8.0.0-preview1".
+if [[ "${MILESTONE_TITLE}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)([-+].*)?$ ]]; then
+  MAJOR="${BASH_REMATCH[1]}"
+  MINOR="${BASH_REMATCH[2]}"
+  PATCH="${BASH_REMATCH[3]}"
+else
+  echo "::notice::Milestone '${MILESTONE_TITLE}' is not in 'major.minor.patch' form; skipping the target branch check."
+  exit 0
+fi
+
+RELEASE_BRANCH="release/${MAJOR}.${MINOR}"
+
+# -- Skip integration branches ------------------------------------------------
+# Only the default branch and release branches carry milestone semantics.
+if [[ "${BASE_REF}" != "${DEFAULT_BRANCH}" && "${BASE_REF}" != release/* ]]; then
+  echo "::notice::PR targets integration branch '${BASE_REF}'; skipping the milestone/branch check."
+  exit 0
+fi
+
+# -- Validate a release branch target -----------------------------------------
+# The target branch itself proves which version is being serviced, so no branch
+# listing is needed here.
+if [[ "${BASE_REF}" == release/* ]]; then
+  if [[ "${BASE_REF}" != "${RELEASE_BRANCH}" ]]; then
+    echo "::error::Milestone '${MILESTONE_TITLE}' belongs to '${RELEASE_BRANCH}', but this PR targets '${BASE_REF}'. Retarget the PR or assign the milestone that matches '${BASE_REF}'."
+    exit 1
+  fi
+
+  echo "::notice::Milestone '${MILESTONE_TITLE}' matches target branch '${BASE_REF}'."
+  exit 0
+fi
+
+# -- Validate a default branch target -----------------------------------------
+# 'matching-refs' returns only refs under the given prefix, so this is a single
+# cheap call regardless of how many topic branches the repository has.
+if ! RELEASE_REFS=$(gh api "repos/${GITHUB_REPOSITORY}/git/matching-refs/heads/release/" \
+    --jq '.[].ref' 2>&1); then
+  echo "::error::Unable to list release branches for '${GITHUB_REPOSITORY}': ${RELEASE_REFS}"
+  exit 1
+fi
+
+if grep -qxF "refs/heads/${RELEASE_BRANCH}" <<< "${RELEASE_REFS}"; then
+  echo "::error::Milestone '${MILESTONE_TITLE}' is a servicing release owned by '${RELEASE_BRANCH}', but this PR targets '${DEFAULT_BRANCH}'. Either retarget the PR to '${RELEASE_BRANCH}', or assign an in-development milestone and add the 'Hotfix ${MAJOR}.${MINOR}.${PATCH}' label so the change is cherry-picked after merge."
+  exit 1
+fi
+
+echo "::notice::Milestone '${MILESTONE_TITLE}' is still in development (no '${RELEASE_BRANCH}' branch); targeting '${DEFAULT_BRANCH}' is correct."

--- a/.github/scripts/check-milestone-branch.sh
+++ b/.github/scripts/check-milestone-branch.sh
@@ -18,17 +18,17 @@
 #
 #     <major>.<minor>.<patch>  ->  release/<major>.<minor>
 #
-# Release branches and open milestones determine where the work belongs:
+# Release branches and configured milestones determine where the work belongs:
 #
 #   * The branch EXISTS  -> that version has already forked off the default
 #     branch and is in servicing. Changes for it go to release/<major>.<minor>.
 #
-#   * The branch DOES NOT exist, and this is the earliest open milestone series
-#     without a release branch -> that version is in development on the default
-#     branch. Changes for it go to the default branch.
+#   * The branch DOES NOT exist, and this is the earliest configured milestone
+#     series without a release branch -> that version is in development on the
+#     default branch. Changes for it go to the default branch.
 #
-#   * An earlier open milestone series has no release branch -> the requested
-#     version is not active yet and cannot target the default branch.
+#   * An earlier configured milestone series has no release branch -> the
+#     requested version is not active yet and cannot target the default branch.
 #
 # This rule is self-maintaining: no hard-coded version list needs updating when
 # a new release branch is cut.
@@ -39,8 +39,8 @@
 #   -----------------------  -----------------------  ----------------------
 #   release/<major>.<minor>  n/a (it is the target)   pass
 #   another release/*        n/a                      fail (mismatch)
-#   default branch           no, earliest open line   pass
-#   default branch           no, later open line      fail (not active yet)
+#   default branch           no, earliest configured line  pass
+#   default branch           no, later configured line     fail (not active yet)
 #   default branch           yes                      fail (needs servicing branch)
 #   anything else            n/a                      skipped (integration branch)
 #
@@ -138,15 +138,31 @@ if grep -qxF "refs/heads/${RELEASE_BRANCH}" <<< "${RELEASE_REFS}"; then
   exit 1
 fi
 
-if ! OPEN_MILESTONES=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/milestones?state=open&per_page=100" \
+if ! MILESTONES=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/milestones?state=all&per_page=100" \
     --jq '.[].title' 2>&1); then
-  echo "::error::Unable to list open milestones for '${GITHUB_REPOSITORY}': ${OPEN_MILESTONES}"
+  echo "::error::Unable to list milestones for '${GITHUB_REPOSITORY}': ${MILESTONES}"
   exit 1
 fi
 
 ACTIVE_MAJOR=""
 ACTIVE_MINOR=""
-ACTIVE_MILESTONE=""
+LATEST_RELEASE_MAJOR=""
+LATEST_RELEASE_MINOR=""
+while IFS= read -r release_ref; do
+  if [[ ! "${release_ref}" =~ ^refs/heads/release/([0-9]+)\.([0-9]+)$ ]]; then
+    continue
+  fi
+
+  release_major="${BASH_REMATCH[1]}"
+  release_minor="${BASH_REMATCH[2]}"
+  if [[ -z "${LATEST_RELEASE_MAJOR}" ]] ||
+      (( 10#${release_major} > 10#${LATEST_RELEASE_MAJOR} )) ||
+      (( 10#${release_major} == 10#${LATEST_RELEASE_MAJOR} && 10#${release_minor} > 10#${LATEST_RELEASE_MINOR} )); then
+    LATEST_RELEASE_MAJOR="${release_major}"
+    LATEST_RELEASE_MINOR="${release_minor}"
+  fi
+done <<< "${RELEASE_REFS}"
+
 while IFS= read -r milestone; do
   if [[ ! "${milestone}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)([-+].*)?$ ]]; then
     continue
@@ -159,19 +175,24 @@ while IFS= read -r milestone; do
     continue
   fi
 
+  if [[ -n "${LATEST_RELEASE_MAJOR}" ]] &&
+      { (( 10#${candidate_major} < 10#${LATEST_RELEASE_MAJOR} )) ||
+        (( 10#${candidate_major} == 10#${LATEST_RELEASE_MAJOR} && 10#${candidate_minor} <= 10#${LATEST_RELEASE_MINOR} )); }; then
+    continue
+  fi
+
   if [[ -z "${ACTIVE_MAJOR}" ]] ||
       (( 10#${candidate_major} < 10#${ACTIVE_MAJOR} )) ||
       (( 10#${candidate_major} == 10#${ACTIVE_MAJOR} && 10#${candidate_minor} < 10#${ACTIVE_MINOR} )); then
     ACTIVE_MAJOR="${candidate_major}"
     ACTIVE_MINOR="${candidate_minor}"
-    ACTIVE_MILESTONE="${milestone}"
   fi
-done <<< "${OPEN_MILESTONES}"
+done <<< "${MILESTONES}"
 
 if [[ -n "${ACTIVE_MAJOR}" ]] &&
     { (( 10#${MAJOR} > 10#${ACTIVE_MAJOR} )) ||
       (( 10#${MAJOR} == 10#${ACTIVE_MAJOR} && 10#${MINOR} > 10#${ACTIVE_MINOR} )); }; then
-  echo "::error::Milestone '${MILESTONE_TITLE}' is for a later development line, but '${ACTIVE_MILESTONE}' remains active on '${DEFAULT_BRANCH}' until 'release/${ACTIVE_MAJOR}.${ACTIVE_MINOR}' is cut. Assign a milestone from the active ${ACTIVE_MAJOR}.${ACTIVE_MINOR} line."
+  echo "::error::Milestone '${MILESTONE_TITLE}' is for a later development line, but the ${ACTIVE_MAJOR}.${ACTIVE_MINOR} milestone series remains active on '${DEFAULT_BRANCH}' until 'release/${ACTIVE_MAJOR}.${ACTIVE_MINOR}' is cut. Assign a milestone from the active ${ACTIVE_MAJOR}.${ACTIVE_MINOR} line."
   exit 1
 fi
 

--- a/.github/scripts/check-milestone-branch.sh
+++ b/.github/scripts/check-milestone-branch.sh
@@ -27,8 +27,9 @@
 #     series without a release branch -> that version is in development on the
 #     default branch. Changes for it go to the default branch.
 #
-#   * An earlier configured milestone series has no release branch -> the
-#     requested version is not active yet and cannot target the default branch.
+#   * Any other series -> the default branch carries exactly one development
+#     line, so a later series is not active yet and an earlier series is no
+#     longer in development. Neither may target the default branch.
 #
 # This rule is self-maintaining: no hard-coded version list needs updating when
 # a new release branch is cut.
@@ -39,8 +40,9 @@
 #   -----------------------  -----------------------  ----------------------
 #   release/<major>.<minor>  n/a (it is the target)   pass
 #   another release/*        n/a                      fail (mismatch)
-#   default branch           no, earliest configured line  pass
+#   default branch           no, active line               pass
 #   default branch           no, later configured line     fail (not active yet)
+#   default branch           no, earlier configured line   fail (no longer in development)
 #   default branch           yes                      fail (needs servicing branch)
 #   anything else            n/a                      skipped (integration branch)
 #
@@ -190,9 +192,13 @@ while IFS= read -r milestone; do
 done <<< "${MILESTONES}"
 
 if [[ -n "${ACTIVE_MAJOR}" ]] &&
-    { (( 10#${MAJOR} > 10#${ACTIVE_MAJOR} )) ||
-      (( 10#${MAJOR} == 10#${ACTIVE_MAJOR} && 10#${MINOR} > 10#${ACTIVE_MINOR} )); }; then
-  echo "::error::Milestone '${MILESTONE_TITLE}' is for a later development line, but the ${ACTIVE_MAJOR}.${ACTIVE_MINOR} milestone series remains active on '${DEFAULT_BRANCH}' until 'release/${ACTIVE_MAJOR}.${ACTIVE_MINOR}' is cut. Assign a milestone from the active ${ACTIVE_MAJOR}.${ACTIVE_MINOR} line."
+    (( 10#${MAJOR} != 10#${ACTIVE_MAJOR} || 10#${MINOR} != 10#${ACTIVE_MINOR} )); then
+  if (( 10#${MAJOR} > 10#${ACTIVE_MAJOR} ||
+        (10#${MAJOR} == 10#${ACTIVE_MAJOR} && 10#${MINOR} > 10#${ACTIVE_MINOR}) )); then
+    echo "::error::Milestone '${MILESTONE_TITLE}' is for a later development line, but the ${ACTIVE_MAJOR}.${ACTIVE_MINOR} milestone series remains active on '${DEFAULT_BRANCH}' until 'release/${ACTIVE_MAJOR}.${ACTIVE_MINOR}' is cut. Assign a milestone from the active ${ACTIVE_MAJOR}.${ACTIVE_MINOR} line."
+  else
+    echo "::error::Milestone '${MILESTONE_TITLE}' is for the ${MAJOR}.${MINOR} line, which is no longer in development on '${DEFAULT_BRANCH}'; the active line is ${ACTIVE_MAJOR}.${ACTIVE_MINOR}. Assign a milestone from the active ${ACTIVE_MAJOR}.${ACTIVE_MINOR} line."
+  fi
   exit 1
 fi
 

--- a/.github/scripts/check-milestone-branch.sh
+++ b/.github/scripts/check-milestone-branch.sh
@@ -43,6 +43,7 @@
 #   default branch           no, active line               pass
 #   default branch           no, later configured line     fail (not active yet)
 #   default branch           no, earlier configured line   fail (no longer in development)
+#   default branch           no active line configured     fail (milestone missing)
 #   default branch           yes                      fail (needs servicing branch)
 #   anything else            n/a                      skipped (integration branch)
 #
@@ -191,8 +192,12 @@ while IFS= read -r milestone; do
   fi
 done <<< "${MILESTONES}"
 
-if [[ -n "${ACTIVE_MAJOR}" ]] &&
-    (( 10#${MAJOR} != 10#${ACTIVE_MAJOR} || 10#${MINOR} != 10#${ACTIVE_MINOR} )); then
+if [[ -z "${ACTIVE_MAJOR}" ]]; then
+  echo "::error::No configured milestone series is newer than the newest release branch, so no development line is active on '${DEFAULT_BRANCH}'. Create the milestone for the next version before targeting '${DEFAULT_BRANCH}' with '${MILESTONE_TITLE}'."
+  exit 1
+fi
+
+if (( 10#${MAJOR} != 10#${ACTIVE_MAJOR} || 10#${MINOR} != 10#${ACTIVE_MINOR} )); then
   if (( 10#${MAJOR} > 10#${ACTIVE_MAJOR} ||
         (10#${MAJOR} == 10#${ACTIVE_MAJOR} && 10#${MINOR} > 10#${ACTIVE_MINOR}) )); then
     echo "::error::Milestone '${MILESTONE_TITLE}' is for a later development line, but the ${ACTIVE_MAJOR}.${ACTIVE_MINOR} milestone series remains active on '${DEFAULT_BRANCH}' until 'release/${ACTIVE_MAJOR}.${ACTIVE_MINOR}' is cut. Assign a milestone from the active ${ACTIVE_MAJOR}.${ACTIVE_MINOR} line."

--- a/.github/scripts/recheck-milestones-for-release-branch.sh
+++ b/.github/scripts/recheck-milestones-for-release-branch.sh
@@ -7,20 +7,20 @@
 #
 # recheck-milestones-for-release-branch.sh
 #
-# Re-runs the milestone check for open pull requests that are invalidated by the
-# creation of a release branch.
+# Re-runs the milestone check for open pull requests whose result can change
+# when a release branch is created.
 #
 # OVERVIEW
 # --------
 # check-milestone-branch.sh decides where a milestone belongs by asking whether
-# release/<major>.<minor> exists. Cutting that branch therefore flips the
-# expected target for every X.Y.* milestone from the default branch to the new
-# release branch.
+# release/<major>.<minor> exists and which configured milestone series is the
+# earliest one without a release branch. Cutting a branch therefore moves its
+# X.Y.* milestones into servicing and can make the next series active.
 #
 # Creating a branch emits no pull request activity, so an already-open PR keeps
-# whatever result it last recorded. This script closes that gap: it finds the
-# open PRs whose milestone now belongs to the new release branch and re-runs
-# their most recent milestone check.
+# whatever result it last recorded. This script closes that gap by re-running
+# every semantic-version-milestoned PR targeting the default branch. That covers
+# both the newly serviced series and any later series whose eligibility changes.
 #
 # Re-running is enough because check-milestone-branch.sh queries the live list
 # of release branches. The replayed event payload still carries the correct
@@ -83,15 +83,12 @@ fi
 : "${WORKFLOW_FILE:?WORKFLOW_FILE environment variable is required}"
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY environment variable is required}"
 
-if [[ "${RELEASE_BRANCH}" =~ ^release/([0-9]+)\.([0-9]+)$ ]]; then
-  MAJOR="${BASH_REMATCH[1]}"
-  MINOR="${BASH_REMATCH[2]}"
-else
+if [[ ! "${RELEASE_BRANCH}" =~ ^release/[0-9]+\.[0-9]+$ ]]; then
   echo "::notice::'${RELEASE_BRANCH}' is not a 'release/<major>.<minor>' branch; nothing to reconcile."
   exit 0
 fi
 
-# -- Find the open PRs the new branch invalidates ------------------------------
+# -- Find open PRs whose result can change -------------------------------------
 if ! OPEN_PRS=$(gh pr list --repo "${GITHUB_REPOSITORY}" --base "${DEFAULT_BRANCH}" \
     --state open --limit 500 --json number,headRefOid,milestone \
     --jq '.[] | select(.milestone != null) | "\(.number) \(.headRefOid) \(.milestone.title)"' 2>&1); then
@@ -106,8 +103,7 @@ while read -r NUMBER HEAD_SHA MILESTONE_TITLE; do
   [[ -n "${NUMBER}" ]] || continue
 
   # Same milestone grammar as check-milestone-branch.sh.
-  [[ "${MILESTONE_TITLE}" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+([-+].*)?$ ]] || continue
-  [[ "${BASH_REMATCH[1]}" == "${MAJOR}" && "${BASH_REMATCH[2]}" == "${MINOR}" ]] || continue
+  [[ "${MILESTONE_TITLE}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+].*)?$ ]] || continue
 
   MATCHED=$((MATCHED + 1))
 
@@ -142,7 +138,7 @@ while read -r NUMBER HEAD_SHA MILESTONE_TITLE; do
 done <<< "${OPEN_PRS}"
 
 if [[ "${MATCHED}" -eq 0 ]]; then
-  echo "::notice::No open PR targeting '${DEFAULT_BRANCH}' carries a ${MAJOR}.${MINOR}.* milestone."
+  echo "::notice::No open PR targeting '${DEFAULT_BRANCH}' carries a semantic-version milestone."
   exit 0
 fi
 

--- a/.github/scripts/recheck-milestones-for-release-branch.sh
+++ b/.github/scripts/recheck-milestones-for-release-branch.sh
@@ -97,9 +97,21 @@ while read -r NUMBER HEAD_SHA MILESTONE_TITLE; do
 
   MATCHED=$((MATCHED + 1))
 
-  RUN_ID=$(gh api \
-    "repos/${GITHUB_REPOSITORY}/actions/workflows/${WORKFLOW_FILE}/runs?head_sha=${HEAD_SHA}&per_page=1" \
-    --jq '.workflow_runs[0].id // empty' 2>/dev/null)
+  RUNS=$(gh api \
+    "repos/${GITHUB_REPOSITORY}/actions/workflows/${WORKFLOW_FILE}/runs?head_sha=${HEAD_SHA}&per_page=100" \
+    2>/dev/null)
+
+  # One head commit can back PRs against several bases, so prefer the run that
+  # names this PR rather than just the newest run for the SHA.
+  RUN_ID=$(jq -r --argjson pr "${NUMBER}" \
+    '([.workflow_runs[] | select(any(.pull_requests[]?; .number == $pr))] | first | .id) // empty' \
+    <<< "${RUNS}" 2>/dev/null)
+
+  # 'pull_requests' is empty for runs from forked repositories, so fall back to
+  # the newest run for the SHA when the association is unavailable.
+  if [[ -z "${RUN_ID}" ]]; then
+    RUN_ID=$(jq -r '.workflow_runs[0].id // empty' <<< "${RUNS}" 2>/dev/null)
+  fi
 
   if [[ -z "${RUN_ID}" ]]; then
     echo "::warning::PR #${NUMBER} (milestone '${MILESTONE_TITLE}') has no milestone check run to re-run; re-check it manually."

--- a/.github/scripts/recheck-milestones-for-release-branch.sh
+++ b/.github/scripts/recheck-milestones-for-release-branch.sh
@@ -27,6 +27,20 @@
 # milestone and base branch, since the check re-runs on every 'milestoned' and
 # 'edited' activity, so the newest run always reflects the current PR state.
 #
+# LIMITATION
+# ----------
+# A re-run replays the original run's commit, which means it executes the
+# workflow definition and script as they existed then. Only the release branch
+# lookup is evaluated live.
+#
+# So a pull request whose most recent milestone check predates the arrival of
+# the target-branch rule will replay the older check, pass it, and keep its
+# stale result. This is transitional: any pull request with activity after the
+# rule shipped has a run that contains it. It is not detected here, because
+# distinguishing a stale replay costs an extra API call per pull request and
+# the window closes on its own. After the first release branch is cut following
+# a change to the check itself, review the affected pull requests by hand.
+#
 # REQUIRED ENVIRONMENT VARIABLES
 # ------------------------------
 #   RELEASE_BRANCH     The branch that was just created (e.g. "release/7.1").

--- a/.github/scripts/recheck-milestones-for-release-branch.sh
+++ b/.github/scripts/recheck-milestones-for-release-branch.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#################################################################################
+# Licensed to the .NET Foundation under one or more agreements.                 #
+# The .NET Foundation licenses this file to you under the MIT license.          #
+# See the LICENSE file in the project root for more information.                #
+#################################################################################
+#
+# recheck-milestones-for-release-branch.sh
+#
+# Re-runs the milestone check for open pull requests that are invalidated by the
+# creation of a release branch.
+#
+# OVERVIEW
+# --------
+# check-milestone-branch.sh decides where a milestone belongs by asking whether
+# release/<major>.<minor> exists. Cutting that branch therefore flips the
+# expected target for every X.Y.* milestone from the default branch to the new
+# release branch.
+#
+# Creating a branch emits no pull request activity, so an already-open PR keeps
+# whatever result it last recorded. This script closes that gap: it finds the
+# open PRs whose milestone now belongs to the new release branch and re-runs
+# their most recent milestone check.
+#
+# Re-running is enough because check-milestone-branch.sh queries the live list
+# of release branches. The replayed event payload still carries the correct
+# milestone and base branch, since the check re-runs on every 'milestoned' and
+# 'edited' activity, so the newest run always reflects the current PR state.
+#
+# REQUIRED ENVIRONMENT VARIABLES
+# ------------------------------
+#   RELEASE_BRANCH     The branch that was just created (e.g. "release/7.1").
+#   DEFAULT_BRANCH     The repository's default branch (e.g. "main").
+#   WORKFLOW_FILE      Workflow file name to re-run (e.g. "check-milestone.yml").
+#   GITHUB_REPOSITORY  Owner/repo (e.g. "dotnet/SqlClient"). Set automatically by Actions.
+#   GH_TOKEN           GitHub token for API calls. Needs 'actions: write'.
+#
+# OUTPUTS
+# -------
+#   Emits ::notice:: per PR re-run and ::warning:: for any PR that could not be
+#   re-run. Exits 1 if at least one re-run failed, so the failure is visible in
+#   the Actions UI; a maintainer can then re-run those checks by hand.
+#
+# USAGE
+#   Called from the check-milestone.yml workflow. Can also be run locally:
+#
+#     export RELEASE_BRANCH="release/7.1"
+#     export DEFAULT_BRANCH="main"
+#     export WORKFLOW_FILE="check-milestone.yml"
+#     export GITHUB_REPOSITORY="dotnet/SqlClient"
+#     bash .github/scripts/recheck-milestones-for-release-branch.sh
+#
+#################################################################################
+# 'set -e' is deliberately omitted: one PR failing to re-run must not abandon
+# the rest. Failures are tracked explicitly and reported at the end.
+set -uo pipefail
+
+# -- Runtime help -------------------------------------------------------------
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  # Print the header comment block (between the license banner and the
+  # closing banner), stripping the leading '# ' prefix.
+  awk '/^#{2,}$/ { n++; next } n == 2 { sub(/^# ?/, ""); print }' "$0"
+  exit 0
+fi
+
+# -- Input validation ---------------------------------------------------------
+: "${RELEASE_BRANCH:?RELEASE_BRANCH environment variable is required}"
+: "${DEFAULT_BRANCH:?DEFAULT_BRANCH environment variable is required}"
+: "${WORKFLOW_FILE:?WORKFLOW_FILE environment variable is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY environment variable is required}"
+
+if [[ "${RELEASE_BRANCH}" =~ ^release/([0-9]+)\.([0-9]+)$ ]]; then
+  MAJOR="${BASH_REMATCH[1]}"
+  MINOR="${BASH_REMATCH[2]}"
+else
+  echo "::notice::'${RELEASE_BRANCH}' is not a 'release/<major>.<minor>' branch; nothing to reconcile."
+  exit 0
+fi
+
+# -- Find the open PRs the new branch invalidates ------------------------------
+if ! OPEN_PRS=$(gh pr list --repo "${GITHUB_REPOSITORY}" --base "${DEFAULT_BRANCH}" \
+    --state open --limit 500 --json number,headRefOid,milestone \
+    --jq '.[] | select(.milestone != null) | "\(.number) \(.headRefOid) \(.milestone.title)"' 2>&1); then
+  echo "::error::Unable to list open pull requests for '${GITHUB_REPOSITORY}': ${OPEN_PRS}"
+  exit 1
+fi
+
+FAILED=0
+MATCHED=0
+
+while read -r NUMBER HEAD_SHA MILESTONE_TITLE; do
+  [[ -n "${NUMBER}" ]] || continue
+
+  # Same milestone grammar as check-milestone-branch.sh.
+  [[ "${MILESTONE_TITLE}" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+([-+].*)?$ ]] || continue
+  [[ "${BASH_REMATCH[1]}" == "${MAJOR}" && "${BASH_REMATCH[2]}" == "${MINOR}" ]] || continue
+
+  MATCHED=$((MATCHED + 1))
+
+  RUN_ID=$(gh api \
+    "repos/${GITHUB_REPOSITORY}/actions/workflows/${WORKFLOW_FILE}/runs?head_sha=${HEAD_SHA}&per_page=1" \
+    --jq '.workflow_runs[0].id // empty' 2>/dev/null)
+
+  if [[ -z "${RUN_ID}" ]]; then
+    echo "::warning::PR #${NUMBER} (milestone '${MILESTONE_TITLE}') has no milestone check run to re-run; re-check it manually."
+    FAILED=$((FAILED + 1))
+    continue
+  fi
+
+  if gh run rerun "${RUN_ID}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+    echo "::notice::Re-ran the milestone check for PR #${NUMBER} (milestone '${MILESTONE_TITLE}', run ${RUN_ID})."
+  else
+    echo "::warning::Could not re-run the milestone check for PR #${NUMBER} (run ${RUN_ID}); re-check it manually."
+    FAILED=$((FAILED + 1))
+  fi
+done <<< "${OPEN_PRS}"
+
+if [[ "${MATCHED}" -eq 0 ]]; then
+  echo "::notice::No open PR targeting '${DEFAULT_BRANCH}' carries a ${MAJOR}.${MINOR}.* milestone."
+  exit 0
+fi
+
+if [[ "${FAILED}" -gt 0 ]]; then
+  echo "::error::${FAILED} of ${MATCHED} affected pull requests could not be re-checked automatically."
+  exit 1
+fi
+
+echo "::notice::Re-checked ${MATCHED} pull request(s) affected by '${RELEASE_BRANCH}'."

--- a/.github/scripts/recheck-milestones-for-release-branch.sh
+++ b/.github/scripts/recheck-milestones-for-release-branch.sh
@@ -42,7 +42,7 @@
 #   the Actions UI; a maintainer can then re-run those checks by hand.
 #
 # USAGE
-#   Called from the check-milestone.yml workflow. Can also be run locally:
+#   Called from the recheck-milestones.yml workflow. Can also be run locally:
 #
 #     export RELEASE_BRANCH="release/7.1"
 #     export DEFAULT_BRANCH="main"

--- a/.github/scripts/tests/README.md
+++ b/.github/scripts/tests/README.md
@@ -116,7 +116,7 @@ bats --formatter pretty .github/scripts/tests/
 | ---- | ----- | ------ |
 | `extract-hotfix-versions.bats` | 18 | Label parsing, version extraction, matrix JSON output, edge cases (malformed labels, duplicates, `labeled` vs `closed` events) |
 | `cherry-pick-to-release.bats` | 15 | Branch derivation, already-applied detection, clean cherry-pick, conflict handling, milestone lookup, PR creation, duplicate skip logic |
-| `check-milestone-branch.bats` | 24 | Milestone version parsing, state-independent active development-line selection, release-branch derivation, default-branch vs release-branch validation, integration-branch and non-semver skips, API invocation assertions, API failure handling |
+| `check-milestone-branch.bats` | 25 | Milestone version parsing, state-independent active development-line selection, rejection of earlier and later series on the default branch, release-branch derivation, default-branch vs release-branch validation, integration-branch and non-semver skips, API invocation assertions, API failure handling |
 | `recheck-milestones-for-release-branch.bats` | 17 | Release-branch name parsing, matching open PRs by milestone, run lookup by head SHA and PR association, fork fallback, re-run invocation, and failure reporting |
 
 ## How the Tests Work

--- a/.github/scripts/tests/README.md
+++ b/.github/scripts/tests/README.md
@@ -116,7 +116,7 @@ bats --formatter pretty .github/scripts/tests/
 | ---- | ----- | ------ |
 | `extract-hotfix-versions.bats` | 18 | Label parsing, version extraction, matrix JSON output, edge cases (malformed labels, duplicates, `labeled` vs `closed` events) |
 | `cherry-pick-to-release.bats` | 15 | Branch derivation, already-applied detection, clean cherry-pick, conflict handling, milestone lookup, PR creation, duplicate skip logic |
-| `check-milestone-branch.bats` | 25 | Milestone version parsing, state-independent active development-line selection, rejection of earlier and later series on the default branch, release-branch derivation, default-branch vs release-branch validation, integration-branch and non-semver skips, API invocation assertions, API failure handling |
+| `check-milestone-branch.bats` | 26 | Milestone version parsing, state-independent active development-line selection, rejection of earlier and later series on the default branch, fail-closed handling when no series is active, release-branch derivation, default-branch vs release-branch validation, integration-branch and non-semver skips, API invocation assertions, API failure handling |
 | `recheck-milestones-for-release-branch.bats` | 17 | Release-branch name parsing, matching open PRs by milestone, run lookup by head SHA and PR association, fork fallback, re-run invocation, and failure reporting |
 
 ## How the Tests Work

--- a/.github/scripts/tests/README.md
+++ b/.github/scripts/tests/README.md
@@ -1,8 +1,9 @@
 # GitHub Actions Script Tests
 
 This directory contains tests for the shell scripts used by the
-[cherry-pick-hotfix](./../../../.github/workflows/cherry-pick-hotfix.yml) and
-[check-milestone](./../../../.github/workflows/check-milestone.yml) GitHub Actions workflows.
+[cherry-pick-hotfix](./../../../.github/workflows/cherry-pick-hotfix.yml),
+[check-milestone](./../../../.github/workflows/check-milestone.yml) and
+[recheck-milestones](./../../../.github/workflows/recheck-milestones.yml) GitHub Actions workflows.
 These tests are intended to be run manually by developers when they are changing the associated
 scripts, and not as part of any CI runs.
 

--- a/.github/scripts/tests/README.md
+++ b/.github/scripts/tests/README.md
@@ -117,7 +117,7 @@ bats --formatter pretty .github/scripts/tests/
 | `extract-hotfix-versions.bats` | 18 | Label parsing, version extraction, matrix JSON output, edge cases (malformed labels, duplicates, `labeled` vs `closed` events) |
 | `cherry-pick-to-release.bats` | 15 | Branch derivation, already-applied detection, clean cherry-pick, conflict handling, milestone lookup, PR creation, duplicate skip logic |
 | `check-milestone-branch.bats` | 21 | Milestone version parsing, release-branch derivation, default-branch vs release-branch validation, integration-branch and non-semver skips, API invocation assertions, API failure handling |
-| `recheck-milestones-for-release-branch.bats` | 15 | Release-branch name parsing, matching open PRs by milestone, run lookup by head SHA, re-run invocation, and failure reporting |
+| `recheck-milestones-for-release-branch.bats` | 17 | Release-branch name parsing, matching open PRs by milestone, run lookup by head SHA and PR association, fork fallback, re-run invocation, and failure reporting |
 
 ## How the Tests Work
 

--- a/.github/scripts/tests/README.md
+++ b/.github/scripts/tests/README.md
@@ -116,7 +116,7 @@ bats --formatter pretty .github/scripts/tests/
 | ---- | ----- | ------ |
 | `extract-hotfix-versions.bats` | 18 | Label parsing, version extraction, matrix JSON output, edge cases (malformed labels, duplicates, `labeled` vs `closed` events) |
 | `cherry-pick-to-release.bats` | 15 | Branch derivation, already-applied detection, clean cherry-pick, conflict handling, milestone lookup, PR creation, duplicate skip logic |
-| `check-milestone-branch.bats` | 21 | Milestone version parsing, release-branch derivation, default-branch vs release-branch validation, integration-branch and non-semver skips, API invocation assertions, API failure handling |
+| `check-milestone-branch.bats` | 23 | Milestone version parsing, active development-line selection, release-branch derivation, default-branch vs release-branch validation, integration-branch and non-semver skips, API invocation assertions, API failure handling |
 | `recheck-milestones-for-release-branch.bats` | 17 | Release-branch name parsing, matching open PRs by milestone, run lookup by head SHA and PR association, fork fallback, re-run invocation, and failure reporting |
 
 ## How the Tests Work

--- a/.github/scripts/tests/README.md
+++ b/.github/scripts/tests/README.md
@@ -116,7 +116,7 @@ bats --formatter pretty .github/scripts/tests/
 | ---- | ----- | ------ |
 | `extract-hotfix-versions.bats` | 18 | Label parsing, version extraction, matrix JSON output, edge cases (malformed labels, duplicates, `labeled` vs `closed` events) |
 | `cherry-pick-to-release.bats` | 15 | Branch derivation, already-applied detection, clean cherry-pick, conflict handling, milestone lookup, PR creation, duplicate skip logic |
-| `check-milestone-branch.bats` | 23 | Milestone version parsing, active development-line selection, release-branch derivation, default-branch vs release-branch validation, integration-branch and non-semver skips, API invocation assertions, API failure handling |
+| `check-milestone-branch.bats` | 24 | Milestone version parsing, state-independent active development-line selection, release-branch derivation, default-branch vs release-branch validation, integration-branch and non-semver skips, API invocation assertions, API failure handling |
 | `recheck-milestones-for-release-branch.bats` | 17 | Release-branch name parsing, matching open PRs by milestone, run lookup by head SHA and PR association, fork fallback, re-run invocation, and failure reporting |
 
 ## How the Tests Work

--- a/.github/scripts/tests/README.md
+++ b/.github/scripts/tests/README.md
@@ -1,7 +1,8 @@
-# Cherry-Pick Workflow Tests
+# GitHub Actions Script Tests
 
 This directory contains tests for the shell scripts used by the
-[cherry-pick-hotfix](./../../../.github/workflows/cherry-pick-hotfix.yml) GitHub Actions workflow.
+[cherry-pick-hotfix](./../../../.github/workflows/cherry-pick-hotfix.yml) and
+[check-milestone](./../../../.github/workflows/check-milestone.yml) GitHub Actions workflows.
 These tests are intended to be run manually by developers when they are changing the associated
 scripts, and not as part of any CI runs.
 
@@ -85,6 +86,7 @@ bats .github/scripts/tests/
 ```bash
 bats .github/scripts/tests/extract-hotfix-versions.bats
 bats .github/scripts/tests/cherry-pick-to-release.bats
+bats .github/scripts/tests/check-milestone-branch.bats
 ```
 
 ### Run a specific test by name
@@ -112,10 +114,11 @@ bats --formatter pretty .github/scripts/tests/
 | ---- | ----- | ------ |
 | `extract-hotfix-versions.bats` | 18 | Label parsing, version extraction, matrix JSON output, edge cases (malformed labels, duplicates, `labeled` vs `closed` events) |
 | `cherry-pick-to-release.bats` | 15 | Branch derivation, already-applied detection, clean cherry-pick, conflict handling, milestone lookup, PR creation, duplicate skip logic |
+| `check-milestone-branch.bats` | 19 | Milestone version parsing, release-branch derivation, default-branch vs release-branch validation, integration-branch and non-semver skips, API failure handling |
 
 ## How the Tests Work
 
-Both test files use the same general approach:
+All test files use the same general approach:
 
 1. **`setup()`** creates a temporary directory and populates it with mock `git` and `gh` executables
    — simple shell scripts that echo predetermined responses. Environment variables (`VERSION`,

--- a/.github/scripts/tests/README.md
+++ b/.github/scripts/tests/README.md
@@ -87,6 +87,7 @@ bats .github/scripts/tests/
 bats .github/scripts/tests/extract-hotfix-versions.bats
 bats .github/scripts/tests/cherry-pick-to-release.bats
 bats .github/scripts/tests/check-milestone-branch.bats
+bats .github/scripts/tests/recheck-milestones-for-release-branch.bats
 ```
 
 ### Run a specific test by name
@@ -114,7 +115,8 @@ bats --formatter pretty .github/scripts/tests/
 | ---- | ----- | ------ |
 | `extract-hotfix-versions.bats` | 18 | Label parsing, version extraction, matrix JSON output, edge cases (malformed labels, duplicates, `labeled` vs `closed` events) |
 | `cherry-pick-to-release.bats` | 15 | Branch derivation, already-applied detection, clean cherry-pick, conflict handling, milestone lookup, PR creation, duplicate skip logic |
-| `check-milestone-branch.bats` | 19 | Milestone version parsing, release-branch derivation, default-branch vs release-branch validation, integration-branch and non-semver skips, API failure handling |
+| `check-milestone-branch.bats` | 21 | Milestone version parsing, release-branch derivation, default-branch vs release-branch validation, integration-branch and non-semver skips, API invocation assertions, API failure handling |
+| `recheck-milestones-for-release-branch.bats` | 15 | Release-branch name parsing, matching open PRs by milestone, run lookup by head SHA, re-run invocation, and failure reporting |
 
 ## How the Tests Work
 

--- a/.github/scripts/tests/check-milestone-branch.bats
+++ b/.github/scripts/tests/check-milestone-branch.bats
@@ -159,6 +159,15 @@ MOCK
   grep -qF "milestones?state=all" "${STUB_DIR}/gh.log"
 }
 
+@test "fails when an earlier milestone series targets the default branch" {
+  export MILESTONE_TITLE="1.0.0"
+  export BASE_REF="main"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no longer in development"* ]]
+  [[ "$output" == *"active line is 7.1"* ]]
+}
+
 @test "passes when a later milestone targets the default branch after the active release branch is cut" {
   mock_release_branches "release/6.1" "release/7.0" "release/7.1"
   export MILESTONE_TITLE="8.0.0-preview1"

--- a/.github/scripts/tests/check-milestone-branch.bats
+++ b/.github/scripts/tests/check-milestone-branch.bats
@@ -1,0 +1,227 @@
+#!/usr/bin/env bats
+#################################################################################
+# Licensed to the .NET Foundation under one or more agreements.                 #
+# The .NET Foundation licenses this file to you under the MIT license.          #
+# See the LICENSE file in the project root for more information.                #
+#################################################################################
+#
+# Tests for check-milestone-branch.sh
+#
+# Run with:  bats .github/scripts/tests/check-milestone-branch.bats
+#
+# Dependencies: bats-core (https://github.com/bats-core/bats-core)
+#
+#################################################################################
+
+# Path to the script under test (relative to repo root).
+SCRIPT=".github/scripts/check-milestone-branch.sh"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+setup() {
+  STUB_DIR="$(mktemp -d)"
+  export PATH="${STUB_DIR}:${PATH}"
+
+  # Defaults — individual tests override as needed.
+  export MILESTONE_TITLE="7.1.0"
+  export BASE_REF="main"
+  export DEFAULT_BRANCH="main"
+  export GITHUB_REPOSITORY="dotnet/SqlClient"
+  export GH_TOKEN="fake-token"
+
+  mock_release_branches "release/6.1" "release/7.0"
+}
+
+teardown() {
+  rm -rf "${STUB_DIR}"
+}
+
+# Install a 'gh' mock that reports the given release branches.
+mock_release_branches() {
+  local refs=""
+  local branch
+  for branch in "$@"; do
+    refs+="refs/heads/${branch}"$'\n'
+  done
+
+  cat > "${STUB_DIR}/gh" <<MOCK
+#!/usr/bin/env bash
+printf '%s' '${refs}'
+MOCK
+  chmod +x "${STUB_DIR}/gh"
+}
+
+# Install a 'gh' mock that fails, simulating an API error.
+mock_gh_failure() {
+  cat > "${STUB_DIR}/gh" <<'MOCK'
+#!/usr/bin/env bash
+echo "HTTP 403: rate limit exceeded" >&2
+exit 1
+MOCK
+  chmod +x "${STUB_DIR}/gh"
+}
+
+# ── --help flag ──────────────────────────────────────────────────────────────
+
+@test "prints help text with --help" {
+  run bash "${SCRIPT}" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"VALIDATION MATRIX"* ]]
+  [[ "$output" == *"REQUIRED ENVIRONMENT VARIABLES"* ]]
+}
+
+@test "prints help text with -h" {
+  run bash "${SCRIPT}" -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"VALIDATION MATRIX"* ]]
+}
+
+# ── Input validation ─────────────────────────────────────────────────────────
+
+@test "fails when MILESTONE_TITLE is unset" {
+  unset MILESTONE_TITLE
+  run bash "${SCRIPT}"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"MILESTONE_TITLE"* ]]
+}
+
+@test "fails when BASE_REF is unset" {
+  unset BASE_REF
+  run bash "${SCRIPT}"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"BASE_REF"* ]]
+}
+
+@test "fails when DEFAULT_BRANCH is unset" {
+  unset DEFAULT_BRANCH
+  run bash "${SCRIPT}"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"DEFAULT_BRANCH"* ]]
+}
+
+@test "fails when GITHUB_REPOSITORY is unset" {
+  unset GITHUB_REPOSITORY
+  run bash "${SCRIPT}"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"GITHUB_REPOSITORY"* ]]
+}
+
+# ── Default branch targets ───────────────────────────────────────────────────
+
+@test "passes when in-development milestone targets the default branch" {
+  export MILESTONE_TITLE="7.1.0"
+  export BASE_REF="main"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"::notice::"* ]]
+  [[ "$output" == *"still in development"* ]]
+}
+
+@test "passes when a preview milestone targets the default branch" {
+  export MILESTONE_TITLE="8.0.0-preview1"
+  export BASE_REF="main"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"still in development"* ]]
+}
+
+@test "fails when a serviced milestone targets the default branch" {
+  export MILESTONE_TITLE="7.0.3"
+  export BASE_REF="main"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::"* ]]
+  [[ "$output" == *"release/7.0"* ]]
+  [[ "$output" == *"Hotfix 7.0.3"* ]]
+}
+
+@test "honours a non-'main' default branch" {
+  export MILESTONE_TITLE="7.1.0"
+  export BASE_REF="master"
+  export DEFAULT_BRANCH="master"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"targeting 'master' is correct"* ]]
+}
+
+# ── Release branch targets ───────────────────────────────────────────────────
+
+@test "passes when the milestone matches the target release branch" {
+  export MILESTONE_TITLE="7.0.3"
+  export BASE_REF="release/7.0"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"matches target branch 'release/7.0'"* ]]
+}
+
+@test "fails when the milestone belongs to a different release branch" {
+  export MILESTONE_TITLE="7.0.3"
+  export BASE_REF="release/6.1"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::"* ]]
+  [[ "$output" == *"belongs to 'release/7.0'"* ]]
+}
+
+@test "fails when an in-development milestone targets a release branch" {
+  export MILESTONE_TITLE="7.1.0"
+  export BASE_REF="release/7.0"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"belongs to 'release/7.1'"* ]]
+}
+
+@test "passes when a newly cut release branch matches the milestone" {
+  mock_release_branches "release/6.1" "release/7.0" "release/7.1"
+  export MILESTONE_TITLE="7.1.0"
+  export BASE_REF="release/7.1"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"matches target branch 'release/7.1'"* ]]
+}
+
+@test "fails on the default branch once the release branch is cut" {
+  mock_release_branches "release/6.1" "release/7.0" "release/7.1"
+  export MILESTONE_TITLE="7.1.0"
+  export BASE_REF="main"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"release/7.1"* ]]
+}
+
+# ── Skipped cases ────────────────────────────────────────────────────────────
+
+@test "skips integration branch targets" {
+  export MILESTONE_TITLE="7.0.3"
+  export BASE_REF="dev/paul/some-feature"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"integration branch"* ]]
+}
+
+@test "skips milestones that are not major.minor.patch" {
+  export MILESTONE_TITLE="vNext"
+  export BASE_REF="main"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"not in 'major.minor.patch' form"* ]]
+}
+
+@test "skips two-part milestone titles" {
+  export MILESTONE_TITLE="1.0 Hotfix 2"
+  export BASE_REF="main"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"not in 'major.minor.patch' form"* ]]
+}
+
+# ── API failures ─────────────────────────────────────────────────────────────
+
+@test "fails when the branch listing API call fails" {
+  mock_gh_failure
+  export MILESTONE_TITLE="7.0.3"
+  export BASE_REF="main"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Unable to list release branches"* ]]
+}

--- a/.github/scripts/tests/check-milestone-branch.bats
+++ b/.github/scripts/tests/check-milestone-branch.bats
@@ -28,6 +28,7 @@ setup() {
   export DEFAULT_BRANCH="main"
   export GITHUB_REPOSITORY="dotnet/SqlClient"
   export GH_TOKEN="fake-token"
+  export MOCK_OPEN_MILESTONES=$'7.1.0\n8.0.0-preview1\n8.0.0-preview2\n8.0.0'
 
   mock_release_branches "release/6.1" "release/7.0"
 }
@@ -47,7 +48,11 @@ mock_release_branches() {
   cat > "${STUB_DIR}/gh" <<MOCK
 #!/usr/bin/env bash
 echo "GH: \$*" >> "${STUB_DIR}/gh.log"
-printf '%s' '${refs}'
+if [[ "\$*" == *"/milestones"* ]]; then
+  printf '%s' "\${MOCK_OPEN_MILESTONES}"
+else
+  printf '%s' '${refs}'
+fi
 MOCK
   chmod +x "${STUB_DIR}/gh"
 }
@@ -59,6 +64,22 @@ mock_gh_failure() {
 echo "GH: \$*" >> "${STUB_DIR}/gh.log"
 echo "HTTP 403: rate limit exceeded" >&2
 exit 1
+MOCK
+  chmod +x "${STUB_DIR}/gh"
+}
+
+# Install a 'gh' mock that lists branches but fails when milestones are queried.
+mock_milestone_failure() {
+  cat > "${STUB_DIR}/gh" <<MOCK
+#!/usr/bin/env bash
+echo "GH: \$*" >> "${STUB_DIR}/gh.log"
+if [[ "\$*" == *"/milestones"* ]]; then
+  echo "HTTP 403: resource not accessible by integration" >&2
+  exit 1
+fi
+printf '%s' 'refs/heads/release/6.1
+refs/heads/release/7.0
+'
 MOCK
   chmod +x "${STUB_DIR}/gh"
 }
@@ -119,7 +140,17 @@ MOCK
   [[ "$output" == *"still in development"* ]]
 }
 
-@test "passes when a preview milestone targets the default branch" {
+@test "fails when a later milestone targets the default branch before the active release branch is cut" {
+  export MILESTONE_TITLE="8.0.0-preview1"
+  export BASE_REF="main"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"7.1.0"* ]]
+  [[ "$output" == *"release/7.1"* ]]
+}
+
+@test "passes when a later milestone targets the default branch after the active release branch is cut" {
+  mock_release_branches "release/6.1" "release/7.0" "release/7.1"
   export MILESTONE_TITLE="8.0.0-preview1"
   export BASE_REF="main"
   run bash "${SCRIPT}"
@@ -154,6 +185,7 @@ MOCK
   run bash "${SCRIPT}"
   [ "$status" -eq 0 ]
   grep -qF "GH: api repos/dotnet/SqlClient/git/matching-refs/heads/release/ --jq .[].ref" "${STUB_DIR}/gh.log"
+  grep -qF "GH: api --paginate repos/dotnet/SqlClient/milestones?state=open&per_page=100 --jq .[].title" "${STUB_DIR}/gh.log"
 }
 
 @test "does not call the API when the PR targets a release branch" {
@@ -244,4 +276,13 @@ MOCK
   run bash "${SCRIPT}"
   [ "$status" -eq 1 ]
   [[ "$output" == *"Unable to list release branches"* ]]
+}
+
+@test "fails when the milestone listing API call fails" {
+  mock_milestone_failure
+  export MILESTONE_TITLE="7.1.0"
+  export BASE_REF="main"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Unable to list open milestones"* ]]
 }

--- a/.github/scripts/tests/check-milestone-branch.bats
+++ b/.github/scripts/tests/check-milestone-branch.bats
@@ -46,6 +46,7 @@ mock_release_branches() {
 
   cat > "${STUB_DIR}/gh" <<MOCK
 #!/usr/bin/env bash
+echo "GH: \$*" >> "${STUB_DIR}/gh.log"
 printf '%s' '${refs}'
 MOCK
   chmod +x "${STUB_DIR}/gh"
@@ -53,8 +54,9 @@ MOCK
 
 # Install a 'gh' mock that fails, simulating an API error.
 mock_gh_failure() {
-  cat > "${STUB_DIR}/gh" <<'MOCK'
+  cat > "${STUB_DIR}/gh" <<MOCK
 #!/usr/bin/env bash
+echo "GH: \$*" >> "${STUB_DIR}/gh.log"
 echo "HTTP 403: rate limit exceeded" >&2
 exit 1
 MOCK
@@ -142,6 +144,24 @@ MOCK
   run bash "${SCRIPT}"
   [ "$status" -eq 0 ]
   [[ "$output" == *"targeting 'master' is correct"* ]]
+}
+
+# ── API invocation ───────────────────────────────────────────────────────────
+
+@test "queries the release refs endpoint with the expected arguments" {
+  export MILESTONE_TITLE="7.1.0"
+  export BASE_REF="main"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  grep -qF "GH: api repos/dotnet/SqlClient/git/matching-refs/heads/release/ --jq .[].ref" "${STUB_DIR}/gh.log"
+}
+
+@test "does not call the API when the PR targets a release branch" {
+  export MILESTONE_TITLE="7.0.3"
+  export BASE_REF="release/7.0"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [ ! -f "${STUB_DIR}/gh.log" ]
 }
 
 # ── Release branch targets ───────────────────────────────────────────────────

--- a/.github/scripts/tests/check-milestone-branch.bats
+++ b/.github/scripts/tests/check-milestone-branch.bats
@@ -28,7 +28,7 @@ setup() {
   export DEFAULT_BRANCH="main"
   export GITHUB_REPOSITORY="dotnet/SqlClient"
   export GH_TOKEN="fake-token"
-  export MOCK_OPEN_MILESTONES=$'7.1.0\n8.0.0-preview1\n8.0.0-preview2\n8.0.0'
+  export MOCK_MILESTONES=$'1.0.0\n2.0.1\n7.1.0\n8.0.0-preview1\n8.0.0-preview2\n8.0.0'
 
   mock_release_branches "release/6.1" "release/7.0"
 }
@@ -49,7 +49,7 @@ mock_release_branches() {
 #!/usr/bin/env bash
 echo "GH: \$*" >> "${STUB_DIR}/gh.log"
 if [[ "\$*" == *"/milestones"* ]]; then
-  printf '%s' "\${MOCK_OPEN_MILESTONES}"
+  printf '%s' "\${MOCK_MILESTONES}"
 else
   printf '%s' '${refs}'
 fi
@@ -145,8 +145,18 @@ MOCK
   export BASE_REF="main"
   run bash "${SCRIPT}"
   [ "$status" -eq 1 ]
-  [[ "$output" == *"7.1.0"* ]]
+  [[ "$output" == *"7.1 milestone series"* ]]
   [[ "$output" == *"release/7.1"* ]]
+}
+
+@test "closed milestone state does not change the active development line" {
+  export MILESTONE_TITLE="8.0.0-preview1"
+  export BASE_REF="main"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"7.1 milestone series"* ]]
+  [[ "$output" != *"1.0.0"* ]]
+  grep -qF "milestones?state=all" "${STUB_DIR}/gh.log"
 }
 
 @test "passes when a later milestone targets the default branch after the active release branch is cut" {
@@ -185,7 +195,7 @@ MOCK
   run bash "${SCRIPT}"
   [ "$status" -eq 0 ]
   grep -qF "GH: api repos/dotnet/SqlClient/git/matching-refs/heads/release/ --jq .[].ref" "${STUB_DIR}/gh.log"
-  grep -qF "GH: api --paginate repos/dotnet/SqlClient/milestones?state=open&per_page=100 --jq .[].title" "${STUB_DIR}/gh.log"
+  grep -qF "GH: api --paginate repos/dotnet/SqlClient/milestones?state=all&per_page=100 --jq .[].title" "${STUB_DIR}/gh.log"
 }
 
 @test "does not call the API when the PR targets a release branch" {
@@ -284,5 +294,5 @@ MOCK
   export BASE_REF="main"
   run bash "${SCRIPT}"
   [ "$status" -eq 1 ]
-  [[ "$output" == *"Unable to list open milestones"* ]]
+  [[ "$output" == *"Unable to list milestones"* ]]
 }

--- a/.github/scripts/tests/check-milestone-branch.bats
+++ b/.github/scripts/tests/check-milestone-branch.bats
@@ -168,6 +168,16 @@ MOCK
   [[ "$output" == *"active line is 7.1"* ]]
 }
 
+@test "fails when no configured milestone series is active" {
+  mock_release_branches "release/7.0"
+  export MOCK_MILESTONES=$'1.0.0'
+  export MILESTONE_TITLE="1.0.0"
+  export BASE_REF="main"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no development line is active"* ]]
+}
+
 @test "passes when a later milestone targets the default branch after the active release branch is cut" {
   mock_release_branches "release/6.1" "release/7.0" "release/7.1"
   export MILESTONE_TITLE="8.0.0-preview1"

--- a/.github/scripts/tests/recheck-milestones-for-release-branch.bats
+++ b/.github/scripts/tests/recheck-milestones-for-release-branch.bats
@@ -33,14 +33,24 @@ setup() {
   mock_gh "100 aaa111 7.1.0
 101 bbb222 8.0.0-preview1
 102 ccc333 7.1.0-preview3"
+
+  # Default: one run per head SHA, correctly associated with its PR.
+  set_runs aaa111 '{"workflow_runs":[{"id":"run-aaa111","pull_requests":[{"number":100}]}]}'
+  set_runs bbb222 '{"workflow_runs":[{"id":"run-bbb222","pull_requests":[{"number":101}]}]}'
+  set_runs ccc333 '{"workflow_runs":[{"id":"run-ccc333","pull_requests":[{"number":102}]}]}'
 }
 
 teardown() {
   rm -rf "${STUB_DIR}"
 }
 
-# Install a 'gh' mock. $1 is the 'pr list' output; the run lookup returns
-# "run-<sha>" and 'run rerun' succeeds unless RERUN_FAILS is set.
+# Register the workflow-runs response for a given head SHA.
+set_runs() {
+  printf '%s' "$2" > "${STUB_DIR}/runs-$1.json"
+}
+
+# Install a 'gh' mock. $1 is the 'pr list' output; 'api' serves the JSON
+# registered by set_runs, and 'run rerun' succeeds unless RERUN_FAILS is set.
 mock_gh() {
   cat > "${STUB_DIR}/gh" <<MOCK
 #!/usr/bin/env bash
@@ -50,11 +60,12 @@ case "\$1" in
     printf '%s\n' '${1}'
     ;;
   api)
-    if [[ -n "\${NO_RUN_FOUND:-}" ]]; then
-      exit 0
-    fi
     sha="\$(sed -n 's/.*head_sha=\([^&]*\).*/\1/p' <<< "\$2")"
-    echo "run-\${sha}"
+    if [[ -n "\${NO_RUN_FOUND:-}" || ! -f "${STUB_DIR}/runs-\${sha}.json" ]]; then
+      echo '{"workflow_runs":[]}'
+    else
+      cat "${STUB_DIR}/runs-\${sha}.json"
+    fi
     ;;
   run)
     [[ -z "\${RERUN_FAILS:-}" ]] || exit 1
@@ -151,6 +162,30 @@ MOCK
   [ "$status" -eq 0 ]
   grep -qF "head_sha=aaa111" "${STUB_DIR}/gh.log"
   grep -qF "GH: run rerun run-aaa111 --repo dotnet/SqlClient" "${STUB_DIR}/gh.log"
+}
+
+@test "picks the run belonging to this PR when a head sha backs several PRs" {
+  # The newest run for the SHA belongs to a different PR against another base.
+  set_runs aaa111 '{"workflow_runs":[
+    {"id":"run-other","pull_requests":[{"number":999}]},
+    {"id":"run-aaa111","pull_requests":[{"number":100}]}
+  ]}'
+  run bash "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  grep -qF "GH: run rerun run-aaa111 --repo dotnet/SqlClient" "${STUB_DIR}/gh.log"
+  ! grep -qF "run rerun run-other" "${STUB_DIR}/gh.log"
+}
+
+@test "falls back to the newest run when the PR association is missing" {
+  # Runs from forked repositories carry an empty 'pull_requests' array.
+  set_runs aaa111 '{"workflow_runs":[
+    {"id":"run-newest","pull_requests":[]},
+    {"id":"run-older","pull_requests":[]}
+  ]}'
+  run bash "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PR #100"* ]]
+  grep -qF "GH: run rerun run-newest --repo dotnet/SqlClient" "${STUB_DIR}/gh.log"
 }
 
 @test "reports when no open PR carries a matching milestone" {

--- a/.github/scripts/tests/recheck-milestones-for-release-branch.bats
+++ b/.github/scripts/tests/recheck-milestones-for-release-branch.bats
@@ -1,0 +1,192 @@
+#!/usr/bin/env bats
+#################################################################################
+# Licensed to the .NET Foundation under one or more agreements.                 #
+# The .NET Foundation licenses this file to you under the MIT license.          #
+# See the LICENSE file in the project root for more information.                #
+#################################################################################
+#
+# Tests for recheck-milestones-for-release-branch.sh
+#
+# Run with:  bats .github/scripts/tests/recheck-milestones-for-release-branch.bats
+#
+# Dependencies: bats-core (https://github.com/bats-core/bats-core)
+#
+#################################################################################
+
+# Path to the script under test (relative to repo root).
+SCRIPT=".github/scripts/recheck-milestones-for-release-branch.sh"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+setup() {
+  STUB_DIR="$(mktemp -d)"
+  export PATH="${STUB_DIR}:${PATH}"
+
+  # Defaults — individual tests override as needed.
+  export RELEASE_BRANCH="release/7.1"
+  export DEFAULT_BRANCH="main"
+  export WORKFLOW_FILE="check-milestone.yml"
+  export GITHUB_REPOSITORY="dotnet/SqlClient"
+  export GH_TOKEN="fake-token"
+
+  # Open PRs as "<number> <headSha> <milestone>", one per line.
+  mock_gh "100 aaa111 7.1.0
+101 bbb222 8.0.0-preview1
+102 ccc333 7.1.0-preview3"
+}
+
+teardown() {
+  rm -rf "${STUB_DIR}"
+}
+
+# Install a 'gh' mock. $1 is the 'pr list' output; the run lookup returns
+# "run-<sha>" and 'run rerun' succeeds unless RERUN_FAILS is set.
+mock_gh() {
+  cat > "${STUB_DIR}/gh" <<MOCK
+#!/usr/bin/env bash
+echo "GH: \$*" >> "${STUB_DIR}/gh.log"
+case "\$1" in
+  pr)
+    printf '%s\n' '${1}'
+    ;;
+  api)
+    if [[ -n "\${NO_RUN_FOUND:-}" ]]; then
+      exit 0
+    fi
+    sha="\$(sed -n 's/.*head_sha=\([^&]*\).*/\1/p' <<< "\$2")"
+    echo "run-\${sha}"
+    ;;
+  run)
+    [[ -z "\${RERUN_FAILS:-}" ]] || exit 1
+    ;;
+esac
+MOCK
+  chmod +x "${STUB_DIR}/gh"
+}
+
+# Install a 'gh' mock whose 'pr list' call fails.
+mock_pr_list_failure() {
+  cat > "${STUB_DIR}/gh" <<'MOCK'
+#!/usr/bin/env bash
+echo "HTTP 403: rate limit exceeded" >&2
+exit 1
+MOCK
+  chmod +x "${STUB_DIR}/gh"
+}
+
+# ── --help flag ──────────────────────────────────────────────────────────────
+
+@test "prints help text with --help" {
+  run bash "${SCRIPT}" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"REQUIRED ENVIRONMENT VARIABLES"* ]]
+}
+
+# ── Input validation ─────────────────────────────────────────────────────────
+
+@test "fails when RELEASE_BRANCH is unset" {
+  unset RELEASE_BRANCH
+  run bash "${SCRIPT}"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"RELEASE_BRANCH"* ]]
+}
+
+@test "fails when DEFAULT_BRANCH is unset" {
+  unset DEFAULT_BRANCH
+  run bash "${SCRIPT}"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"DEFAULT_BRANCH"* ]]
+}
+
+@test "fails when WORKFLOW_FILE is unset" {
+  unset WORKFLOW_FILE
+  run bash "${SCRIPT}"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"WORKFLOW_FILE"* ]]
+}
+
+@test "fails when GITHUB_REPOSITORY is unset" {
+  unset GITHUB_REPOSITORY
+  run bash "${SCRIPT}"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"GITHUB_REPOSITORY"* ]]
+}
+
+# ── Branch name parsing ──────────────────────────────────────────────────────
+
+@test "skips branches that are not release/<major>.<minor>" {
+  export RELEASE_BRANCH="dev/paul/some-feature"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"nothing to reconcile"* ]]
+  [ ! -f "${STUB_DIR}/gh.log" ]
+}
+
+@test "skips a release branch with a patch component" {
+  export RELEASE_BRANCH="release/7.1.0"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"nothing to reconcile"* ]]
+}
+
+# ── Matching and re-running ──────────────────────────────────────────────────
+
+@test "re-runs only the PRs whose milestone matches the new branch" {
+  run bash "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PR #100"* ]]
+  [[ "$output" == *"PR #102"* ]]
+  [[ "$output" != *"PR #101"* ]]
+  [[ "$output" == *"Re-checked 2 pull request(s)"* ]]
+}
+
+@test "queries open PRs against the default branch" {
+  run bash "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  grep -qF "GH: pr list --repo dotnet/SqlClient --base main --state open" "${STUB_DIR}/gh.log"
+}
+
+@test "looks up the run by the PR head sha and re-runs it" {
+  run bash "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  grep -qF "head_sha=aaa111" "${STUB_DIR}/gh.log"
+  grep -qF "GH: run rerun run-aaa111 --repo dotnet/SqlClient" "${STUB_DIR}/gh.log"
+}
+
+@test "reports when no open PR carries a matching milestone" {
+  export RELEASE_BRANCH="release/6.1"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No open PR targeting 'main' carries a 6.1.* milestone"* ]]
+}
+
+@test "ignores PRs whose milestone is not major.minor.patch" {
+  mock_gh "200 ddd444 vNext"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No open PR"* ]]
+}
+
+# ── Failure handling ─────────────────────────────────────────────────────────
+
+@test "warns and fails when a PR has no run to re-run" {
+  export NO_RUN_FOUND=1
+  run bash "${SCRIPT}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"has no milestone check run to re-run"* ]]
+  [[ "$output" == *"2 of 2 affected pull requests"* ]]
+}
+
+@test "warns and fails when a re-run cannot be started" {
+  export RERUN_FAILS=1
+  run bash "${SCRIPT}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Could not re-run the milestone check for PR #100"* ]]
+}
+
+@test "fails when the PR listing API call fails" {
+  mock_pr_list_failure
+  run bash "${SCRIPT}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Unable to list open pull requests"* ]]
+}

--- a/.github/scripts/tests/recheck-milestones-for-release-branch.bats
+++ b/.github/scripts/tests/recheck-milestones-for-release-branch.bats
@@ -142,13 +142,13 @@ MOCK
 
 # ── Matching and re-running ──────────────────────────────────────────────────
 
-@test "re-runs only the PRs whose milestone matches the new branch" {
+@test "re-runs all semver-milestoned PRs affected by active-line transitions" {
   run bash "${SCRIPT}"
   [ "$status" -eq 0 ]
   [[ "$output" == *"PR #100"* ]]
   [[ "$output" == *"PR #102"* ]]
-  [[ "$output" != *"PR #101"* ]]
-  [[ "$output" == *"Re-checked 2 pull request(s)"* ]]
+  [[ "$output" == *"PR #101"* ]]
+  [[ "$output" == *"Re-checked 3 pull request(s)"* ]]
 }
 
 @test "queries open PRs against the default branch" {
@@ -190,9 +190,10 @@ MOCK
 
 @test "reports when no open PR carries a matching milestone" {
   export RELEASE_BRANCH="release/6.1"
+  mock_gh "200 ddd444 vNext"
   run bash "${SCRIPT}"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"No open PR targeting 'main' carries a 6.1.* milestone"* ]]
+  [[ "$output" == *"No open PR targeting 'main' carries a semantic-version milestone"* ]]
 }
 
 @test "ignores PRs whose milestone is not major.minor.patch" {
@@ -209,7 +210,7 @@ MOCK
   run bash "${SCRIPT}"
   [ "$status" -eq 1 ]
   [[ "$output" == *"has no milestone check run to re-run"* ]]
-  [[ "$output" == *"2 of 2 affected pull requests"* ]]
+  [[ "$output" == *"3 of 3 affected pull requests"* ]]
 }
 
 @test "warns and fails when a re-run cannot be started" {

--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -1,14 +1,42 @@
+#################################################################################
+# Licensed to the .NET Foundation under one or more agreements.                 #
+# The .NET Foundation licenses this file to you under the MIT license.          #
+# See the LICENSE file in the project root for more information.                #
+#################################################################################
+#
+# Check Milestone
+#
+# Validates that every pull request has an open milestone assigned, and that
+# the milestone is consistent with the branch the PR targets.
+#
+# Milestones map to release branches by major.minor:
+#
+#   * "7.0.3" -> release/7.0 exists -> the PR must target release/7.0.
+#   * "7.1.0" -> release/7.1 does not exist yet -> the PR must target main.
+#
+# See .github/scripts/check-milestone-branch.sh for the full rule set.
+#
+# This job never executes PR-authored code: it checks out only .github/scripts from the base
+# branch and reads the PR metadata from the event payload.
+#################################################################################
+
 name: Check Milestone
 
 on:
-  pull_request:
-    types: [opened, edited, synchronize, milestoned, demilestoned]
+  # 'pull_request_target' is used instead of 'pull_request' because
+  # 'pull_request' workflows do not run while a PR has a merge conflict —
+  # a common state right after a stacked PR is retargeted.
+  pull_request_target:
+    # The 'edited' type covers base branch changes, so retargeting a PR (manually,
+    # or automatically when a stacked PR's parent merges) re-runs this check.
+    types: [opened, reopened, edited, synchronize, milestoned, demilestoned]
 
 jobs:
   check-milestone:
     name: Validate milestone
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     steps:
       - name: Check milestone is set
@@ -22,3 +50,22 @@ jobs:
         run: |
           echo "::error::Milestone '${{ github.event.pull_request.milestone.title }}' is ${{ github.event.pull_request.milestone.state }}. Please assign an open milestone."
           exit 1
+
+      - name: Checkout scripts
+        if: github.event.pull_request.milestone != null
+        uses: actions/checkout@v6
+        with:
+          # Checks out the base branch, not the PR head, so the script is trusted.
+          # Only the scripts directory is needed; skip full history.
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Check milestone matches target branch
+        if: github.event.pull_request.milestone != null
+        env:
+          # Pass PR data via env to avoid script injection from milestone text.
+          MILESTONE_TITLE: ${{ github.event.pull_request.milestone.title }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash "${GITHUB_WORKSPACE}/.github/scripts/check-milestone-branch.sh"

--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -16,9 +16,9 @@
 #
 # See .github/scripts/check-milestone-branch.sh for the full rule set.
 #
-# Cutting release/X.Y flips the expected target for X.Y.* milestones, but emits
-# no pull request activity. The 'recheck-open-prs' job reconciles the already
-# open PRs that the new branch invalidates.
+# Cutting release/X.Y flips the expected target for X.Y.* milestones but emits
+# no pull request activity. recheck-milestones.yml reconciles the already open
+# PRs that the new branch invalidates.
 #
 #################################################################################
 
@@ -29,14 +29,10 @@ on:
     # The 'edited' type covers base branch changes, so retargeting a PR (manually,
     # or automatically when a stacked PR's parent merges) re-runs this check.
     types: [opened, reopened, edited, synchronize, milestoned, demilestoned]
-  # 'create' has no branch filter, so every branch creation starts a run; the
-  # job-level guard below skips all but release/* immediately.
-  create:
 
 jobs:
   check-milestone:
     name: Validate milestone
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -71,29 +67,3 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash "${GITHUB_WORKSPACE}/.github/scripts/check-milestone-branch.sh"
-
-  recheck-open-prs:
-    name: Re-check open PRs after a release branch is cut
-    if: github.event_name == 'create' && github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release/')
-    runs-on: ubuntu-latest
-    permissions:
-      # 'actions: write' is needed to re-run the affected milestone checks.
-      actions: write
-      contents: read
-      pull-requests: read
-    steps:
-      - name: Checkout scripts
-        uses: actions/checkout@v6
-        with:
-          # Only the scripts directory is needed; skip full history.
-          sparse-checkout: .github/scripts
-          sparse-checkout-cone-mode: false
-
-      - name: Re-check affected pull requests
-        env:
-          # Pass the ref via env to avoid script injection from branch names.
-          RELEASE_BRANCH: ${{ github.event.ref }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          WORKFLOW_FILE: check-milestone.yml
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bash "${GITHUB_WORKSPACE}/.github/scripts/recheck-milestones-for-release-branch.sh"

--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -36,6 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: read
       pull-requests: read
     steps:
       - name: Check milestone is set

--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -16,17 +16,12 @@
 #
 # See .github/scripts/check-milestone-branch.sh for the full rule set.
 #
-# This job never executes PR-authored code: it checks out only .github/scripts from the base
-# branch and reads the PR metadata from the event payload.
 #################################################################################
 
 name: Check Milestone
 
 on:
-  # 'pull_request_target' is used instead of 'pull_request' because
-  # 'pull_request' workflows do not run while a PR has a merge conflict —
-  # a common state right after a stacked PR is retargeted.
-  pull_request_target:
+  pull_request:
     # The 'edited' type covers base branch changes, so retargeting a PR (manually,
     # or automatically when a stacked PR's parent merges) re-runs this check.
     types: [opened, reopened, edited, synchronize, milestoned, demilestoned]
@@ -55,7 +50,6 @@ jobs:
         if: github.event.pull_request.milestone != null
         uses: actions/checkout@v6
         with:
-          # Checks out the base branch, not the PR head, so the script is trusted.
           # Only the scripts directory is needed; skip full history.
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false

--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -16,6 +16,10 @@
 #
 # See .github/scripts/check-milestone-branch.sh for the full rule set.
 #
+# Cutting release/X.Y flips the expected target for X.Y.* milestones, but emits
+# no pull request activity. The 'recheck-open-prs' job reconciles the already
+# open PRs that the new branch invalidates.
+#
 #################################################################################
 
 name: Check Milestone
@@ -25,10 +29,14 @@ on:
     # The 'edited' type covers base branch changes, so retargeting a PR (manually,
     # or automatically when a stacked PR's parent merges) re-runs this check.
     types: [opened, reopened, edited, synchronize, milestoned, demilestoned]
+  # 'create' has no branch filter, so every branch creation starts a run; the
+  # job-level guard below skips all but release/* immediately.
+  create:
 
 jobs:
   check-milestone:
     name: Validate milestone
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -63,3 +71,29 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash "${GITHUB_WORKSPACE}/.github/scripts/check-milestone-branch.sh"
+
+  recheck-open-prs:
+    name: Re-check open PRs after a release branch is cut
+    if: github.event_name == 'create' && github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release/')
+    runs-on: ubuntu-latest
+    permissions:
+      # 'actions: write' is needed to re-run the affected milestone checks.
+      actions: write
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout scripts
+        uses: actions/checkout@v6
+        with:
+          # Only the scripts directory is needed; skip full history.
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Re-check affected pull requests
+        env:
+          # Pass the ref via env to avoid script injection from branch names.
+          RELEASE_BRANCH: ${{ github.event.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          WORKFLOW_FILE: check-milestone.yml
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash "${GITHUB_WORKSPACE}/.github/scripts/recheck-milestones-for-release-branch.sh"

--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -12,7 +12,10 @@
 # Milestones map to release branches by major.minor:
 #
 #   * "7.0.3" -> release/7.0 exists -> the PR must target release/7.0.
-#   * "7.1.0" -> release/7.1 does not exist yet -> the PR must target main.
+#   * "7.1.0" -> release/7.1 does not exist and it is the earliest configured
+#     unbranched series -> the PR must target main.
+#   * "8.0.0-preview1" -> release/8.0 does not exist, but 7.1 is still the
+#     active unbranched series -> the PR cannot target main yet.
 #
 # See .github/scripts/check-milestone-branch.sh for the full rule set.
 #

--- a/.github/workflows/recheck-milestones.yml
+++ b/.github/workflows/recheck-milestones.yml
@@ -18,6 +18,11 @@
 # request scoped, and so the elevated 'actions: write' permission needed to
 # re-run checks is isolated from the PR gate.
 #
+# A re-run replays the original run's commit, so a pull request whose last
+# milestone check predates a change to the check itself replays the older
+# version and keeps its stale result. See the LIMITATION section in
+# .github/scripts/recheck-milestones-for-release-branch.sh.
+#
 # See .github/scripts/recheck-milestones-for-release-branch.sh for the details.
 #
 #################################################################################

--- a/.github/workflows/recheck-milestones.yml
+++ b/.github/workflows/recheck-milestones.yml
@@ -1,0 +1,60 @@
+#################################################################################
+# Licensed to the .NET Foundation under one or more agreements.                 #
+# The .NET Foundation licenses this file to you under the MIT license.          #
+# See the LICENSE file in the project root for more information.                #
+#################################################################################
+#
+# Recheck Milestones
+#
+# Reconciles open pull requests when a release branch is cut.
+#
+# check-milestone.yml decides where a milestone belongs by asking whether
+# release/<major>.<minor> exists, so creating that branch flips the expected
+# target for every X.Y.* milestone from the default branch to the new release
+# branch. Branch creation emits no pull request activity, so an already open PR
+# would otherwise keep the verdict it last recorded.
+#
+# This lives in its own workflow so that check-milestone.yml stays purely pull
+# request scoped, and so the elevated 'actions: write' permission needed to
+# re-run checks is isolated from the PR gate.
+#
+# See .github/scripts/recheck-milestones-for-release-branch.sh for the details.
+#
+#################################################################################
+
+name: Recheck Milestones
+
+# 'create' has no branch filter, so every branch creation starts a run of this
+# workflow. The guard below skips the job for anything but release/*, which is
+# why this is kept out of check-milestone.yml.
+on: [create]
+
+jobs:
+  recheck-open-prs:
+    name: Re-check open PRs after a release branch is cut
+    if: github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release/')
+    runs-on: ubuntu-latest
+    permissions:
+      # 'actions: write' is needed to re-run the affected milestone checks.
+      actions: write
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout scripts
+        uses: actions/checkout@v6
+        with:
+          # A 'create' run defaults to the new branch; pin the default branch so
+          # the script is read from a known-good copy.
+          ref: ${{ github.event.repository.default_branch }}
+          # Only the scripts directory is needed; skip full history.
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Re-check affected pull requests
+        env:
+          # Pass the ref via env to avoid script injection from branch names.
+          RELEASE_BRANCH: ${{ github.event.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          WORKFLOW_FILE: check-milestone.yml
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash "${GITHUB_WORKSPACE}/.github/scripts/recheck-milestones-for-release-branch.sh"

--- a/.github/workflows/recheck-milestones.yml
+++ b/.github/workflows/recheck-milestones.yml
@@ -9,10 +9,10 @@
 # Reconciles open pull requests when a release branch is cut.
 #
 # check-milestone.yml decides where a milestone belongs by asking whether
-# release/<major>.<minor> exists, so creating that branch flips the expected
-# target for every X.Y.* milestone from the default branch to the new release
-# branch. Branch creation emits no pull request activity, so an already open PR
-# would otherwise keep the verdict it last recorded.
+# release/<major>.<minor> exists and which milestone series is active on the
+# default branch. Creating a release branch can invalidate X.Y.* pull requests
+# and make the next series eligible, but emits no pull request activity, so
+# already open pull requests would otherwise keep their previous verdicts.
 #
 # This lives in its own workflow so that check-milestone.yml stays purely pull
 # request scoped, and so the elevated 'actions: write' permission needed to


### PR DESCRIPTION
## Description

The `Check Milestone` workflow only verified that a PR had an *open* milestone assigned. It accepted nonsensical combinations, such as a PR targeting `main` with milestone `7.0.3` — that work belongs on `release/7.0`.

This adds a target-branch consistency check governed by the complete milestone/branch contract:

- A milestone `X.Y.Z` (with an optional pre-release suffix) maps to `release/X.Y`.
- If `release/X.Y` exists, that series is in servicing and PRs for it must target `release/X.Y`.
- Among configured semantic-version milestone series newer than the latest existing release branch, the earliest series without a release branch is the sole active default-branch line.
- Later configured series cannot target the default branch yet, because they are not active.
- Earlier configured series cannot target the default branch either, because they are no longer in development; the default branch carries exactly one active line.
- Milestone open/closed state does not affect active-line selection.

### Validation matrix

| PR target | `release/X.Y` exists? | Milestone series | Result |
| --- | --- | --- | --- |
| `release/X.Y` (matching) | n/a | n/a | pass |
| a different `release/*` | n/a | n/a | fail — milestone/branch mismatch |
| default branch | no | active configured series | pass |
| default branch | no | later configured series | fail — not active yet |
| default branch | no | earlier configured series | fail — no longer in development |
| default branch | no | no active series configured | fail — create the next milestone |
| default branch | yes | servicing series | fail — retarget to `release/X.Y`, or use a `Hotfix X.Y.Z` label |
| anything else (`dev/...`) | n/a | n/a | skipped |

PRs into long-lived integration branches are skipped, because the milestone is enforced when that branch is merged into `main` or a release branch. Milestones that don't parse as `major.minor.patch` (e.g. `1.0 Hotfix 2`) emit a `::notice::` rather than failing.

The existing hotfix flow is unaffected: a change that lands in `main` and is cherry-picked carries an in-development milestone plus a `Hotfix X.Y.Z` label, which the failure message points at.

### Reconciling already-open PRs

Cutting `release/X.Y` can both invalidate already-open PRs for the `X.Y.*` series and make the next configured series eligible as the active default-branch line. Because creating a branch emits no pull request activity, `recheck-milestones.yml` closes that gap: on `create` of a `release/*` branch it reruns the milestone check for every semver-milestoned open PR targeting the default branch. Re-running is sufficient because the check queries the live branch list, so the replayed run produces the updated verdict on the same check name that gates the merge.

It lives in a separate workflow so `check-milestone.yml` stays purely pull-request scoped, and so the `actions: write` permission needed to re-run checks is isolated from the PR gate. `create` supports no branch filter, so the job guard skips anything that isn't `release/*`.

### Trigger

`check-milestone.yml` stays on `pull_request` (with `reopened` added alongside the existing types). `edited` covers base-branch changes, so retargeting a PR — manually, or automatically when a stacked PR's parent merges — re-runs the check.

`pull_request_target` was considered and rejected. It evaluates the workflow file on the *base* branch, which means a change to this check can never be exercised by the PR that makes it — confirmed on this PR, where the milestone check ran on neither event until the trigger was reverted. Its one real advantage, preventing a PR author from disabling the check in their own PR, is already covered by the three-reviewer requirement on `.github` changes.

## Issues

None.

## Testing

- `.github/scripts/tests/check-milestone-branch.bats` — 26 Bats tests covering version parsing, release-branch derivation, default-branch vs release-branch validation, integration-branch and non-semver skips, a newly cut release branch, the exact `gh` invocation, and API failure handling, including state-independent active-line selection and later-line transition coverage.
- `.github/scripts/tests/recheck-milestones-for-release-branch.bats` — 17 Bats tests covering release-branch name parsing, milestone matching, run lookup by head SHA, re-run invocation, and failure reporting, including state-independent active-line selection and later-line transition coverage.
- Replayed the rule against real repository data: every open PR and the 100 most recently updated closed PRs in `dotnet/SqlClient` that carry a milestone. Zero false positives.
- Exercised end-to-end on this PR: milestone `7.1.0` targeting `main` passed with `::notice::Milestone '7.1.0' is still in development (no 'release/7.1' branch); targeting 'main' is correct.`, and temporarily setting `7.0.3` failed with the expected `release/7.0` error before being restored.

The `recheck-milestones.yml` path cannot be exercised until a release branch is actually cut, so it degrades loudly — a `::warning::` per PR and a non-zero exit — rather than failing silently.

One known limitation, documented in the script header: a re-run replays the original run's commit, so it executes the workflow and script as they were then, with only the release-branch lookup evaluated live. A PR whose last milestone check predates a change to the check itself will replay the older version and keep its stale result. The window is transitional — any PR with activity after the change has a run containing it — so this is recorded rather than detected, which would cost an extra API call per PR. After the first release branch cut following a change to the check, review the affected PRs by hand.

