### PR TITLE
Address AccessToken and SSPI review feedback

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml
@@ -262,10 +262,11 @@ The following example creates a <xref:Microsoft.Data.SqlClient.SqlCommand> and a
         </para>
         <para>
           This property is mutually exclusive with the
-          <see cref="P:Microsoft.Data.SqlClient.SqlConnection.AccessTokenCallback" />
+          <see cref="P:Microsoft.Data.SqlClient.SqlConnection.AccessTokenCallback" />,
+          <see cref="P:Microsoft.Data.SqlClient.SqlConnection.Credential" />,
           and
           <see cref="P:Microsoft.Data.SqlClient.SqlConnection.SspiContextProvider" />
-          properties, among others. Setting this property when
+          properties. Setting this property when
           <see cref="P:Microsoft.Data.SqlClient.SqlConnection.SspiContextProvider" />
           is already set throws
           <see cref="T:System.InvalidOperationException" />, because SSPI is an

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -1488,11 +1488,8 @@ namespace Microsoft.Data.Common
         internal static Exception InvalidMixedUsageOfAccessTokenCallbackAndIntegratedSecurity()
             => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfAccessTokenCallbackAndIntegratedSecurity));
 
-        internal static Exception InvalidMixedUsageOfAccessTokenAndSspiContextProvider()
-            => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfAccessTokenAndSspiContextProvider));
-
-        internal static Exception InvalidMixedUsageOfSspiContextProviderAndAccessToken()
-            => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfSspiContextProviderAndAccessToken));
+        internal static Exception InvalidMixedUsageOfAccessTokenProperties()
+            => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfAccessTokenProperties));
         #endregion
 
         internal static readonly IntPtr s_ptrZero = IntPtr.Zero;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1199,7 +1199,7 @@ namespace Microsoft.Data.SqlClient
 
             if (_sspiContextProvider != null)
             {
-                throw ADP.InvalidMixedUsageOfAccessTokenAndSspiContextProvider();
+                throw ADP.InvalidMixedUsageOfAccessTokenProperties();
             }
         }
 
@@ -1226,7 +1226,7 @@ namespace Microsoft.Data.SqlClient
 
             if (_sspiContextProvider != null)
             {
-                throw ADP.InvalidMixedUsageOfAccessTokenAndSspiContextProvider();
+                throw ADP.InvalidMixedUsageOfAccessTokenProperties();
             }
         }
 
@@ -1238,7 +1238,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (_accessToken != null || _accessTokenCallback != null)
             {
-                throw ADP.InvalidMixedUsageOfSspiContextProviderAndAccessToken();
+                throw ADP.InvalidMixedUsageOfAccessTokenProperties();
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
@@ -484,20 +484,11 @@ namespace System {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot set the AccessToken or AccessTokenCallback property if the SspiContextProvider property has been set..
+        ///   Looks up a localized string similar to Cannot set more than one of the properties AccessToken, AccessTokenCallback, or SspiContextProvider..
         /// </summary>
-        internal static string ADP_InvalidMixedUsageOfAccessTokenAndSspiContextProvider {
+        internal static string ADP_InvalidMixedUsageOfAccessTokenProperties {
             get {
-                return ResourceManager.GetString("ADP_InvalidMixedUsageOfAccessTokenAndSspiContextProvider", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Cannot set the SspiContextProvider property if the AccessToken or AccessTokenCallback property has been set..
-        /// </summary>
-        internal static string ADP_InvalidMixedUsageOfSspiContextProviderAndAccessToken {
-            get {
-                return ResourceManager.GetString("ADP_InvalidMixedUsageOfSspiContextProviderAndAccessToken", resourceCulture);
+                return ResourceManager.GetString("ADP_InvalidMixedUsageOfAccessTokenProperties", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
@@ -2082,11 +2082,8 @@
   <data name="ADP_InvalidMixedUsageOfAccessTokenCallbackAndIntegratedSecurity" xml:space="preserve">
     <value>Cannot set the AccessTokenCallback property if the 'Integrated Security' connection string keyword has been set to 'true' or 'SSPI'.</value>
   </data>
-  <data name="ADP_InvalidMixedUsageOfAccessTokenAndSspiContextProvider" xml:space="preserve">
-    <value>Cannot set the AccessToken or AccessTokenCallback property if the SspiContextProvider property has been set.</value>
-  </data>
-  <data name="ADP_InvalidMixedUsageOfSspiContextProviderAndAccessToken" xml:space="preserve">
-    <value>Cannot set the SspiContextProvider property if the AccessToken or AccessTokenCallback property has been set.</value>
+  <data name="ADP_InvalidMixedUsageOfAccessTokenProperties" xml:space="preserve">
+    <value>Cannot set more than one of the properties AccessToken, AccessTokenCallback, or SspiContextProvider.</value>
   </data>
   <data name="ADP_InvalidMixedUsageOfAuthenticationAndTokenCallback" xml:space="preserve">
     <value>Cannot set the AccessTokenCallback property if 'Authentication=Active Directory Default' has been specified in the connection string.</value>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionTests.cs
@@ -902,33 +902,41 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
         {
             Func<SqlAuthenticationParameters, CancellationToken, Task<SqlAuthenticationToken>> callback =
                 (ctx, token) => Task.FromResult(new SqlAuthenticationToken("invalid", DateTimeOffset.MaxValue));
+            string expectedMessage = global::Microsoft.Data.StringsHelper.GetString(
+                global::System.Strings.ADP_InvalidMixedUsageOfAccessTokenProperties);
 
             // Token first, then provider.
             using (SqlConnection conn = new("Data Source=localhost"))
             {
                 conn.AccessToken = "token";
-                Assert.Throws<InvalidOperationException>(
+                InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
                     () => conn.SspiContextProvider = new TestSspiContextProvider());
+                Assert.Equal(expectedMessage, exception.Message);
             }
 
             using (SqlConnection conn = new("Data Source=localhost"))
             {
                 conn.AccessTokenCallback = callback;
-                Assert.Throws<InvalidOperationException>(
+                InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
                     () => conn.SspiContextProvider = new TestSspiContextProvider());
+                Assert.Equal(expectedMessage, exception.Message);
             }
 
             // Provider first, then token.
             using (SqlConnection conn = new("Data Source=localhost"))
             {
                 conn.SspiContextProvider = new TestSspiContextProvider();
-                Assert.Throws<InvalidOperationException>(() => conn.AccessToken = "token");
+                InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+                    () => conn.AccessToken = "token");
+                Assert.Equal(expectedMessage, exception.Message);
             }
 
             using (SqlConnection conn = new("Data Source=localhost"))
             {
                 conn.SspiContextProvider = new TestSspiContextProvider();
-                Assert.Throws<InvalidOperationException>(() => conn.AccessTokenCallback = callback);
+                InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+                    () => conn.AccessTokenCallback = callback);
+                Assert.Equal(expectedMessage, exception.Message);
             }
         }
 


### PR DESCRIPTION
Addresses open review feedback from #4561.

## Summary
- Use one exception message for conflicting token/SSPI properties.
- Assert the message in mutual-exclusivity tests.
- List all conflicting `AccessToken` properties in docs.

## Checklist
- [x] Tests added or updated
- [x] Public API changes documented
- [x] Ensure no breaking changes introduced
