### PR TITLE
Pipelines | Read the general-purpose pool name from one shared variable group

### DIFF
--- a/eng/pipelines/ci/package/sqlclient-ci-package-pipeline.yml
+++ b/eng/pipelines/ci/package/sqlclient-ci-package-pipeline.yml
@@ -79,6 +79,9 @@ parameters:
       - diagnostic
 
 variables:
+  # Provides 'general_purpose_pool_name', the 1ES pool that hosts most jobs in this project.
+  - group: sqlclient_pipeline_config
+
   # Whether this is an internal (ADO.Net project) or public (Public project) build.
   - name: isInternalBuild
     value: ${{ eq(variables['System.TeamProject'], 'ADO.Net') }}
@@ -96,10 +99,7 @@ jobs:
     displayName: Build NuGet Packages
 
     pool:
-      ${{ if eq(variables.isInternalBuild, true) }}:
-        name: ADO-1ES-Pool
-      ${{ else }}:
-        name: ADO-CI-1ES-Pool
+      name: $(general_purpose_pool_name)
       demands:
         - ImageOverride -equals ${{ parameters.poolImage }}
 

--- a/eng/pipelines/ci/package/sqlclient-ci-package-pipeline.yml
+++ b/eng/pipelines/ci/package/sqlclient-ci-package-pipeline.yml
@@ -80,7 +80,7 @@ parameters:
 
 variables:
   # Provides 'general_purpose_pool_name', the 1ES pool that hosts most jobs in this project.
-  - group: sqlclient_pipeline_config
+  - group: sqlclient-pipeline-config-v1
 
   # Whether this is an internal (ADO.Net project) or public (Public project) build.
   - name: isInternalBuild

--- a/eng/pipelines/ci/stress/sqlclient-ci-stress-pipeline.yml
+++ b/eng/pipelines/ci/stress/sqlclient-ci-stress-pipeline.yml
@@ -99,13 +99,13 @@ stages:
   - template: /eng/pipelines/stages/generate-secrets-ci-stage.yml@self
     parameters:
       debug: ${{ parameters.debug }}
-      poolName: $(ci_var_defaultPoolName)
+      poolName: $(general_purpose_pool_name)
       poolImage: ADO-UB24
 
   # Run the stress tests.
   - template: /eng/pipelines/ci/stress/sqlclient-ci-stress-stage.yml@self
     parameters:
-      poolName: $(ci_var_defaultPoolName)
+      poolName: $(general_purpose_pool_name)
       buildConfiguration: ${{ parameters.buildConfiguration }}
       debug: ${{ parameters.debug }}
       warnOnTestFailure: ${{ parameters.warnOnTestFailure }}

--- a/eng/pipelines/common/templates/jobs/ci-build-nugets-job.yml
+++ b/eng/pipelines/common/templates/jobs/ci-build-nugets-job.yml
@@ -87,9 +87,6 @@ jobs:
     demands:
     - imageOverride -equals ${{ parameters.poolImage }}
 
-  variables:
-    - template: /eng/pipelines/libraries/ci-build-variables.yml@self
-
   steps:
   - ${{ if eq(parameters.debug, true)}}:
     - powershell: |

--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -94,21 +94,21 @@ parameters:
       - Debug
       - Release
 
-  # The name of the 1ES pool that all CI jobs run in.
+  # The name of the general-purpose 1ES pool that all CI jobs run in.
   #
   # This is the single place in the CI pipelines where the pool name is read
   # from a variable group; every stage and job below receives it as a
   # parameter so that the value flows down from here.
   #
-  # 'ci_var_defaultPoolName' is defined in the 'ADO Build properties' variable
-  # group (see /eng/pipelines/libraries/ci-build-variables.yml), for both the
-  # Public and ADO.Net projects.  The PR pipelines are configured from a
-  # different variable group and use '$(PoolNameDefault)' instead; see
-  # /eng/pipelines/pr/sqlclient-pr-pipeline.yml.
+  # 'general_purpose_pool_name' is defined in the 'sqlclient_pipeline_config'
+  # variable group (see /eng/pipelines/libraries/ci-build-variables.yml), for
+  # both the Public and ADO.Net projects, and names each project's own pool.
+  # Special-purpose pools, such as the Always Encrypted and ARM64 pools used
+  # below, are still named directly.
   #
   - name: defaultPoolName
     type: string
-    default: $(ci_var_defaultPoolName)
+    default: $(general_purpose_pool_name)
 
   # The timeout, in minutes, for each test job.
   - name: testJobTimeout

