### PR TITLE
[6.1.7] Fix flaky code coverage job: pin tool versions and harden thread-job handling

### DIFF
--- a/eng/pipelines/common/templates/jobs/ci-code-coverage-job.yml
+++ b/eng/pipelines/common/templates/jobs/ci-code-coverage-job.yml
@@ -49,6 +49,9 @@ jobs:
     variables:
       netFxDir: $(Build.SourcesDirectory)\coverageNetFx
       netCoreDir: $(Build.SourcesDirectory)\coverageNetCore
+      # The first-run telemetry notice is written to stderr, which PowerShell
+      # surfaces as an error record and fails the step.
+      DOTNET_COVERAGE_TELEMETRY_OPTOUT: 1
 
     steps:
       - ${{if eq(parameters.debug, true)}}:
@@ -68,10 +71,30 @@ jobs:
           debug: ${{ parameters.debug }}
 
       # Install additional dotnet tools.
-      - pwsh: |
-          dotnet tool install --global dotnet-coverage
-          dotnet tool install --global dotnet-reportgenerator-globaltool
-        displayName: Install dotnet tools
+      #
+      # The dotnet CLI tool tasks need a working directory that contains at most
+      # one project file, but they must still obey the repo's NuGet.config.  We
+      # copy the NuGet.config to a temp dir and run the tasks from there; the
+      # tools are still installed globally for subsequent steps to use.
+      #
+      - pwsh: Copy-Item "$(Build.SourcesDirectory)\NuGet.config" "$(Agent.TempDirectory)\"
+        displayName: Copy NuGet.config for tool installs
+
+      - task: DotNetCoreCLI@2
+        displayName: Install dotnet-coverage tool
+        inputs:
+          command: custom
+          custom: tool
+          workingDirectory: $(Agent.TempDirectory)
+          arguments: install --global dotnet-coverage --version 18.9.0
+
+      - task: DotNetCoreCLI@2
+        displayName: Install dotnet-reportgenerator tool
+        inputs:
+          command: custom
+          custom: tool
+          workingDirectory: $(Agent.TempDirectory)
+          arguments: install --global dotnet-reportgenerator-globaltool --version 5.5.11
 
       - ${{ each targetFramework in parameters.targetFrameworks }}:
         - task: DownloadPipelineArtifact@2
@@ -120,20 +143,33 @@ jobs:
             foreach ($file in $toProcess){
                 $jobs += Start-ThreadJob -ScriptBlock {
                     $params = $using:file
-                    & dotnet-coverage merge $($params.File) --output $($params.OutputFile) --output-format xml
+                    # Redirect stderr into stdout so informational tool output
+                    # isn't surfaced as a PowerShell error record.
+                    $out = & dotnet-coverage merge $($params.File) --output $($params.OutputFile) --output-format xml 2>&1
+                    $exitCode = $LASTEXITCODE
+                    $out | Out-String | Write-Output
+                    if ($exitCode -ne 0) {
+                        throw "dotnet-coverage merge failed with exit code $exitCode for $($params.File)."
+                    }
                 }
             }
 
             if ($jobs.Count -eq 0) {
-                Write-Error "No .coverage files found in $InputDirectoryPath. Cannot merge."
-                exit 1
+                throw "No .coverage files found in $InputDirectoryPath. Cannot merge."
             }
 
             Write-Host "Merging started..."
-            Wait-Job -Job $jobs
+            $null = Wait-Job -Job $jobs
+
+            $failed = @($jobs | Where-Object { $_.State -ne 'Completed' })
 
             foreach ($job in $jobs) {
-                Receive-Job -Job $job -Wait -AutoRemoveJob
+                Receive-Job -Job $job -ErrorAction Continue 2>&1 | Out-String | Write-Host
+                Remove-Job -Job $job -Force
+            }
+
+            if ($failed.Count -gt 0) {
+                throw "$($failed.Count) of $($jobs.Count) merge jobs failed for $InputDirectoryPath."
             }
           }
 
@@ -155,24 +191,40 @@ jobs:
           displayName: '[Debug] List converted files'
 
       - pwsh: |
