### PR TITLE
Stop the localization pipeline from opening duplicate PRs

### DIFF
--- a/eng/pipelines/scripts/Open-LocalizationPr.ps1
+++ b/eng/pipelines/scripts/Open-LocalizationPr.ps1
@@ -182,15 +182,29 @@ function Invoke-GitHubApi {
         $status = $null
         $responseBody = ''
 
+        # PowerShell 7 already carries the response body on the error record and
+        # exposes an HttpResponseMessage, which has no GetResponseStream(). Windows
+        # PowerShell leaves ErrorDetails empty but does expose the stream, so try
+        # the error record first and keep the stream as a fallback.
+        if ($null -ne $_.ErrorDetails -and -not [string]::IsNullOrWhiteSpace($_.ErrorDetails.Message)) {
+            $responseBody = $_.ErrorDetails.Message
+        }
+
         if ($_.Exception.PSObject.Properties.Name -contains 'Response' -and $null -ne $_.Exception.Response) {
             $status = $_.Exception.Response.StatusCode.value__
-            try {
-                $reader = New-Object System.IO.StreamReader($_.Exception.Response.GetResponseStream())
-                $responseBody = $reader.ReadToEnd()
-            }
-            catch {
-                # The response stream may already be consumed; the status code
-                # alone is still useful.
+
+            if ([string]::IsNullOrWhiteSpace($responseBody)) {
+                try {
+                    $stream = $_.Exception.Response.GetResponseStream()
+                    if ($null -ne $stream) {
+                        $reader = New-Object System.IO.StreamReader($stream)
+                        try { $responseBody = $reader.ReadToEnd() } finally { $reader.Dispose() }
+                    }
+                }
+                catch {
+                    # No readable stream (PowerShell 7) or it was already consumed;
+                    # the status code alone is still useful.
+                }
             }
         }
 
@@ -273,10 +287,16 @@ try {
         Remove-Item -LiteralPath $WorkingDirectory -Recurse -Force
     }
 
-    # The token is embedded in the remote URL so git can push without an
-    # interactive credential prompt. Git masks it in its own output, and the
-    # pipeline masks the secret in task logs.
-    $cloneUrl = "https://x-access-token:$AccessToken@github.com/$repoSlug.git"
+    # Authenticate through git's environment-based config rather than the remote
+    # URL, so the token never lands in .git/config, on a process command line, or
+    # in Invoke-Git's exception messages. GIT_CONFIG_* is honoured by git 2.31+
+    # and applies to clone, fetch and push alike.
+    $basicAuth = [Convert]::ToBase64String(
+        [Text.Encoding]::ASCII.GetBytes("x-access-token:$AccessToken"))
+    $env:GIT_CONFIG_COUNT = '1'
+    $env:GIT_CONFIG_KEY_0 = 'http.https://github.com/.extraheader'
+    $env:GIT_CONFIG_VALUE_0 = "AUTHORIZATION: basic $basicAuth"
+    $cloneUrl = "https://github.com/$repoSlug.git"
 
     Write-Host "Cloning $repoSlug@$BaseBranch..."
     Invoke-Git clone --branch $BaseBranch --quiet $cloneUrl $WorkingDirectory
@@ -345,10 +365,18 @@ try {
         Write-Host "Branch '$BranchName' already has these exact changes on top of '$BaseBranch'. Skipping push."
     }
     elseif ($DryRun) {
-        Write-Host "[DryRun] Would force-push '$BranchName' to $repoSlug."
+        Write-Host "[DryRun] Would push '$BranchName' to $repoSlug."
     }
     else {
-        Invoke-Git push origin "${BranchName}:refs/heads/$BranchName" --force --quiet
+        # Pin the push to the remote SHA observed above so an overlapping run that
+        # already updated the branch makes this push fail loudly, instead of
+        # silently discarding the other run's localization result.
+        $pushArgs = @('push', 'origin', "${BranchName}:refs/heads/$BranchName", '--quiet')
+        if ($remoteBranchExists) {
+            $pushArgs += "--force-with-lease=refs/heads/${BranchName}:$($remoteBranchSha.Trim())"
+        }
+
+        Invoke-Git @pushArgs
         Write-Host "Pushed '$BranchName'."
     }
 
@@ -415,6 +443,10 @@ try {
 }
 finally {
     Set-Location -LiteralPath $originalLocation
+
+    Remove-Item Env:\GIT_CONFIG_COUNT -ErrorAction SilentlyContinue
+    Remove-Item Env:\GIT_CONFIG_KEY_0 -ErrorAction SilentlyContinue
+    Remove-Item Env:\GIT_CONFIG_VALUE_0 -ErrorAction SilentlyContinue
 
     if ($ownedWorkingDirectory -and (Test-Path -LiteralPath $WorkingDirectory)) {
         Remove-Item -LiteralPath $WorkingDirectory -Recurse -Force -ErrorAction SilentlyContinue

--- a/eng/pipelines/scripts/Open-LocalizationPr.ps1
+++ b/eng/pipelines/scripts/Open-LocalizationPr.ps1
@@ -1,0 +1,394 @@
+<#
+.SYNOPSIS
+    Publishes OneLocBuild-generated localized resource files to GitHub as a
+    single, continuously-updated pull request.
+
+.DESCRIPTION
+    The Localization-CI pipeline regenerates the localized `Strings.*.resx`
+    files on every scheduled run. Because the generated content is identical
+    until a previous localization PR is merged, naively opening a new PR per
+    run produces a pile of byte-for-byte duplicate PRs.
+
+    This script makes the publish step idempotent:
+
+      1. Clones the target GitHub repository at the base branch.
+      2. Copies the freshly generated localized resource files into the clone.
+      3. If the content matches the base branch, exits without doing anything.
+      4. Otherwise commits onto a *stable* branch name, force-pushes it, and
+         reuses the existing open pull request if one is already present.
+
+    The net effect is at most one open localization PR at any time. Subsequent
+    runs refresh that PR in place instead of opening another one.
+
+.PARAMETER GitHubRepository
+    The target repository in "owner/repo" form. A trailing ".git" is tolerated
+    so the existing $(GitHubRepository) pipeline variable can be passed as-is.
+
+.PARAMETER AccessToken
+    A GitHub token with "contents: write" and "pull requests: write" on the
+    target repository. Defaults to the GITHUB_TOKEN environment variable.
+
+.PARAMETER SourceDirectory
+    The directory holding the OneLocBuild output. Localized files are resolved
+    relative to this path using ResourcesPath. Defaults to the current
+    directory.
+
+.PARAMETER WorkingDirectory
+    The directory the target repository is cloned into. Defaults to a new
+    "loc-pr-<guid>" folder under the system temp path, which is removed when
+    the script finishes.
+
+.PARAMETER BaseBranch
+    The branch the pull request targets. Defaults to "main".
+
+.PARAMETER BranchName
+    The stable branch the localized files are published to. Reusing one branch
+    name across runs is what allows the pull request to be reused. Defaults to
+    "dev/automation/onelocbuild".
+
+.PARAMETER ResourcesPath
+    Repository-relative path to the resources folder. Defaults to the
+    Microsoft.Data.SqlClient resources folder.
+
+.PARAMETER ResourceFilePattern
+    Filename pattern for the localized resource files to publish. Defaults to
+    "Strings.*.resx", which matches the localized files but not the English
+    "Strings.resx" source.
+
+.NOTES
+    Intended to be invoked from the internal Localization-CI pipeline. It is
+    safe to re-run: with no localization changes pending it is a no-op, and
+    with changes pending it converges on a single open pull request.
+#>
+
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the MIT license.
+# See the LICENSE file in the project root for more information.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$GitHubRepository,
+
+    [string]$AccessToken = $env:GITHUB_TOKEN,
+
+    [string]$SourceDirectory = (Get-Location).Path,
+
+    [string]$WorkingDirectory,
+
+    [string]$BaseBranch = 'main',
+
+    [string]$BranchName = 'dev/automation/onelocbuild',
+
+    [string]$ResourcesPath = 'src/Microsoft.Data.SqlClient/src/Resources',
+
+    [string]$ResourceFilePattern = 'Strings.*.resx'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Several git invocations below use the exit code as a signal (for example
+# "git diff --cached --quiet" returns 1 when there are staged changes). On
+# PowerShell 7.3+ that would otherwise be turned into a terminating error.
+$PSNativeCommandUseErrorActionPreference = $false
+
+$PrTitle = '[Scheduled Run] Localized resource files from OneLocBuild'
+
+#region Helper Functions
+
+function Get-RepositorySlug {
+    <#
+    .SYNOPSIS
+        Normalizes a repository reference into "owner/repo" form.
+    #>
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Repository
+    )
+
+    $slug = $Repository.Trim().TrimEnd('/')
+    if ($slug.EndsWith('.git', [StringComparison]::OrdinalIgnoreCase)) {
+        $slug = $slug.Substring(0, $slug.Length - 4)
+    }
+
+    if ($slug -notmatch '^[^/\s]+/[^/\s]+$') {
+        throw "GitHubRepository must be in 'owner/repo' form, but was '$Repository'."
+    }
+
+    return $slug
+}
+
+function Get-PullRequestBody {
+    <#
+    .SYNOPSIS
+        Builds the pull request description.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$Branch,
+        [Parameter(Mandatory)][datetime]$UpdatedUtc
+    )
+
+    $timestamp = $UpdatedUtc.ToString('yyyy-MM-dd HH:mm')
+
+    return @"
+Automated PR created from the OneLocBuild scheduled pipeline run.
+
+Contains updated localized ``Strings.*.resx`` resource files.
+
+This pull request is refreshed in place by every scheduled localization run, so
+there is only ever one open localization PR. Merging it lets the next run start
+from a clean base; leaving it open simply keeps it up to date.
+
+- Branch: ``$Branch``
+- Last updated: $timestamp UTC
+"@
+}
+
+function Invoke-GitHubApi {
+    <#
+    .SYNOPSIS
+        Calls a GitHub REST API endpoint, surfacing the response body on error.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$Uri,
+        [string]$Method = 'GET',
+        [object]$Body = $null,
+        [Parameter(Mandatory)][hashtable]$Headers
+    )
+
+    $params = @{
+        Uri     = $Uri
+        Method  = $Method
+        Headers = $Headers
+    }
+
+    if ($null -ne $Body) {
+        $params['Body'] = ($Body | ConvertTo-Json -Depth 10 -Compress)
+        $params['ContentType'] = 'application/json'
+    }
+
+    try {
+        return Invoke-RestMethod @params -ErrorAction Stop
+    }
+    catch {
+        $status = $null
+        $responseBody = ''
+
+        if ($_.Exception.PSObject.Properties.Name -contains 'Response' -and $null -ne $_.Exception.Response) {
+            $status = $_.Exception.Response.StatusCode.value__
+            try {
+                $reader = New-Object System.IO.StreamReader($_.Exception.Response.GetResponseStream())
+                $responseBody = $reader.ReadToEnd()
+            }
+            catch {
+                # The response stream may already be consumed; the status code
+                # alone is still useful.
+            }
+        }
+
+        Write-Host "##vso[task.logissue type=error]GitHub API $Method $Uri failed (HTTP $status)."
+        if ($responseBody) {
+            Write-Host "##vso[task.logissue type=error]Response: $responseBody"
+        }
+
+        throw
+    }
+}
+
+function Invoke-Git {
+    <#
+    .SYNOPSIS
+        Runs a git command and throws if it reports failure.
+    #>
+    param(
+        [Parameter(Mandatory, ValueFromRemainingArguments)][string[]]$Arguments
+    )
+
+    & git @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($Arguments -join ' ') failed with exit code $LASTEXITCODE."
+    }
+}
+
+#endregion
+
+#region Validation
+
+if ([string]::IsNullOrWhiteSpace($AccessToken)) {
+    throw 'A GitHub access token is required. Set GITHUB_TOKEN or pass -AccessToken.'
+}
+
+$repoSlug = Get-RepositorySlug -Repository $GitHubRepository
+$repoOwner = $repoSlug.Split('/')[0]
+
+$sourceResources = Join-Path $SourceDirectory $ResourcesPath
+if (-not (Test-Path -LiteralPath $sourceResources)) {
+    throw "Localized resources folder not found at '$sourceResources'."
+}
+
+$localizedFiles = @(Get-ChildItem -Path $sourceResources -Filter $ResourceFilePattern -File)
+if ($localizedFiles.Count -eq 0) {
+    throw "No files matching '$ResourceFilePattern' were found in '$sourceResources'. Did the OneLocBuild step run?"
+}
+
+$ownedWorkingDirectory = $false
+if ([string]::IsNullOrWhiteSpace($WorkingDirectory)) {
+    $WorkingDirectory = Join-Path ([System.IO.Path]::GetTempPath()) "loc-pr-$([guid]::NewGuid().ToString('n'))"
+    $ownedWorkingDirectory = $true
+}
+
+$headers = @{
+    'Authorization'        = "Bearer $AccessToken"
+    'Accept'               = 'application/vnd.github+json'
+    'X-GitHub-Api-Version' = '2022-11-28'
+    'User-Agent'           = 'SqlClient-DevOps'
+}
+
+#endregion
+
+Write-Host '=== Publish localized resources to GitHub ==='
+Write-Host "Repository : $repoSlug"
+Write-Host "Base       : $BaseBranch"
+Write-Host "Branch     : $BranchName"
+Write-Host "Resources  : $($localizedFiles.Count) file(s) from $sourceResources"
+Write-Host ''
+
+$originalLocation = Get-Location
+
+try {
+    #region Clone and stage
+
+    if (Test-Path -LiteralPath $WorkingDirectory) {
+        Remove-Item -LiteralPath $WorkingDirectory -Recurse -Force
+    }
+
+    # The token is embedded in the remote URL so git can push without an
+    # interactive credential prompt. Git masks it in its own output, and the
+    # pipeline masks the secret in task logs.
+    $cloneUrl = "https://x-access-token:$AccessToken@github.com/$repoSlug.git"
+
+    Write-Host "Cloning $repoSlug@$BaseBranch..."
+    Invoke-Git clone --branch $BaseBranch --quiet $cloneUrl $WorkingDirectory
+
+    Set-Location -LiteralPath $WorkingDirectory
+
+    Invoke-Git config user.email 'sqlclient@microsoft.com'
+    Invoke-Git config user.name 'SqlClient DevOps'
+
+    $baseSha = (& git rev-parse HEAD).Trim()
+    Write-Host "Base HEAD  : $baseSha"
+
+    # Fetch the automation branch if it already exists so we can tell an actual
+    # content change apart from a re-run that would produce an identical commit.
+    & git fetch origin "refs/heads/${BranchName}:refs/remotes/origin/$BranchName" --quiet 2>&1 | Out-Null
+    $remoteBranchSha = (& git rev-parse --verify --quiet "refs/remotes/origin/$BranchName")
+    $remoteBranchExists = -not [string]::IsNullOrWhiteSpace($remoteBranchSha)
+
+    if ($remoteBranchExists) {
+        Write-Host "Branch HEAD: $($remoteBranchSha.Trim())"
+    }
+
+    $targetResources = Join-Path $WorkingDirectory $ResourcesPath
+    if (-not (Test-Path -LiteralPath $targetResources)) {
+        throw "Resources folder '$ResourcesPath' does not exist in $repoSlug@$BaseBranch."
+    }
+
+    Copy-Item -Path (Join-Path $sourceResources $ResourceFilePattern) -Destination $targetResources -Force
+
+    Invoke-Git add --all -- $ResourcesPath
+
+    & git diff --cached --quiet
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host ''
+        Write-Host "No localization changes relative to '$BaseBranch'. Nothing to publish."
+        exit 0
+    }
+
+    #endregion
+
+    #region Commit and push
+
+    Write-Host ''
+    Write-Host "Committing localized resources onto '$BranchName'..."
+
+    # Always rebuild the branch from the current base so the pull request stays
+    # mergeable, rather than accumulating commits run over run.
+    Invoke-Git checkout -B $BranchName --quiet
+    Invoke-Git commit --quiet --message $PrTitle
+
+    $newTree = (& git rev-parse 'HEAD^{tree}').Trim()
+
+    $branchUpToDate = $false
+    if ($remoteBranchExists) {
+        $remoteTree = (& git rev-parse "refs/remotes/origin/$BranchName^{tree}" 2>$null)
+        $remoteParent = (& git rev-parse --verify --quiet "refs/remotes/origin/$BranchName^")
+
+        $branchUpToDate =
+            $null -ne $remoteTree -and
+            $remoteTree.Trim() -eq $newTree -and
+            $null -ne $remoteParent -and
+            $remoteParent.Trim() -eq $baseSha
+    }
+
+    if ($branchUpToDate) {
+        Write-Host "Branch '$BranchName' already has these exact changes on top of '$BaseBranch'. Skipping push."
+    }
+    else {
+        Invoke-Git push origin "${BranchName}:refs/heads/$BranchName" --force --quiet
+        Write-Host "Pushed '$BranchName'."
+    }
+
+    #endregion
+
+    #region Create or reuse the pull request
+
+    Write-Host ''
+    Write-Host 'Checking for an existing open pull request...'
+
+    $encodedHead = [Uri]::EscapeDataString("${repoOwner}:$BranchName")
+    $encodedBase = [Uri]::EscapeDataString($BaseBranch)
+    $listUri = "https://api.github.com/repos/$repoSlug/pulls?state=open&head=$encodedHead&base=$encodedBase"
+
+    $openPrs = @(Invoke-GitHubApi -Uri $listUri -Headers $headers)
+    $existingPr = $openPrs | Select-Object -First 1
+
+    $body = Get-PullRequestBody -Branch $BranchName -UpdatedUtc ([datetime]::UtcNow)
+
+    if ($existingPr) {
+        $prNumber = $existingPr.number
+        Write-Host "Reusing open PR #$prNumber - refreshing its description."
+
+        $patchUri = "https://api.github.com/repos/$repoSlug/pulls/$prNumber"
+        Invoke-GitHubApi -Uri $patchUri -Method 'PATCH' -Headers $headers -Body @{
+            title = $PrTitle
+            body  = $body
+        } | Out-Null
+
+        Write-Host "Pull request updated: $($existingPr.html_url)"
+    }
+    else {
+        Write-Host 'No open pull request found. Creating one...'
+
+        $createUri = "https://api.github.com/repos/$repoSlug/pulls"
+        $newPr = Invoke-GitHubApi -Uri $createUri -Method 'POST' -Headers $headers -Body @{
+            title = $PrTitle
+            head  = $BranchName
+            base  = $BaseBranch
+            body  = $body
+        }
+
+        Write-Host "Pull request created: $($newPr.html_url)"
+    }
+
+    #endregion
+
+    Write-Host ''
+    Write-Host '=== Done ==='
+}
+finally {
+    Set-Location -LiteralPath $originalLocation
+
+    if ($ownedWorkingDirectory -and (Test-Path -LiteralPath $WorkingDirectory)) {
+        Remove-Item -LiteralPath $WorkingDirectory -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/eng/pipelines/scripts/Open-LocalizationPr.ps1
+++ b/eng/pipelines/scripts/Open-LocalizationPr.ps1
@@ -55,6 +55,12 @@
     "Strings.*.resx", which matches the localized files but not the English
     "Strings.resx" source.
 
+.PARAMETER DryRun
+    Performs every read-only step - clone, copy, change detection and the
+    existing-pull-request lookup - but does not push the branch and does not
+    create or update a pull request. Use this to validate pipeline wiring
+    (paths, token scopes, OneLocBuild output) without publishing anything.
+
 .NOTES
     Intended to be invoked from the internal Localization-CI pipeline. It is
     safe to re-run: with no localization changes pending it is a no-op, and
@@ -82,7 +88,9 @@ param(
 
     [string]$ResourcesPath = 'src/Microsoft.Data.SqlClient/src/Resources',
 
-    [string]$ResourceFilePattern = 'Strings.*.resx'
+    [string]$ResourceFilePattern = 'Strings.*.resx',
+
+    [switch]$DryRun
 )
 
 Set-StrictMode -Version Latest
@@ -251,6 +259,9 @@ Write-Host "Repository : $repoSlug"
 Write-Host "Base       : $BaseBranch"
 Write-Host "Branch     : $BranchName"
 Write-Host "Resources  : $($localizedFiles.Count) file(s) from $sourceResources"
+if ($DryRun) {
+    Write-Host 'Mode       : DRY RUN (no push, no pull request changes)'
+}
 Write-Host ''
 
 $originalLocation = Get-Location
@@ -333,6 +344,9 @@ try {
     if ($branchUpToDate) {
         Write-Host "Branch '$BranchName' already has these exact changes on top of '$BaseBranch'. Skipping push."
     }
+    elseif ($DryRun) {
+        Write-Host "[DryRun] Would force-push '$BranchName' to $repoSlug."
+    }
     else {
         Invoke-Git push origin "${BranchName}:refs/heads/$BranchName" --force --quiet
         Write-Host "Pushed '$BranchName'."
@@ -356,15 +370,24 @@ try {
 
     if ($existingPr) {
         $prNumber = $existingPr.number
-        Write-Host "Reusing open PR #$prNumber - refreshing its description."
 
-        $patchUri = "https://api.github.com/repos/$repoSlug/pulls/$prNumber"
-        Invoke-GitHubApi -Uri $patchUri -Method 'PATCH' -Headers $headers -Body @{
-            title = $PrTitle
-            body  = $body
-        } | Out-Null
+        if ($DryRun) {
+            Write-Host "[DryRun] Would refresh open PR #$prNumber ($($existingPr.html_url))."
+        }
+        else {
+            Write-Host "Reusing open PR #$prNumber - refreshing its description."
 
-        Write-Host "Pull request updated: $($existingPr.html_url)"
+            $patchUri = "https://api.github.com/repos/$repoSlug/pulls/$prNumber"
+            Invoke-GitHubApi -Uri $patchUri -Method 'PATCH' -Headers $headers -Body @{
+                title = $PrTitle
+                body  = $body
+            } | Out-Null
+
+            Write-Host "Pull request updated: $($existingPr.html_url)"
+        }
+    }
+    elseif ($DryRun) {
+        Write-Host "[DryRun] No open pull request found. Would create one ($BranchName -> $BaseBranch)."
     }
     else {
         Write-Host 'No open pull request found. Creating one...'
@@ -383,7 +406,12 @@ try {
     #endregion
 
     Write-Host ''
-    Write-Host '=== Done ==='
+    if ($DryRun) {
+        Write-Host '=== Done (dry run - nothing was published) ==='
+    }
+    else {
+        Write-Host '=== Done ==='
+    }
 }
 finally {
     Set-Location -LiteralPath $originalLocation

--- a/eng/pipelines/scripts/tests/Open-LocalizationPr.Tests.ps1
+++ b/eng/pipelines/scripts/tests/Open-LocalizationPr.Tests.ps1
@@ -242,4 +242,50 @@ Describe 'Open-LocalizationPr.ps1' {
             (Get-RestCallCount -Method 'POST' -UriPattern '*/pulls') | Should -Be 0
         }
     }
+
+    Context 'When running in dry-run mode' {
+
+        It 'Neither pushes nor creates a pull request' {
+            & $global:scriptPath `
+                -GitHubRepository 'dotnet/SqlClient' `
+                -AccessToken 'token' `
+                -SourceDirectory $global:sourceDir `
+                -WorkingDirectory $global:workDir `
+                -DryRun
+
+            @($global:gitCalls | Where-Object { $_ -like 'push*' }).Count | Should -Be 0
+            (Get-RestCallCount -Method 'POST' -UriPattern '*/pulls') | Should -Be 0
+            (Get-RestCallCount -Method 'PATCH' -UriPattern '*/pulls/*') | Should -Be 0
+        }
+
+        It 'Still performs the existing pull request lookup' {
+            & $global:scriptPath `
+                -GitHubRepository 'dotnet/SqlClient' `
+                -AccessToken 'token' `
+                -SourceDirectory $global:sourceDir `
+                -WorkingDirectory $global:workDir `
+                -DryRun
+
+            (Get-RestCallCount -Method 'GET' -UriPattern '*/pulls?*') | Should -Be 1
+        }
+
+        It 'Does not update an existing pull request' {
+            $global:remoteSha = 'remote0000'
+            $global:remoteTree = 'differenttree'
+            $global:remoteParent = 'oldbase000'
+            $global:openPullRequests = @(
+                @{ number = 4612; html_url = 'https://github.com/dotnet/SqlClient/pull/4612' }
+            )
+
+            & $global:scriptPath `
+                -GitHubRepository 'dotnet/SqlClient' `
+                -AccessToken 'token' `
+                -SourceDirectory $global:sourceDir `
+                -WorkingDirectory $global:workDir `
+                -DryRun
+
+            @($global:gitCalls | Where-Object { $_ -like 'push*' }).Count | Should -Be 0
+            (Get-RestCallCount -Method 'PATCH' -UriPattern '*/pulls/4612') | Should -Be 0
+        }
+    }
 }

--- a/eng/pipelines/scripts/tests/Open-LocalizationPr.Tests.ps1
+++ b/eng/pipelines/scripts/tests/Open-LocalizationPr.Tests.ps1
@@ -1,0 +1,245 @@
+<#
+.SYNOPSIS
+    Pester tests for Open-LocalizationPr.ps1.
+
+.DESCRIPTION
+    These tests focus on the de-duplication behaviour: a scheduled run must
+    reuse the existing open localization pull request rather than opening a new
+    one, and must do nothing at all when there is no localization delta.
+
+    'git' and 'Invoke-RestMethod' are mocked, so no network or repository
+    access is required.
+#>
+
+BeforeAll {
+    $global:scriptPath = Join-Path $PSScriptRoot '..' 'Open-LocalizationPr.ps1'
+    $global:resourcesPath = 'src/Microsoft.Data.SqlClient/src/Resources'
+
+    function New-TempDirectoryPath {
+        return Join-Path ([System.IO.Path]::GetTempPath()) "loc-test-$([guid]::NewGuid().ToString('n'))"
+    }
+
+    function New-SourceTree {
+        $root = New-TempDirectoryPath
+        $resources = Join-Path $root $global:resourcesPath
+        New-Item -ItemType Directory -Path $resources -Force | Out-Null
+
+        foreach ($culture in @('de', 'fr', 'ja')) {
+            Set-Content -Path (Join-Path $resources "Strings.$culture.resx") -Value '<root />'
+        }
+
+        return $root
+    }
+
+    function Get-RestCallCount {
+        param(
+            [Parameter(Mandatory)][string]$Method,
+            [Parameter(Mandatory)][string]$UriPattern
+        )
+
+        return @($global:restCalls | Where-Object { $_.Method -eq $Method -and $_.Uri -like $UriPattern }).Count
+    }
+
+    function Get-RestCallsTo {
+        param(
+            [Parameter(Mandatory)][string]$Method,
+            [Parameter(Mandatory)][string]$UriPattern
+        )
+
+        return , @($global:restCalls | Where-Object { $_.Method -eq $Method -and $_.Uri -like $UriPattern })
+    }
+}
+
+Describe 'Open-LocalizationPr.ps1' {
+
+    BeforeAll {
+        Mock -CommandName 'git' -MockWith {
+            $joined = $args -join ' '
+            $global:gitCalls += $joined
+            $global:LASTEXITCODE = 0
+
+            if ($joined -like 'clone*') {
+                # Stand in for a real clone so the script finds the expected layout.
+                New-Item -ItemType Directory -Force -Path (Join-Path $global:workDir $global:resourcesPath) | Out-Null
+                return
+            }
+
+            if ($joined -like 'diff --cached --quiet*') {
+                $global:LASTEXITCODE = $global:diffExitCode
+                return
+            }
+
+            if ($joined -like 'rev-parse HEAD^{tree}*') { return $global:localTree }
+            if ($joined -like 'rev-parse HEAD*') { return $global:baseSha }
+            if ($joined -like 'rev-parse *origin/*^{tree}*') { return $global:remoteTree }
+            if ($joined -like 'rev-parse *origin/*^') { return $global:remoteParent }
+            if ($joined -like 'rev-parse *origin/*') { return $global:remoteSha }
+
+            return $null
+        }
+
+        Mock -CommandName 'Invoke-RestMethod' -MockWith {
+            $global:restCalls += @{ Method = $Method; Uri = $Uri; Body = $Body }
+
+            if ($Method -eq 'GET') {
+                return $global:openPullRequests
+            }
+
+            return @{ number = 999; html_url = 'https://github.com/dotnet/SqlClient/pull/999' }
+        }
+    }
+
+    BeforeEach {
+        $global:gitCalls = @()
+        $global:restCalls = @()
+        $global:diffExitCode = 1          # by default, there is a localization delta
+        $global:baseSha = 'base000000'
+        $global:localTree = 'tree111111'
+        $global:remoteSha = $null         # by default, the branch does not exist yet
+        $global:remoteTree = $null
+        $global:remoteParent = $null
+        $global:openPullRequests = @()
+
+        $global:sourceDir = New-SourceTree
+        $global:workDir = New-TempDirectoryPath
+    }
+
+    AfterEach {
+        foreach ($path in @($global:sourceDir, $global:workDir)) {
+            if ($path -and (Test-Path -LiteralPath $path)) {
+                Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    Context 'Input validation' {
+
+        It 'Requires an access token' {
+            { & $global:scriptPath -GitHubRepository 'dotnet/SqlClient' -AccessToken '' -SourceDirectory $global:sourceDir } |
+                Should -Throw '*access token is required*'
+        }
+
+        It 'Rejects a repository that is not in owner/repo form' {
+            { & $global:scriptPath -GitHubRepository 'SqlClient' -AccessToken 'token' -SourceDirectory $global:sourceDir } |
+                Should -Throw "*'owner/repo' form*"
+        }
+
+        It 'Fails when the localized resources are missing' {
+            Remove-Item -Path (Join-Path $global:sourceDir $global:resourcesPath 'Strings.*.resx') -Force
+
+            { & $global:scriptPath -GitHubRepository 'dotnet/SqlClient' -AccessToken 'token' -SourceDirectory $global:sourceDir } |
+                Should -Throw '*Did the OneLocBuild step run?*'
+        }
+    }
+
+    Context 'When there is no localization delta' {
+
+        It 'Does not push a branch or touch the GitHub API' {
+            $global:diffExitCode = 0
+
+            & $global:scriptPath `
+                -GitHubRepository 'dotnet/SqlClient' `
+                -AccessToken 'token' `
+                -SourceDirectory $global:sourceDir `
+                -WorkingDirectory $global:workDir
+
+            $global:restCalls.Count | Should -Be 0
+            @($global:gitCalls | Where-Object { $_ -like 'push*' }).Count | Should -Be 0
+            @($global:gitCalls | Where-Object { $_ -like 'commit*' }).Count | Should -Be 0
+        }
+    }
+
+    Context 'When a localization pull request is already open' {
+
+        BeforeEach {
+            $global:openPullRequests = @(
+                @{ number = 4612; html_url = 'https://github.com/dotnet/SqlClient/pull/4612' }
+            )
+        }
+
+        It 'Updates the existing pull request instead of opening another one' {
+            & $global:scriptPath `
+                -GitHubRepository 'dotnet/SqlClient' `
+                -AccessToken 'token' `
+                -SourceDirectory $global:sourceDir `
+                -WorkingDirectory $global:workDir
+
+            (Get-RestCallCount -Method 'POST' -UriPattern '*/pulls') | Should -Be 0
+            (Get-RestCallCount -Method 'PATCH' -UriPattern '*/pulls/4612') | Should -Be 1
+        }
+
+        It 'Looks the pull request up by the stable head branch' {
+            & $global:scriptPath `
+                -GitHubRepository 'dotnet/SqlClient' `
+                -AccessToken 'token' `
+                -SourceDirectory $global:sourceDir `
+                -WorkingDirectory $global:workDir
+
+            $lookups = Get-RestCallsTo -Method 'GET' -UriPattern '*/pulls?*'
+            $lookups.Count | Should -Be 1
+            $lookups[0].Uri | Should -BeLike '*state=open*'
+            $lookups[0].Uri | Should -BeLike '*dotnet%3Adev%2Fautomation%2Fonelocbuild*'
+        }
+    }
+
+    Context 'When no localization pull request is open' {
+
+        It 'Creates exactly one pull request' {
+            & $global:scriptPath `
+                -GitHubRepository 'dotnet/SqlClient' `
+                -AccessToken 'token' `
+                -SourceDirectory $global:sourceDir `
+                -WorkingDirectory $global:workDir
+
+            (Get-RestCallCount -Method 'POST' -UriPattern '*/repos/dotnet/SqlClient/pulls') | Should -Be 1
+        }
+
+        It 'Pushes a stable branch name rather than a timestamped one' {
+            & $global:scriptPath `
+                -GitHubRepository 'dotnet/SqlClient' `
+                -AccessToken 'token' `
+                -SourceDirectory $global:sourceDir `
+                -WorkingDirectory $global:workDir
+
+            $push = @($global:gitCalls | Where-Object { $_ -like 'push*' })
+            $push.Count | Should -Be 1
+            $push[0] | Should -BeLike '*dev/automation/onelocbuild:refs/heads/dev/automation/onelocbuild*'
+            $push[0] | Should -Not -Match 'onelocbuild-\d'
+        }
+
+        It 'Normalizes a repository value that carries a .git suffix' {
+            & $global:scriptPath `
+                -GitHubRepository 'dotnet/SqlClient.git' `
+                -AccessToken 'token' `
+                -SourceDirectory $global:sourceDir `
+                -WorkingDirectory $global:workDir
+
+            (Get-RestCallCount -Method 'POST' -UriPattern 'https://api.github.com/repos/dotnet/SqlClient/pulls') |
+                Should -Be 1
+        }
+    }
+
+    Context 'When the branch already carries the identical change' {
+
+        BeforeEach {
+            $global:remoteSha = 'remote0000'
+            $global:remoteTree = $global:localTree
+            $global:remoteParent = $global:baseSha
+            $global:openPullRequests = @(
+                @{ number = 4612; html_url = 'https://github.com/dotnet/SqlClient/pull/4612' }
+            )
+        }
+
+        It 'Skips the force-push but still keeps the pull request current' {
+            & $global:scriptPath `
+                -GitHubRepository 'dotnet/SqlClient' `
+                -AccessToken 'token' `
+                -SourceDirectory $global:sourceDir `
+                -WorkingDirectory $global:workDir
+
+            @($global:gitCalls | Where-Object { $_ -like 'push*' }).Count | Should -Be 0
+            (Get-RestCallCount -Method 'PATCH' -UriPattern '*/pulls/4612') | Should -Be 1
+            (Get-RestCallCount -Method 'POST' -UriPattern '*/pulls') | Should -Be 0
+        }
+    }
+}

--- a/eng/pipelines/scripts/tests/Open-LocalizationPr.Tests.ps1
+++ b/eng/pipelines/scripts/tests/Open-LocalizationPr.Tests.ps1
@@ -243,6 +243,72 @@ Describe 'Open-LocalizationPr.ps1' {
         }
     }
 
+    Context 'When pushing over an existing remote branch' {
+
+        BeforeEach {
+            $global:remoteSha = 'remote0000'
+            $global:remoteTree = 'differenttree'
+            $global:remoteParent = 'staleparent'
+            $global:openPullRequests = @(
+                @{ number = 4612; html_url = 'https://github.com/dotnet/SqlClient/pull/4612' }
+            )
+        }
+
+        It 'Leases the push against the observed remote SHA' {
+            & $global:scriptPath `
+                -GitHubRepository 'dotnet/SqlClient' `
+                -AccessToken 'token' `
+                -SourceDirectory $global:sourceDir `
+                -WorkingDirectory $global:workDir
+
+            $push = @($global:gitCalls | Where-Object { $_ -like 'push*' })
+            $push.Count | Should -Be 1
+            $push[0] | Should -BeLike '*--force-with-lease=refs/heads/dev/automation/onelocbuild:remote0000*'
+            $push[0] | Should -Not -Match '(^|\s)--force(\s|$)'
+        }
+    }
+
+    Context 'When the remote branch does not exist yet' {
+
+        It 'Pushes without forcing' {
+            & $global:scriptPath `
+                -GitHubRepository 'dotnet/SqlClient' `
+                -AccessToken 'token' `
+                -SourceDirectory $global:sourceDir `
+                -WorkingDirectory $global:workDir
+
+            $push = @($global:gitCalls | Where-Object { $_ -like 'push*' })
+            $push.Count | Should -Be 1
+            $push[0] | Should -Not -Match '--force'
+        }
+    }
+
+    Context 'Credential handling' {
+
+        It 'Keeps the access token out of the git remote URL' {
+            & $global:scriptPath `
+                -GitHubRepository 'dotnet/SqlClient' `
+                -AccessToken 'super-secret-token-value' `
+                -SourceDirectory $global:sourceDir `
+                -WorkingDirectory $global:workDir
+
+            $global:gitCalls | Should -Not -Match 'super-secret-token-value'
+            @($global:gitCalls | Where-Object { $_ -like 'clone*' })[0] |
+                Should -BeLike '*https://github.com/dotnet/SqlClient.git*'
+        }
+
+        It 'Clears the git credential environment afterwards' {
+            & $global:scriptPath `
+                -GitHubRepository 'dotnet/SqlClient' `
+                -AccessToken 'token' `
+                -SourceDirectory $global:sourceDir `
+                -WorkingDirectory $global:workDir
+
+            $env:GIT_CONFIG_COUNT | Should -BeNullOrEmpty
+            $env:GIT_CONFIG_VALUE_0 | Should -BeNullOrEmpty
+        }
+    }
+
     Context 'When running in dry-run mode' {
 
         It 'Neither pushes nor creates a pull request' {

--- a/eng/pipelines/scripts/tests/README.md
+++ b/eng/pipelines/scripts/tests/README.md
@@ -1,0 +1,29 @@
+# Pipeline Script Tests
+
+Pester tests for the PowerShell helpers under `eng/pipelines/scripts/`.
+
+## Prerequisites
+
+These tests require **Pester v5 or later**:
+
+```powershell
+Install-Module Pester -MinimumVersion 5.0 -Scope CurrentUser -Force -SkipPublisherCheck
+```
+
+## Running the tests
+
+```powershell
+Import-Module Pester -MinimumVersion 5.0
+Invoke-Pester ./eng/pipelines/scripts/tests/
+```
+
+Add `-Output Detailed` to see per-test results.
+
+## Test files
+
+| File | Covers |
+| ---- | ------ |
+| `Open-LocalizationPr.Tests.ps1` | `Open-LocalizationPr.ps1` — de-duplication of the scheduled localization pull request. |
+
+`git` and `Invoke-RestMethod` are mocked, so the tests never touch the network
+or a real repository.


### PR DESCRIPTION
## Problem

The `Localization-CI` pipeline has opened four byte-for-byte identical pull requests — #4607, #4612, #4613 and #4614 — one per night, each the same +2/-2 change across the same 13 `Strings.*.resx` files.

## Root cause

Ours, not the localization team's or `OneLocBuild`'s.

`Localization-CI` is a classic (designer) ADO pipeline, so its logic isn't in this repo. Its last step, *"Open PR on GitHub"*, is inline PowerShell that builds a timestamped branch and unconditionally `POST`s a new PR:

```powershell
$timestamp  = Get-Date -Format "yyyyMMdd-HHmmss"
$branchName = "dev/automation/onelocbuild-$timestamp"
```

It never checks whether a PR is already open. Its only guard is `git diff --cached --quiet` against `main`, which stays non-empty until a previous PR merges — so every run passes the guard and opens another PR.

Two things keep it firing: the schedule is daily at 19:30 UTC with `scheduleOnlyWithChanges: false`, and the ADO-side `locfiles/*` PR is never auto-completed, so `master` never receives the translations and the same delta regenerates each day.

## Fix

The logic moves into a reusable, testable script the pipeline step calls — the pattern already used by `eng/pipelines/scripts/Sync-GitHubToAdo.ps1`.

`eng/pipelines/scripts/Open-LocalizationPr.ps1`:

- **Stable branch** (`dev/automation/onelocbuild`), rebuilt from base each run — no timestamp proliferation.
- **Exits before any push or API call** when the resources match the base branch.
- **Reuses the open PR** (`PATCH` to refresh it) instead of opening a second one.
- Pushes with **`--force-with-lease`** pinned to the SHA read earlier in the run, so an overlapping run fails loudly instead of discarding another run's result.
- Authenticates via **`GIT_CONFIG_*` extraheader**, so the token never reaches `.git/config`, a command line, or an exception message.
- `-DryRun` walks the full decision tree without publishing anything.

17 Pester tests in `eng/pipelines/scripts/tests/`, `git` and `Invoke-RestMethod` mocked.

## Validation

**Pipeline, dry-run.** `Localization-CI` was pointed at this branch with `LocPrDryRun=true`. Build [171252](https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=171252&view=results) (manual) and 171295 (scheduled) both succeeded, loaded all 13 files, and short-circuited on `No localization changes relative to 'main'`. **The scheduled run created zero PRs** — first clean night in six.

**Fork, live.** Those runs never touch the write paths, so the script was run three times against `priyankatiwari08/SqlClient` with real credentials and no `-DryRun`:

| Run | Input | Behaviour | PRs after |
|---|---|---|---|
| 1 | Delta present | Pushed → created PR | 1 |
| 2 | Identical re-run | Skipped push → reused PR #1 | 1 |
| 3 | New delta | Pushed → reused PR #1 | 1 |

Three runs, one PR. The old step produces three.

**Credentials.** The `GIT_CONFIG_*` change landed after those runs, so it was checked separately with `git ls-remote`: valid token resolves the ref, invalid token fails with `Authentication failed`. The second case matters — it fails on a *public* repo, proving the header is really being sent rather than the request succeeding anonymously.

## Merge sequence

Order matters; flipping first makes the step fail, since the script won't be on `main` yet.

1. Merge this PR.
2. In `Localization-CI`, set `GitHubBranch` → `main` and `LocPrDryRun` → `false`.
3. Watch the next 19:30 UTC run.

## Follow-up ([AB#47729](https://sqlclientdrivers.visualstudio.com/ADO.Net/_workitems/edit/47729))

- [ ] Consider `scheduleOnlyWithChanges: true` or a weekly cadence.
- [ ] Auto-complete the ADO `locfiles/*` PR so `master` receives translations and the delta stops regenerating.
- [ ] Port `Localization-CI` to YAML under `eng/pipelines/` so it gets code-reviewed like the rest of CI.

## Checklist

- [x] Tests added or updated — 17 Pester tests, two pipeline runs, a three-run fork test
- [x] Public API changes documented — n/a
- [x] Verified against customer repro — n/a; verified against the four duplicate PRs
- [x] No breaking changes — CI infrastructure only, no shipping code touched