--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -100,7 +100,7 @@ parameters:
   # from a variable group; every stage and job below receives it as a
   # parameter so that the value flows down from here.
   #
-  # 'general_purpose_pool_name' is defined in the 'sqlclient_pipeline_config'
+  # 'general_purpose_pool_name' is defined in the 'sqlclient-pipeline-config-v1'
   # variable group (see /eng/pipelines/libraries/ci-build-variables.yml), for
   # both the Public and ADO.Net projects, and names each project's own pool.
   # Special-purpose pools, such as the Always Encrypted and ARM64 pools used

--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -94,7 +94,7 @@ parameters:
       - Debug
       - Release
 
-  # The name of the general-purpose 1ES pool that all CI jobs run in.
+  # The name of the general-purpose 1ES pool that most CI jobs run in.
   #
   # This is the single place in the CI pipelines where the pool name is read
   # from a variable group; every stage and job below receives it as a

--- a/eng/pipelines/github-sync-pipeline.yml
+++ b/eng/pipelines/github-sync-pipeline.yml
@@ -64,7 +64,7 @@ jobs:
   - job: SyncGitHub
     displayName: Sync GitHub to ADO
     pool:
-      name: $(ci_var_defaultPoolName)
+      name: $(general_purpose_pool_name)
       demands:
         - imageOverride -equals ADO-UB24
 

--- a/eng/pipelines/libraries/ci-build-variables.yml
+++ b/eng/pipelines/libraries/ci-build-variables.yml
@@ -9,6 +9,7 @@
 # The buildSuffix itself is set by each pipeline via the core template parameter.
 
 variables:
+  - group: sqlclient_pipeline_config
   - group: ADO Build properties
   - group: ADO Test Configuration Properties
 

--- a/eng/pipelines/libraries/ci-build-variables.yml
+++ b/eng/pipelines/libraries/ci-build-variables.yml
@@ -9,7 +9,7 @@
 # The buildSuffix itself is set by each pipeline via the core template parameter.
 
 variables:
-  - group: sqlclient_pipeline_config
+  - group: sqlclient-pipeline-config-v1
   - group: ADO Build properties
   - group: ADO Test Configuration Properties
 

--- a/eng/pipelines/pr/sqlclient-pr-pipeline.yml
+++ b/eng/pipelines/pr/sqlclient-pr-pipeline.yml
@@ -103,15 +103,14 @@ variables:
   - template: /eng/pipelines/pr/variables/pr-variables.yml@self
 
 stages:
-  # NOTE: '$(PoolNameDefault)' comes from the 'sqlclient-testconfig-v1'
+  # NOTE: '$(general_purpose_pool_name)' comes from the 'sqlclient_pipeline_config'
   # variable group, which is imported by
   # /eng/pipelines/pr/variables/pr-variables.yml (included above).  It is
   # referenced here, at the pipeline root, and passed down to every stage as a
   # parameter, so that no template reads the pool name from a variable group
   # directly.
   #
-  # The CI pipelines are configured from a different variable group and use
-  # '$(ci_var_defaultPoolName)' instead; see
+  # The same variable group and variable are used by the CI pipelines; see
   # /eng/pipelines/dotnet-sqlclient-ci-core.yml.
 
   # Stage 1a: Build and pack all projects in the repository
@@ -121,14 +120,14 @@ stages:
       buildSuffix: pr
       stageName: ${{ variables.stageNamePack }}
       packArtifactBaseName: ${{ variables.packArtifactBaseName }}
-      poolName: $(PoolNameDefault)
+      poolName: $(general_purpose_pool_name)
       poolImage: ADO-UB24
 
   # Stage 1b: Generate secrets
   - template: /eng/pipelines/pr/stages/generate-secrets-stage.yml@self
     parameters:
       stageName: ${{ variables.stageNameSecrets }}
-      poolName: $(PoolNameDefault)
+      poolName: $(general_purpose_pool_name)
       poolImage: ADO-UB24
 
   # Stage 2: Execute tests and collect code coverage
@@ -137,7 +136,7 @@ stages:
       buildConfiguration: Debug
       buildSuffix: pr
       dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
-      poolName: $(PoolNameDefault)
+      poolName: $(general_purpose_pool_name)
       stageNamePack: ${{ variables.stageNamePack }}
       stageNameSecrets: ${{ variables.stageNameSecrets }}
       testResultsArtifactBaseName: ${{ variables.testResultsArtifactBaseName }}
@@ -159,7 +158,7 @@ stages:
   - template: /eng/pipelines/pr/stages/collect-coverage-stage.yml@self
     parameters:
       coverageArtifactBaseName: ${{ variables.coverageArtifactBaseName }}