+          function StartReportGenerator {
+            param([string[]]$Arguments)
+
+            Start-ThreadJob -ArgumentList @(,$Arguments) -ScriptBlock {
+              param([string[]]$reportGeneratorArgs)
+
+              # Redirect stderr into stdout so informational tool output isn't
+              # surfaced as a PowerShell error record.
+              $out = & reportgenerator @reportGeneratorArgs 2>&1
+              $exitCode = $LASTEXITCODE
+              $out | Out-String | Write-Output
+              if ($exitCode -ne 0) {
+                  throw "reportgenerator failed with exit code $exitCode."
+              }
+            }
+          }
+
           $jobs = @()
-          $jobs += Start-ThreadJob -ScriptBlock {
-              & reportgenerator "-reports:coverageNetFxXml\*.coveragexml" "-targetdir:coveragereportNetFx" "-reporttypes:Cobertura;" "-assemblyfilters:+microsoft.data.sqlclient.dll" "-sourcedirs:$(Build.SourcesDirectory)\src\Microsoft.Data.SqlClient\netfx\src;$(Build.SourcesDirectory)\src\Microsoft.Data.SqlClient\src" "-classfilters:+Microsoft.Data.*"
-          }
-
-          $jobs += Start-ThreadJob -ScriptBlock {
-              & reportgenerator "-reports:coverageNetCoreXml\*.coveragexml" "-targetdir:coveragereportNetCore" "-reporttypes:Cobertura;" "-assemblyfilters:+microsoft.data.sqlclient.dll" "-sourcedirs:$(Build.SourcesDirectory)\src\Microsoft.Data.SqlClient\netcore\src;$(Build.SourcesDirectory)\src\Microsoft.Data.SqlClient\src" "-classfilters:+Microsoft.Data.*"
-          }
-
-          $jobs += Start-ThreadJob -ScriptBlock {
-              & reportgenerator "-reports:coverageNetCoreXml\*.coveragexml" "-targetdir:coveragereportAddOns" "-reporttypes:Cobertura;" "-assemblyfilters:+microsoft.data.sqlclient.alwaysencrypted.azurekeyvaultprovider.dll" "-sourcedirs:$(Build.SourcesDirectory)\src\Microsoft.Data.SqlClient\add-ons\AzureKeyVaultProvider" "-classfilters:+Microsoft.Data.*"
-          }
+          $jobs += StartReportGenerator @("-reports:coverageNetFxXml\*.coveragexml", "-targetdir:coveragereportNetFx", "-reporttypes:Cobertura;", "-assemblyfilters:+microsoft.data.sqlclient.dll", "-sourcedirs:$(Build.SourcesDirectory)\src\Microsoft.Data.SqlClient\netfx\src;$(Build.SourcesDirectory)\src\Microsoft.Data.SqlClient\src", "-classfilters:+Microsoft.Data.*")
+          $jobs += StartReportGenerator @("-reports:coverageNetCoreXml\*.coveragexml", "-targetdir:coveragereportNetCore", "-reporttypes:Cobertura;", "-assemblyfilters:+microsoft.data.sqlclient.dll", "-sourcedirs:$(Build.SourcesDirectory)\src\Microsoft.Data.SqlClient\netcore\src;$(Build.SourcesDirectory)\src\Microsoft.Data.SqlClient\src", "-classfilters:+Microsoft.Data.*")
+          $jobs += StartReportGenerator @("-reports:coverageNetCoreXml\*.coveragexml", "-targetdir:coveragereportAddOns", "-reporttypes:Cobertura;", "-assemblyfilters:+microsoft.data.sqlclient.alwaysencrypted.azurekeyvaultprovider.dll", "-sourcedirs:$(Build.SourcesDirectory)\src\Microsoft.Data.SqlClient\add-ons\AzureKeyVaultProvider", "-classfilters:+Microsoft.Data.*")
 
           Write-Host "Running ReportGenerator..."
-          Wait-Job -Job $jobs
+          $null = Wait-Job -Job $jobs
+
+          $failed = @($jobs | Where-Object { $_.State -ne 'Completed' })
 
           foreach ($job in $jobs) {
-              Receive-Job -Job $job -Wait -AutoRemoveJob
+              Receive-Job -Job $job -ErrorAction Continue 2>&1 | Out-String | Write-Host
+              Remove-Job -Job $job -Force
+          }
+
+          if ($failed.Count -gt 0) {
+              throw "$($failed.Count) of $($jobs.Count) ReportGenerator jobs failed."
           }
 
           Write-Host "Removing merged XML files..."


