### PR TITLE
Make code coverage artifact names unique per attempt

### DIFF
--- a/eng/pipelines/common/templates/jobs/ci-code-coverage-job.yml
+++ b/eng/pipelines/common/templates/jobs/ci-code-coverage-job.yml
@@ -112,12 +112,13 @@ jobs:
           displayName: '[Debug] Show Disk Usage'
 
       # Publish the Cobertura XML coverage file as a pipeline artifact for
-      # debugging purposes.
+      # debugging purposes. Pipeline artifact names must be unique within a
+      # build, so include the attempt numbers to allow this job to be rerun.
       - task: PublishPipelineArtifact@1
         displayName: Publish Cobertura XML Artifact
         inputs:
           targetPath: $(workingDir)/merge
-          artifact: Cobertura Merge Results
+          artifact: Cobertura Merge Results $(System.StageAttempt)-$(System.JobAttempt)
 
       # Publish the Cobertura reports to the pipeline to be viewed in the Azure
       # DevOps pipeline run UI.


### PR DESCRIPTION
## Description

Make the diagnostic Cobertura pipeline artifact name unique for every stage/job attempt by appending `$(System.StageAttempt)-$(System.JobAttempt)`.

Pipeline artifacts are immutable within a build. Rerunning the final code coverage job currently fails when `Cobertura Merge Results` was published by an earlier attempt. Attempt-qualified names allow this long-running pipeline's final job to be rerun while retaining each attempt's diagnostic artifact.