-      poolName: $(PoolNameDefault)
+      poolName: $(general_purpose_pool_name)
       poolImage: ADO-UB24
       dependsOn:
         - ${{ each platform in parameters.platforms }}:

--- a/eng/pipelines/pr/sqlclient-pr-pipeline.yml
+++ b/eng/pipelines/pr/sqlclient-pr-pipeline.yml
@@ -103,7 +103,7 @@ variables:
   - template: /eng/pipelines/pr/variables/pr-variables.yml@self
 
 stages:
-  # NOTE: '$(general_purpose_pool_name)' comes from the 'sqlclient_pipeline_config'
+  # NOTE: '$(general_purpose_pool_name)' comes from the 'sqlclient-pipeline-config-v1'
   # variable group, which is imported by
   # /eng/pipelines/pr/variables/pr-variables.yml (included above).  It is
   # referenced here, at the pipeline root, and passed down to every stage as a

--- a/eng/pipelines/pr/variables/pr-variables.yml
+++ b/eng/pipelines/pr/variables/pr-variables.yml
@@ -23,6 +23,9 @@ variables:
   # UserManagedIdentityClientId
   - group: sqlclient-testconfig-v1
 
+  # Provides 'general_purpose_pool_name', the 1ES pool that hosts most jobs in this project.
+  - group: sqlclient_pipeline_config
+
   # General Variables ======================================================
 
   # Name to use for the packaging stage. This is to ensure that the packaging stage and the test

--- a/eng/pipelines/pr/variables/pr-variables.yml
+++ b/eng/pipelines/pr/variables/pr-variables.yml
@@ -24,7 +24,7 @@ variables:
   - group: sqlclient-testconfig-v1
 
   # Provides 'general_purpose_pool_name', the 1ES pool that hosts most jobs in this project.
-  - group: sqlclient_pipeline_config
+  - group: sqlclient-pipeline-config-v1
 
   # General Variables ======================================================
 


### PR DESCRIPTION
## Summary

One value - the general-purpose 1ES pool - was configured three different ways:

| pipeline | source |
| --- | --- |
| CI | `$(ci_var_defaultPoolName)` from the `ADO Build properties` group |
| PR | `$(PoolNameDefault)` from the `sqlclient-testconfig-v1` group |
| CI package | hardcoded `ADO-1ES-Pool` / `ADO-CI-1ES-Pool`, chosen by a `System.TeamProject` check |

This consolidates them onto a single variable in a single group.

- **New variable group `sqlclient-pipeline-config-v1`**, created in both the `ADO.Net` and `Public` projects and authorized for all pipelines, holding one variable:

  | project | `general_purpose_pool_name` |
  | --- | --- |
  | `ADO.Net` | `ADO-1ES-Pool` |
  | `Public` | `ADO-CI-1ES-Pool` |

  These are the values the two existing variables already carried in each project, so no pool assignment changes.

- **Read it at every pipeline root** - CI core, PR, stress, GitHub sync and CI package. Templates below the root still receive the pool as a `poolName` parameter and never read a variable group directly.

- **Drop the project-name check** in the CI package pipeline, which had its own copy of both pool names. `isInternalBuild` now serves only the signing key argument.