### PR DESCRIPTION
## Problem

The `Publish Code Coverage` job has been failing in CI. Example: [run 23310, build 168798](https://sqlclientdrivers.visualstudio.com/public/_build/results?buildId=168798&view=logs&j=b1fd794d-3789-5a59-2151-8b8698a903b9&t=9ca8e947-05f6-5d8c-af37-59b35f02d467&s=0e764f33-bc11-5623-b953-af4d12740068).

No test failed. The `Convert coverage files to xml` step died with a bare `##[error]PowerShell exited with code '1'.`

Root cause: `dotnet-coverage` **18.10.0** emits a first-run telemetry notice on **stderr**:

```
Telemetry
---------
The code coverage tools collect usage data in order to help us improve your experience.
The data is collected by Microsoft. You can opt out of telemetry by setting the
DOTNET_COVERAGE_TELEMETRY_OPTOUT environment variable to '1' ...
```

PowerShell converts native-command stderr into `ErrorRecord`s, which land in each thread job's error stream. `PowerShell@2` defaults to `errorActionPreference: stop`, so the first `Receive-Job` that replayed the notice raised a **terminating** error and `pwsh` exited 1.

Evidence from the log:
- `Merging started...` appears **once** — the script died draining the very first netFx job, so `MergeFiles` for netCore never ran.
- All 151 individual merges reported `Merged into file ...` successfully. The coverage data itself was fine.
- The log ends mid-banner at `Telemetry`, immediately followed by the error.

The tool install was unpinned, so 18.10.0 floated in on its own. The last green run of this job ([build 167409](https://sqlclientdrivers.visualstudio.com/public/_build/results?buildId=167409), 2026-08-16) ran `dotnet-coverage v18.9.0.0` with zero occurrences of "Telemetry" across 36,065 log lines.

## Changes

**Pin the tool versions**
- `dotnet-coverage` → `18.9.0`, `dotnet-reportgenerator-globaltool` → `5.5.11`. These are exactly the versions from the last green run of this job.
- Installs moved from a bare `dotnet tool install` script to `DotNetCoreCLI@2` tasks, with `NuGet.config` copied to `$(Agent.TempDirectory)` so tool restores honour the repo's feeds. This matches the pattern already used on `main`.

**Opt out of the telemetry notice**
- Added `DOTNET_COVERAGE_TELEMETRY_OPTOUT: 1` as a job variable so the banner is never emitted, independent of tool version.

**Harden the thread-job steps**
- Tool invocations now redirect `2>&1` and capture `$LASTEXITCODE`, so informational stderr becomes ordinary output and only a genuine non-zero exit throws. Previously a real `dotnet-coverage` failure was **silently ignored** — the job still reported `Completed`.
- Draining changed to `Receive-Job -ErrorAction Continue 2>&1 | Out-String | Write-Host` plus explicit `Remove-Job`, with job state checked after `Wait-Job` and an explicit throw naming how many jobs failed.
- `Write-Error` + `exit 1` for the "no .coverage files" case became a `throw`, so it doesn't abort the whole script from inside the function.
- ReportGenerator's three near-identical blocks collapsed into a `StartReportGenerator` helper using `-ArgumentList`.

## Notes on version choice

`main` pins `dotnet-coverage` to `18.3.2`, but its coverage job is a different shape — Linux, a single `dotnet-coverage merge` in a plain `script:` step, no ReportGenerator, no thread jobs — so it never exercised this path. Pinning 6.1 to `18.3.2` would be a six-version downgrade to something this job has never run, hence `18.9.0`.

## Validation

- YAML parses cleanly; all 13 embedded `pwsh` scripts pass `[Parser]::ParseFile` with no errors.
- The new thread-job pattern was smoke-tested locally under `$ErrorActionPreference = 'Stop'` with a stub tool: a noisy-but-successful tool no longer fails the step, and a tool exiting non-zero still does.
- Full CI validation pending on this PR.

## Checklist

- [x] Verified against the failing CI run
- [x] Ensure no breaking changes introduced
- [ ] Tests added or updated — n/a, pipeline-only change
- [ ] Public API changes documented — n/a
