### PR TITLE
Fix | Enable serialization of SqlException

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlException.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlException.cs
@@ -49,9 +49,7 @@ namespace Microsoft.Data.SqlClient
 #endif
         private SqlException(SerializationInfo si, StreamingContext sc) : base(si, sc)
         {
-#if NETFRAMEWORK
             _errors = (SqlErrorCollection)si.GetValue("Errors", typeof(SqlErrorCollection));
-#endif
             HResult = SqlExceptionHResult;
             foreach (SerializationEntry siEntry in si)
             {
@@ -70,7 +68,7 @@ namespace Microsoft.Data.SqlClient
         public override void GetObjectData(SerializationInfo si, StreamingContext context)
         {
             base.GetObjectData(si, context);
-            si.AddValue("Errors", null); // Not specifying type to enable serialization of null value of non-serializable type
+            si.AddValue("Errors", _errors, typeof(SqlErrorCollection));
             si.AddValue("ClientConnectionId", _clientConnectionId, typeof(object));
 
             // Writing sqlerrors to base exception data table

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlExceptionTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlExceptionTests.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NETFRAMEWORK
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using Microsoft.Data.Common.ConnectionString;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests;
+
+public class SqlExceptionTests
+{
+    private static SqlError ExampleSqlError =>
+        new(infoNumber: 123,
+            errorState: 2,
+            errorClass: 3,
+            server: "ServerName",
+            errorMessage: "SqlError Message",
+            procedure: "ProcedureName",
+            lineNumber: 234,
+            win32ErrorCode: 15,
+            exception: new ArgumentNullException(paramName: "param", message: "Associated exception"),
+            batchIndex: 0);
+
+    [Fact]
+    public void Serialization_RoundTrips()
+    {
+        // Arrange
+        // - Create the test exception
+        SqlBatchCommand originalBatchCommand = new("SELECT @@VERSION");
+        Guid originalConnId = Guid.NewGuid();
+        SqlException originalException = SqlException.CreateException(
+            errorCollection: [ExampleSqlError],
+            serverVersion: "0.0.000.0",
+            conId: originalConnId,
+            innerException: null,
+            batchCommand: originalBatchCommand);
+        originalException._doNotReconnect = true;
+
+        // Set up the serialization infrastructure
+        BinaryFormatter binaryFormatter = new();
+        using MemoryStream stream = new();
+
+        // Act - Serialize and deserialize
+        binaryFormatter.Serialize(stream, originalException);
+        stream.Position = 0;
+        SqlException? actualException = binaryFormatter.Deserialize(stream) as SqlException;
+
+        // Assert
+        Assert.NotNull(actualException);
+        Assert.NotNull(actualException.InnerException);
+        Assert.NotNull(actualException.Errors);
+
+        Assert.Equal(originalConnId, actualException.ClientConnectionId);
+        Assert.Equal(originalException.InnerException!.ToString(), actualException.InnerException.ToString());
+        Assert.Equal(originalException.Errors.Count, actualException.Errors.Count);
+
+        Assert.Equal(DbConnectionStringDefaults.ApplicationName, actualException.Errors[0].Source);
+        Assert.Equal(ExampleSqlError.Number, actualException.Errors[0].Number);
+        Assert.Equal(ExampleSqlError.State, actualException.Errors[0].State);
+        Assert.Equal(ExampleSqlError.Class, actualException.Errors[0].Class);
+        Assert.Equal(ExampleSqlError.Server, actualException.Errors[0].Server);
+        Assert.Equal(ExampleSqlError.Message, actualException.Errors[0].Message);
+        Assert.Equal(ExampleSqlError.Procedure, actualException.Errors[0].Procedure);
+        Assert.Equal(ExampleSqlError.LineNumber, actualException.Errors[0].LineNumber);
+        Assert.Equal(ExampleSqlError.Win32ErrorCode, actualException.Errors[0].Win32ErrorCode);
+        Assert.Equal(ExampleSqlError.BatchIndex, actualException.Errors[0].BatchIndex);
+
+        Assert.NotNull(actualException.Errors[0].Exception);
+        Assert.Equal(ExampleSqlError.Exception.ToString(), actualException.Errors[0].Exception.ToString());
+
+        // Some fields are not serialized
+        Assert.Null(actualException.BatchCommand);
+        Assert.False(actualException._doNotReconnect);
+    }
+}
+
+#endif


### PR DESCRIPTION
## Description

This fixes two longstanding bugs when serializing a SqlException using .NET Framework's `SerializableAttribute`-based infrastructure - via DataContractSerializer, BinaryFormatter or SoapFormatter.

The underlying bug was simply that we weren't providing a value for the `Errors` collection in `GetObjectData`, or reading it back in the deserialization constructor. Since properties such as `SqlException.Number` just read from the first entry in `Errors`, populating that collection automatically lights up those property values.

The broader picture here is that there are a few separate requests for changes to SqlException - issues 648 and 649 request SqlState and IsTransient support, issue 35 requests a public-facing constructor. Before adding new fields, I want to be sure that the underlying type serializes and deserializes correctly.

## Issues

Fixes #1940.
Fixes #2150.

## Testing

New unit test added to highlight regressions.

This new test uses BinaryFormatter, which is a bad practice in user code: it's known to be insecure when used with untrusted payloads. The alternative (DataContractSerializer) doesn't exactly mimic the original use case of .NET Framework Remoting though - DataContractSerializer requires a list of known types. I don't believe that the test introduces a security bug (we've got full control of the payloads we serialize and deserialize) but I'm not sure whether it'll be flagged as a risk.