- **Remove a redundant job-scope import** of `ci-build-variables.yml` from `ci-build-nugets-job.yml`, so no template below a pipeline root loads the group. See [Review feedback](#review-feedback).

## How the variable reaches a job

Three supply paths, all rooted at a pipeline root:

| path | group declared in | pipelines |
| --- | --- | --- |
| A | `libraries/ci-build-variables.yml`, imported at root | CI core (4 roots), stress, GitHub sync |
| B | `pr/variables/pr-variables.yml` | `pr/sqlclient-pr-pipeline.yml` |
| C | inline at the root | `ci/package/sqlclient-ci-package-pipeline.yml` |

## Why "general-purpose"

We also run jobs on special-purpose pools - `ADO-CI-AE-1ES-Pool` (Always Encrypted), `ADO-CI-PUBLIC-ARM64-1ES-EUS-POOL` (ARM64), `ADO-Trusted-*-WestUS2` (Kerberos), `Managed-Instance-pool` - plus the Microsoft-hosted `Azure Pipelines` pool for macOS. Those are still named directly at their point of use. The variable name leaves room for them to get their own entries in this group later.

## No existing variable group is modified

`ci_var_defaultPoolName` and `PoolNameDefault` keep their current values in their current groups. They are simply no longer read by any pipeline, and can be retired separately once this has run clean.

## Review feedback

`ci-build-nugets-job.yml` imported `ci-build-variables.yml` at **job** scope, which meant the new group was loaded below a pipeline root. The import was redundant: that job is reachable only via `build-sqlclient-package-ci-stage.yml` from `dotnet-sqlclient-ci-core.yml`, which already imports the same template at its root, so the only two variables the job consumes from it - `localFeedPath` and `packagePath` - were already in scope. It was also the only job template in the repo importing a shared variables file; every other job and stage template relies on root pipeline variables.

Removing it leaves `ci-build-variables.yml` with exactly three importers, all pipeline roots.

Also reworded the `defaultPoolName` parameter comment from "all CI jobs" to "most CI jobs", to agree with the special-purpose pools listed a few lines below it.

## Validation

| check | result |
| --- | --- |
| YAML parses across `eng/pipelines/**` | 90 files, 0 failures |
| References to `ci_var_defaultPoolName` / `PoolNameDefault` | 0 (one comment remains, listing the older group's contents) |
| Pipeline roots reading `general_purpose_pool_name` | 5 |
| Importers of `ci-build-variables.yml` | 3, all at pipeline root |
| Special-purpose pools still named directly | unchanged |
| Variable group authorization | `allPipelines.authorized = true` in both projects |

## Pipeline runs

All runs below are complete. Across all 8, **643 jobs ran with 0 failed and 0 cancelled**.

A missing or unresolvable variable group is reported at queue time, before an agent is allocated, so a run that compiles already proves the group resolves in that project.

### Public

Runs are on `refs/pull/4627/merge` (merge commit `0695d7bc`).

| pipeline | path | trigger | run | result | jobs |
| --- | --- | --- | --- | --- | --- |
| `PR-SqlClient-Project` (2197) | A | automatic on PR push | [173748](https://dev.azure.com/SqlClientDrivers/public/_build/results?buildId=173748) | partially succeeded - 0 failed | 141 |
| `sqlclient-pr` (2281) | B | automatic on PR push | [173749](https://dev.azure.com/SqlClientDrivers/public/_build/results?buildId=173749) | **succeeded** | 63 |
| `sqlclient-ci-package` (2300) | C | queued manually | [173752](https://dev.azure.com/SqlClientDrivers/public/_build/results?buildId=173752) | **succeeded** | 1 |

`CI-SqlClient` (1879) is path A on the same core template as `PR-SqlClient-Project`, and runs on `main` after merge. `CI-SqlClient-Package` (1917), `PR-SqlClient-Package` (2198) and `sqlclient-ci-stress` (2250) are affected but disabled, so there is nothing to run.

### ADO.Net

These build the internal `dotnet-sqlclient` repo, so no GitHub PR can reach them. All runs are on `refs/heads/dev/paul/pool-name` at commit `5337d5c4`.

| pipeline | path | run | result | jobs |
| --- | --- | --- | --- | --- |
| `MDS Main CI` (1825) | A | [173753](https://dev.azure.com/SqlClientDrivers/ADO.Net/_build/results?buildId=173753) | partially succeeded - 0 failed | 218 |
| `MDS Main CI-Package` (1933) | A | [173755](https://dev.azure.com/SqlClientDrivers/ADO.Net/_build/results?buildId=173755) | partially succeeded - 0 failed | 199 |
| `sqlclient-ci-package` (2277) | C | [173754](https://dev.azure.com/SqlClientDrivers/ADO.Net/_build/results?buildId=173754) | **succeeded** | 1 |
| `sqlclient-ci-kerberos` (2306) | - | [20260909.4](https://dev.azure.com/SqlClientDrivers/ADO.Net/_build/results?buildId=173762) | **succeeded** | 10 |
| `sqlclient-ci-managed-instance` (2308) | - | [173757](https://dev.azure.com/SqlClientDrivers/ADO.Net/_build/results?buildId=173757) | **succeeded** | 10 |

`sqlclient-ci-stress` (2284) is affected but disabled. `sqlclient-pr` (2271) is path B, already covered by `sqlclient-pr` (2281) in Public.

`sqlclient-ci-kerberos` and `sqlclient-ci-managed-instance` carry no path, because they read no pool from a variable group - their stage templates name `ADO-Trusted-*-WestUS2` and `Managed-Instance-pool` directly, which the pool data below confirms. They are included as regression evidence that the shared templates still expand for them, not as coverage of this change.

`GitHub ADO mirror sync` (2263) is affected - it is the only path A consumer that exists solely in `ADO.Net` - but running it pushes a sync branch and opens a PR in the internal repo, so it is left to its schedule rather than queued for validation.

### Why "partially succeeded"

The three `partiallySucceeded` runs have **no failed and no cancelled job**. The result is downgraded solely by the quarantined flaky-test steps (`Run Flaky Unit Tests`, `Run Flaky Manual Tests`, `Run Flaky Functional Tests`), which report `succeededWithIssues` by design. That is the normal outcome for these pipelines.

| run | succeeded | succeededWithIssues | failed | cancelled |
| --- | --- | --- | --- | --- |
| 173748 | 76 | 65 | 0 | 0 |
| 173753 | 112 | 106 | 0 | 0 |
| 173755 | 107 | 92 | 0 | 0 |

### Pools actually used

Agent worker names were read from each run's timeline, covering all 643 jobs.

| project | pool | jobs | expected role |
| --- | --- | --- | --- |
| `Public` | `ADO-CI-1ES-Pool` | 182 | **general purpose - the value under test** |
| `ADO.Net` | `ADO-1ES-Pool` | 356 | **general purpose - the value under test** |
| `ADO.Net` | `ADO-CI-PUBLIC-ARM64-1ES-EUS-POOL` | 30 | special purpose, named directly |
| `Public` | `ADO-CI-PUBLIC-ARM64-1ES-EUS-POOL` | 15 | special purpose, named directly |
| `ADO.Net` | `ADO-CI-AE-1ES-Pool` | 14 | special purpose, named directly |
| `ADO.Net` | `ADO-Trusted-Domain-Win-WestUS2` | 7 | special purpose, named directly |
| `ADO.Net` | `ADO-Trusted-Linux-WestUS2` | 3 | special purpose, named directly |
| `ADO.Net` | `Managed-Instance-pool` | 10 | special purpose, named directly |
| `ADO.Net` | `Azure Pipelines` | 16 | Microsoft-hosted, macOS |
| `Public` | `Azure Pipelines` | 8 | Microsoft-hosted, macOS |
| `ADO.Net` | *(none - server job)* | 2 | `Finalize build` |

Every job landed on the pool its project expects. No `Public` job ran on `ADO-1ES-Pool` and no `ADO.Net` job ran on `ADO-CI-1ES-Pool`, so the group resolves to the correct per-project value with no leakage. The special-purpose pools appear exactly where they are named directly, unchanged by this PR.

`build_mds_akv_packages_job` - the job whose `variables:` block this PR removes - succeeded in every run that contains it, on the correct general-purpose pool each time:

| run | job | pool |
| --- | --- | --- |
| `PR-SqlClient-Project` 173748 | Build MDS & AKV Packages | `ADO-CI-1ES-Pool` |
| `sqlclient-ci-package` 173752 | Build NuGet Packages | `ADO-CI-1ES-Pool` |
| `MDS Main CI` 173753 | Build MDS & AKV Packages | `ADO-1ES-Pool` |
| `sqlclient-ci-package` 173754 | Build NuGet Packages | `ADO-1ES-Pool` |
| `MDS Main CI-Package` 173755 | Build MDS & AKV Packages | `ADO-1ES-Pool` |

This is the direct evidence that `localFeedPath` and `packagePath` still resolve from pipeline-root scope after the job-scope import was dropped.

### Note on the red checks in this PR

`PR-SqlClient-Project` [173781](https://dev.azure.com/SqlClientDrivers/public/_build/results?buildId=173781) and `sqlclient-pr` [173782](https://dev.azure.com/SqlClientDrivers/public/_build/results?buildId=173782) show as cancelled in the checks list. They are **duplicate re-runs of the same merge commit** `0695d7bc`, re-triggered by an edit to this PR description rather than by any code change - `triggerInfo` reports the same `pr.sourceSha` as the clean pair above.

They were starved of agents: every cancelled job carries `Remote machine provider issue: The agent did not connect within the alloted time of 45 minute(s)`, with no worker ever assigned. That is 1ES provisioning capacity, not a pipeline problem - 108 jobs in 173781 and 33 in 173782 did acquire agents on `ADO-CI-1ES-Pool`, the value this PR sets, and the earlier runs on the identical commit had zero agent issues.

The authoritative results for this change are 173748 and 173749.

### Not affected

OneBranch (2240/2241), perf (2305/2311/2313), the sni and ctaip pipelines, and the docs pipelines.

## Checklist

- [x] Tests added or updated - n/a, pipeline-only change
- [x] Public API changes documented - n/a
- [ ] Verified against customer repro - n/a
- [x] Ensure no breaking changes introduced - no product code touched; pool values per project are unchanged
