### PR TITLE
[v7.0.3] Backport Localization Changes

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.cs.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.cs.resx
@@ -4444,7 +4444,7 @@
     <value>Ověření podpisu sestavy enklávy se nezdařilo. Podpis sestavy neodpovídá podpisu vypočítanému pomocí kořenového certifikátu HGS. Ověřte mapování DNS pro koncový bod. Další podrobnosti najdete na https://go.microsoft.com/fwlink/?linkid=2160553. Pokud je to správně, obraťte se na oddělení služeb zákazníkům.</value>
   </data>
   <data name="VerifyEnclaveKeyBindingFailed" xml:space="preserve">
-    <value>Enclave attestation failed because the signed enclave report did not bind to the enclave public key used to establish the session. The enclave public key must match the value committed to by the signed report - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details. If correct, contact Customer Support Services.</value>
+    <value>Ověření identity enklávy se nezdařilo, protože podepsaná sestava enklávy nebyla svázána s veřejným klíčem enklávy použitým k vytvoření relace. Veřejný klíč enklávy musí odpovídat hodnotě potvrzené podepsanou sestavou – další podrobnosti najdete na https://go.microsoft.com/fwlink/?linkid=2160553. Pokud je to správně, obraťte se na oddělení služeb zákazníkům.</value>
   </data>
   <data name="VerifyEnclaveReportFormatFailed" xml:space="preserve">
     <value>Sestava enklávy přijatá z SQL Server nemá správný formát. Obraťte se na služby zákaznické podpory.</value>
@@ -4664,6 +4664,12 @@
   </data>
   <data name="SQL_RemoteCertificateDoesNotMatchServerCertificate" xml:space="preserve">
     <value>Certifikát poskytnutý serverem neodpovídá certifikátu poskytnutému možností ServerCertificate.</value>
+  </data>
+  <data name="SQL_ServerCertificateFileLoadFailed" xml:space="preserve">
+    <value>Soubor certifikátu určený možností 'ServerCertificate' se nepodařilo načíst ani parsovat: '{0}'.</value>
+  </data>
+  <data name="SQL_ServerCertificateNotAvailable" xml:space="preserve">
+    <value>Byla zadána možnost 'ServerCertificate', ale server nepředložil certifikát, který by s ním bylo možné porovnat.</value>
   </data>
   <data name="SQL_JsonDocumentNotSupportedOnColumnType" xml:space="preserve">
     <value>Neplatný pokus o získání třídy JsonDocument ve sloupci {0}. Třída JsonDocument se podporuje jenom pro sloupce typu json.</value>

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.de.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.de.resx
@@ -4444,7 +4444,7 @@
     <value>Fehler bei der Signaturüberprüfung des Enclave-Berichts. Die Berichtssignatur stimmt nicht mit der Signatur überein, die mit dem HGS-Stammzertifikat berechnet wurde. Überprüfen Sie die DNS-Zuordnung für den Endpunkt – Weitere Informationen finden Sie unter https://go.microsoft.com/fwlink/?linkid=2160553. Wenn sie korrekt ist, wenden Sie sich an den Kundensupport.</value>
   </data>
   <data name="VerifyEnclaveKeyBindingFailed" xml:space="preserve">
-    <value>Enclave attestation failed because the signed enclave report did not bind to the enclave public key used to establish the session. The enclave public key must match the value committed to by the signed report - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details. If correct, contact Customer Support Services.</value>
+    <value>Der Enklavennachweis ist fehlgeschlagen, weil der signierte Enklavenbericht nicht an den öffentlichen Enklavenschlüssel gebunden wurde, der zum Einrichten der Sitzung verwendet wurde. Der öffentliche Enclave-Schlüssel muss mit dem Wert übereinstimmen, für den vom signierten Bericht ein Commit ausgeführt wurde. Weitere Informationen finden Sie unter https://go.microsoft.com/fwlink/?linkid=2160553. Wenn sie korrekt ist, wenden Sie sich an den Kundensupport.</value>
   </data>
   <data name="VerifyEnclaveReportFormatFailed" xml:space="preserve">
     <value>Der von SQL Server empfangene Enclavebericht weist nicht das richtige Format auf. Wenden Sie sich an den Kundensupport.</value>
@@ -4664,6 +4664,12 @@
   </data>
   <data name="SQL_RemoteCertificateDoesNotMatchServerCertificate" xml:space="preserve">
     <value>Das vom Server bereitgestellte Zertifikat stimmt nicht mit dem Zertifikat überein, das über die ServerCertificate-Option bereitgestellt wurde.</value>
+  </data>
+  <data name="SQL_ServerCertificateFileLoadFailed" xml:space="preserve">
+    <value>Die mit der Option „ServerCertificate“ angegebene Zertifikatdatei konnte nicht geladen oder geparst werden: '{0}'.</value>
+  </data>
+  <data name="SQL_ServerCertificateNotAvailable" xml:space="preserve">
+    <value>Die Option „ServerCertificate“ wurde angegeben, aber der Server hat kein Zertifikat bereitgestellt, mit dem es verglichen werden kann.</value>
   </data>
   <data name="SQL_JsonDocumentNotSupportedOnColumnType" xml:space="preserve">
     <value>Ungültiger Versuch, „JsonDocument“ für Spalte „{0}“ abzurufen. „JsonDocument“ wird nur für Spalten vom Typ JSON unterstützt.</value>

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.es.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.es.resx
@@ -4444,7 +4444,7 @@
     <value>Error de comprobación de firma del informe de enclave. La firma del informe no coincide con la firma calculada mediante el certificado raíz de HGS. Compruebe la asignación de DNS del punto de conexión. Vea https://go.microsoft.com/fwlink/?linkid=2160553 para más detalles. Si es correcta, póngase en contacto con el servicio de atención al cliente.</value>
   </data>
   <data name="VerifyEnclaveKeyBindingFailed" xml:space="preserve">
-    <value>Enclave attestation failed because the signed enclave report did not bind to the enclave public key used to establish the session. The enclave public key must match the value committed to by the signed report - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details. If correct, contact Customer Support Services.</value>
+    <value>Error de atestación de enclave porque el informe de enclave firmado no se enlazaba a la clave pública del enclave usada para establecer la sesión. La clave pública del enclave debe coincidir con el valor confirmado por el informe firmado. Consulte https://go.microsoft.com/fwlink/?linkid=2160553 para obtener más detalles. Si es correcto, póngase en contacto con los servicios de soporte al cliente.</value>
   </data>
   <data name="VerifyEnclaveReportFormatFailed" xml:space="preserve">
     <value>El informe de enclave recibido desde SQL Server no tiene el formato correcto. Póngase en contacto con el servicio de atención al cliente.</value>
@@ -4664,6 +4664,12 @@
   </data>
   <data name="SQL_RemoteCertificateDoesNotMatchServerCertificate" xml:space="preserve">
     <value>El certificado proporcionado por el servidor no coincide con el certificado proporcionado por la opción ServerCertificate.</value>
+  </data>
+  <data name="SQL_ServerCertificateFileLoadFailed" xml:space="preserve">
+    <value>No se pudo cargar ni analizar el archivo de certificado especificado por la opción "ServerCertificate": "{0}".</value>
+  </data>
+  <data name="SQL_ServerCertificateNotAvailable" xml:space="preserve">
+    <value>Se especificó la opción 'ServerCertificate', pero el servidor no presentó un certificado que se pudiera comparar con él.</value>
   </data>
   <data name="SQL_JsonDocumentNotSupportedOnColumnType" xml:space="preserve">
     <value>Intento no válido de obtener JsonDocument en la columna '{0}'. JsonDocument solo se admite para columnas de tipo json.</value>

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.fr.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.fr.resx
@@ -4444,7 +4444,7 @@
     <value>La vérification de signature du rapport d'enclave a échoué. La signature de rapport ne correspond pas à la signature calculée à l'aide du certificat racine SGH - consultez https://go.microsoft.com/fwlink/?linkid=2160553 pour plus d’informations. Vérifiez le mappage DNS pour le point de terminaison. S'il est correct, contactez le service client.</value>
   </data>
   <data name="VerifyEnclaveKeyBindingFailed" xml:space="preserve">
-    <value>Enclave attestation failed because the signed enclave report did not bind to the enclave public key used to establish the session. The enclave public key must match the value committed to by the signed report - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details. If correct, contact Customer Support Services.</value>
+    <value>L’attestation d’enclave a échoué, car le rapport d’enclave signé n’était pas lié à la clé publique de l’enclave utilisée pour établir la session. La clé publique de l’enclave doit correspondre à la valeur engagée par le rapport signé – consultez https://go.microsoft.com/fwlink/?linkid=2160553 pour plus de détails. S'il est correct, contactez le service clientèle.</value>
   </data>
   <data name="VerifyEnclaveReportFormatFailed" xml:space="preserve">
     <value>Le rapport d'enclave envoyé par SQL Server n'a pas un format correct. Contactez le service client.</value>
@@ -4664,6 +4664,12 @@
   </data>
   <data name="SQL_RemoteCertificateDoesNotMatchServerCertificate" xml:space="preserve">
     <value>Le certificat fourni par le serveur ne correspond pas au certificat fourni par l’option ServerCertificate.</value>
+  </data>
+  <data name="SQL_ServerCertificateFileLoadFailed" xml:space="preserve">
+    <value>Le fichier de certificat spécifié par l’option « ServerCertificate » n’a pas pu être chargé ou analysé : « {0} ».</value>
+  </data>
+  <data name="SQL_ServerCertificateNotAvailable" xml:space="preserve">
+    <value>L’option « ServerCertificate » a été spécifiée, mais le serveur n’a présenté aucun certificat qui puisse être comparé à celui-ci.</value>
   </data>
   <data name="SQL_JsonDocumentNotSupportedOnColumnType" xml:space="preserve">
     <value>Tentative non valide d’obtention de JsonDocument sur la colonne « {0} ». JsonDocument est uniquement pris en charge pour les colonnes de type JSON.</value>

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.it.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.it.resx
@@ -4444,7 +4444,7 @@
     <value>La verifica della firma del report dell'enclave non è riuscita. La firma del report non corrisponde alla firma calcolata usando il certificato radice HGS. Verificare il mapping DNS per l'endpoint - vedere https://go.microsoft.com/fwlink/?linkid=2160553 per altri dettagli. Se è corretto, contattare il Servizio Supporto Tecnico Clienti.</value>
   </data>
   <data name="VerifyEnclaveKeyBindingFailed" xml:space="preserve">
-    <value>Enclave attestation failed because the signed enclave report did not bind to the enclave public key used to establish the session. The enclave public key must match the value committed to by the signed report - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details. If correct, contact Customer Support Services.</value>
+    <value>L'attestazione dell'enclave non è riuscita perché il report firmato dell'enclave non è stato vincolato alla chiave pubblica dell'enclave usata per stabilire la sessione. La chiave pubblica dell'enclave deve corrispondere al valore a cui fa riferimento il report firmato: per altri dettagli, vedere https://go.microsoft.com/fwlink/?linkid=2160553. Se è corretto, contattare il Servizio Supporto Tecnico Clienti.</value>
   </data>
   <data name="VerifyEnclaveReportFormatFailed" xml:space="preserve">
     <value>Il formato del report dell'enclave ricevuto da SQL Server non è corretto. Contattare il Servizio Supporto Tecnico Clienti.</value>
@@ -4664,6 +4664,12 @@
   </data>
   <data name="SQL_RemoteCertificateDoesNotMatchServerCertificate" xml:space="preserve">
     <value>Il certificato fornito dal server non corrisponde al certificato fornito dall'opzione ServerCertificate.</value>
+  </data>
+  <data name="SQL_ServerCertificateFileLoadFailed" xml:space="preserve">
+    <value>Non è possibile caricare o analizzare il file del certificato specificato dall'opzione 'ServerCertificate: '{0}'.</value>
+  </data>
+  <data name="SQL_ServerCertificateNotAvailable" xml:space="preserve">
+    <value>È stata specificata l'opzione 'ServerCertificate', ma il server non ha presentato un certificato confrontabile con essa.</value>
   </data>
   <data name="SQL_JsonDocumentNotSupportedOnColumnType" xml:space="preserve">
     <value>Tentativo non valido di ottenere JsonDocument nella colonna '{0}'. JsonDocument è supportato solo per colonne di tipo JSON.</value>

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.ja.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.ja.resx
@@ -4444,7 +4444,7 @@
     <value>エンクレーブ レポートの署名の検証に失敗しました。レポートの署名が、HGS ルート証明書を使用して計算された署名と一致しません。エンドポイントの DNS マッピングをご確認ください。詳細については、https://go.microsoft.com/fwlink/?linkid=2160553 を参照してください。適切である場合、カスタマー サポート サービスにお問い合わせください。</value>
   </data>
   <data name="VerifyEnclaveKeyBindingFailed" xml:space="preserve">
-    <value>Enclave attestation failed because the signed enclave report did not bind to the enclave public key used to establish the session. The enclave public key must match the value committed to by the signed report - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details. If correct, contact Customer Support Services.</value>
+    <value>署名付きエンクレーブ レポートが、セッションの確立に使用されたエンクレーブ公開キーにバインドされていなかったため、エンクレーブの構成証明に失敗しました。エンクレーブ公開キーは、署名付きレポートでコミットされた値と一致している必要があります。詳細については、https://go.microsoft.com/fwlink/?linkid=2160553 を参照してください。正しい場合は、カスタマー サポート サービスにお問い合わせください。</value>
   </data>
   <data name="VerifyEnclaveReportFormatFailed" xml:space="preserve">
     <value>SQL Server から受信したエンクレーブ レポートの形式が適切ではありません。カスタマー サポート サービスにお問い合わせください。</value>
@@ -4664,6 +4664,12 @@
   </data>
   <data name="SQL_RemoteCertificateDoesNotMatchServerCertificate" xml:space="preserve">
     <value>サーバーによって提供された証明書が、ServerCertificate オプションで指定された証明書と一致しません。</value>
+  </data>
+  <data name="SQL_ServerCertificateFileLoadFailed" xml:space="preserve">
+    <value>'ServerCertificate' オプションで指定された証明書ファイルを読み込むことも解析することもできませんでした: '{0}'。</value>
+  </data>
+  <data name="SQL_ServerCertificateNotAvailable" xml:space="preserve">
+    <value>'ServerCertificate' オプションが指定されましたが、サーバーから、このオプションと照合できる証明書が提示されませんでした。</value>
   </data>
   <data name="SQL_JsonDocumentNotSupportedOnColumnType" xml:space="preserve">
     <value>列 '{0}' で JsonDocument を取得しようとしましたが無効です。JsonDocument は json 型の列でのみサポートされています。</value>

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.ko.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.ko.resx
@@ -4444,7 +4444,7 @@
     <value>enclave 보고서의 서명을 확인하지 못했습니다. 보고서 서명이 HGS 루트 인증서를 사용하여 계산된 서명과 일치하지 않습니다. 엔드포인트에 대한 DNS 매핑을 확인하세요. 자세한 내용은 https://go.microsoft.com/fwlink/?linkid=2160553을 확인 하세요. 올바른 경우 고객 지원 서비스에 문의하세요.</value>
   </data>
   <data name="VerifyEnclaveKeyBindingFailed" xml:space="preserve">
-    <value>Enclave attestation failed because the signed enclave report did not bind to the enclave public key used to establish the session. The enclave public key must match the value committed to by the signed report - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details. If correct, contact Customer Support Services.</value>
+    <value>서명된 엔클레이브 보고서가 세션을 설정하는 데 사용된 엔클레이브 공개 키에 바인딩되지 않아 엔클레이브 증명이 실패했습니다. 엔클레이브 공개 키는 서명된 보고서에 커밋된 값과 일치해야 합니다. 자세한 내용은 https://go.microsoft.com/fwlink/?linkid=2160553을 참조하세요. 올바른 경우 고객 지원 서비스에 문의하세요.</value>
   </data>
   <data name="VerifyEnclaveReportFormatFailed" xml:space="preserve">
     <value>SQL Server에서 수신된 enclave 보고서의 형식이 잘못되었습니다. 고객 지원 서비스에 문의하세요.</value>
@@ -4664,6 +4664,12 @@
   </data>
   <data name="SQL_RemoteCertificateDoesNotMatchServerCertificate" xml:space="preserve">
     <value>서버에서 제공하는 인증서가 ServerCertificate 옵션에서 제공하는 인증서와 일치하지 않습니다.</value>
+  </data>
+  <data name="SQL_ServerCertificateFileLoadFailed" xml:space="preserve">
+    <value>'ServerCertificate' 옵션으로 지정된 인증서 파일을 로드하거나 구문 분석할 수 없습니다. '{0}'.</value>
+  </data>
+  <data name="SQL_ServerCertificateNotAvailable" xml:space="preserve">
+    <value>'ServerCertificate' 옵션이 지정되었지만 서버에서 비교할 수 있는 인증서를 제공하지 않았습니다.</value>
   </data>
   <data name="SQL_JsonDocumentNotSupportedOnColumnType" xml:space="preserve">
     <value>열 '{0}'의 JsonDocument를 가져오려는 시도가 잘못되었습니다. JsonDocument는 json 형식의 열에 대해서만 지원됩니다.</value>

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.pl.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.pl.resx
@@ -4444,7 +4444,7 @@
     <value>Weryfikacja podpisu w raporcie enklawy zakończyła się niepowodzeniem. Podpis raportu jest niezgodny z podpisem obliczonym przy użyciu certyfikatu głównego usługi Ochrona hosta. Sprawdź mapowanie DNS dla punktu końcowego — zobacz https://go.microsoft.com/fwlink/?linkid=2160553, aby uzyskać więcej szczegółów. Jeśli to ustawienie jest poprawne, skontaktuj się z Działem Obsługi Klienta.</value>
   </data>
   <data name="VerifyEnclaveKeyBindingFailed" xml:space="preserve">
-    <value>Enclave attestation failed because the signed enclave report did not bind to the enclave public key used to establish the session. The enclave public key must match the value committed to by the signed report - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details. If correct, contact Customer Support Services.</value>
+    <value>Zaświadczanie enklawy nie powiodło się, ponieważ podpisany raport enklawy nie został powiązany z kluczem publicznym enklawy używanym do ustanowienia sesji. Klucz publiczny enklawy musi być zgodny z wartością zatwierdzoną przez podpisany raport — zobacz https://go.microsoft.com/fwlink/?linkid=2160553, aby uzyskać więcej szczegółów. Jeśli to ustawienie jest poprawne, skontaktuj się z Działem Obsługi Klienta.</value>
   </data>
   <data name="VerifyEnclaveReportFormatFailed" xml:space="preserve">
     <value>Raport enklawy odebrany z systemu SQL Server nie ma prawidłowego formatu. Skontaktuj się z Działem Obsługi Klienta.</value>
@@ -4664,6 +4664,12 @@
   </data>
   <data name="SQL_RemoteCertificateDoesNotMatchServerCertificate" xml:space="preserve">
     <value>Certyfikat dostarczony przez serwer nie jest zgodny z certyfikatem dostarczonym przez opcję ServerCertificate.</value>
+  </data>
+  <data name="SQL_ServerCertificateFileLoadFailed" xml:space="preserve">
+    <value>Nie można załadować lub przeanalizować pliku certyfikatu określonego przez opcję „ServerCertificate”: „{0}”.</value>
+  </data>
+  <data name="SQL_ServerCertificateNotAvailable" xml:space="preserve">
+    <value>Określono opcję „ServerCertificate”, ale serwer nie przedstawia certyfikatu, który można porównać z nim.</value>
   </data>
   <data name="SQL_JsonDocumentNotSupportedOnColumnType" xml:space="preserve">
     <value>Nieprawidłowa próba pobrania pliku JsonDocument w kolumnie „{0}”. Obiekt JsonDocument jest obsługiwany tylko w przypadku kolumn typu JSON.</value>

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.pt-BR.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.pt-BR.resx
@@ -4444,7 +4444,7 @@
     <value>A verificação da assinatura do relatório do enclave falhou. A assinatura do relatório não corresponde à assinatura calculada usando o certificado raiz HGS. Verifique o mapeamento DNS para o ponto de extremidade - consulte https://go.microsoft.com/fwlink/?linkid=2160553 para mais detalhes. Se estiver correto, entre em contato com os Serviços de Suporte ao Cliente.</value>
   </data>
   <data name="VerifyEnclaveKeyBindingFailed" xml:space="preserve">
-    <value>Enclave attestation failed because the signed enclave report did not bind to the enclave public key used to establish the session. The enclave public key must match the value committed to by the signed report - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details. If correct, contact Customer Support Services.</value>
+    <value>O atestado do enclave falhou porque o relatório assinado do enclave não se vinculou à chave pública do enclave usada para estabelecer a sessão. A chave pública do enclave deve corresponder ao valor registrado no relatório assinado - consulte https://go.microsoft.com/fwlink/?linkid=2160553 para obter mais detalhes. Se correto, entre em contato com os Serviços de Atendimento ao Cliente.</value>
   </data>
   <data name="VerifyEnclaveReportFormatFailed" xml:space="preserve">
     <value>O relatório de enclave recebido do SQL Server não está no formato correto. Entre em contato com os Serviços de Atendimento ao Cliente.</value>
@@ -4664,6 +4664,12 @@
   </data>
   <data name="SQL_RemoteCertificateDoesNotMatchServerCertificate" xml:space="preserve">
     <value>O certificado fornecido pelo servidor não corresponde ao certificado fornecido pela opção ServerCertificate.</value>
+  </data>
+  <data name="SQL_ServerCertificateFileLoadFailed" xml:space="preserve">
+    <value>O arquivo de certificado especificado pela opção ''ServerCertificate'' não pôde ser carregado ou analisado: ''{0}''.</value>
+  </data>
+  <data name="SQL_ServerCertificateNotAvailable" xml:space="preserve">
+    <value>A opção ''ServerCertificate'' foi especificada, mas o servidor não apresentou um certificado que pudesse ser comparado com ele.</value>
   </data>
   <data name="SQL_JsonDocumentNotSupportedOnColumnType" xml:space="preserve">
     <value>Tentativa inválida de obter JsonDocument na coluna ''{0}''. Só há suporte para JsonDocument em colunas do tipo json.</value>

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.ru.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.ru.resx
@@ -4444,7 +4444,7 @@
     <value>Проверка подписи отчета анклава не пройдена. Подпись отчета не соответствует подписи, вычисленной с помощью корневого сертификата HGS. Проверьте сопоставление DNS для конечной точки — см. https://go.microsoft.com/fwlink/?linkid=2160553 для получения дополнительных сведений. Если оно верно, обратитесь в службу поддержки пользователей.</value>
   </data>
   <data name="VerifyEnclaveKeyBindingFailed" xml:space="preserve">
-    <value>Enclave attestation failed because the signed enclave report did not bind to the enclave public key used to establish the session. The enclave public key must match the value committed to by the signed report - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details. If correct, contact Customer Support Services.</value>
+    <value>Аттестация анклава завершилась сбоем, так как подписанный отчет анклава не был привязан к открытому ключу анклава, использованному для установления сеанса. Открытый ключ анклава должен совпадать со значением, зафиксированным в подписанном отчете; подробнее см. по ссылке https://go.microsoft.com/fwlink/?linkid=2160553. Если это верно, обратитесь в службу поддержки клиентов.</value>
   </data>
   <data name="VerifyEnclaveReportFormatFailed" xml:space="preserve">
     <value>Полученный с SQL Server отчет анклава имеет неправильный формат. Обратитесь в службу поддержки пользователей.</value>
@@ -4664,6 +4664,12 @@
   </data>
   <data name="SQL_RemoteCertificateDoesNotMatchServerCertificate" xml:space="preserve">
     <value>Сертификат, предоставленный сервером, не совпадает с сертификатом, указанным в параметре ServerCertificate.</value>
+  </data>
+  <data name="SQL_ServerCertificateFileLoadFailed" xml:space="preserve">
+    <value>Не удалось загрузить или проанализировать файл сертификата, указанный параметром "ServerCertificate": "{0}".</value>
+  </data>
+  <data name="SQL_ServerCertificateNotAvailable" xml:space="preserve">
+    <value>Параметр "ServerCertificate" был указан, но сервер не представил сертификат, с которым можно было бы его сравнить.</value>
   </data>
   <data name="SQL_JsonDocumentNotSupportedOnColumnType" xml:space="preserve">
     <value>Недопустимая попытка получить JsonDocument для столбца "{0}". JsonDocument поддерживается только для столбцов типа JSON.</value>

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.tr.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.tr.resx
@@ -4444,7 +4444,7 @@
     <value>Kapanım raporunun imza doğrulaması başarısız oldu. Rapor imzası, HGS kök sertifikası kullanılarak hesaplanan imzayla eşleşmiyor. Uç nokta için DNS eşlemesini doğrulayın - daha fazla için bkz. https://go.microsoft.com/fwlink/?linkid=2160553. Doğruysa Müşteri Destek Hizmetleri'ne başvurun.</value>
   </data>
   <data name="VerifyEnclaveKeyBindingFailed" xml:space="preserve">
-    <value>Enclave attestation failed because the signed enclave report did not bind to the enclave public key used to establish the session. The enclave public key must match the value committed to by the signed report - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details. If correct, contact Customer Support Services.</value>
+    <value>İmzalı kapanım raporu oturum oluşturulurken kullanılan kapanım ortak anahtarına bağlanmadığı için, kapanım kanıtlaması başarısız oldu. Kapanım ortak anahtarı, imzalı rapor tarafından işlenen değerle eşleşmelidir - diğer ayrıntılar için bkz. see https://go.microsoft.com/fwlink/?linkid=2160553. Doğruysa, Müşteri Destek Hizmetleri'ne başvurun.</value>
   </data>
   <data name="VerifyEnclaveReportFormatFailed" xml:space="preserve">
     <value>SQL Server'dan alınan kapanım raporu doğru biçimde değil. Müşteri Destek Hizmetleri'ne başvurun.</value>
@@ -4664,6 +4664,12 @@
   </data>
   <data name="SQL_RemoteCertificateDoesNotMatchServerCertificate" xml:space="preserve">
     <value>Sunucu tarafından sağlanan sertifika, ServerCertificate seçeneği tarafından sağlanan sertifikayla eşleşmiyor.</value>
+  </data>
+  <data name="SQL_ServerCertificateFileLoadFailed" xml:space="preserve">
+    <value>'ServerCertificate' seçeneğiyle belirtilen sertifika dosyası yüklenemedi veya ayrıştırılamadı: '{0}'.</value>
+  </data>
+  <data name="SQL_ServerCertificateNotAvailable" xml:space="preserve">
+    <value>'ServerCertificate' seçeneği belirtildi, ancak sunucu bununla karşılaştırılabilecek bir sertifika sunmadı.</value>
   </data>
   <data name="SQL_JsonDocumentNotSupportedOnColumnType" xml:space="preserve">
     <value>'{0}' sütununda JsonDocument alma denemesi geçersiz. JsonDocument yalnızca json türündeki sütunlar için desteklenir.</value>

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.zh-Hans.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.zh-Hans.resx
@@ -4444,7 +4444,7 @@
     <value>无法验证 enclave 报告的签名。报告签名与使用 HGS 根证书计算出的签名不匹配。请验证终结点的 DNS 映射 - 有关 更多 详细信息，请 参阅 https://go.microsoft.com/fwlink/?linkid=2160553。如果正确，请联系客户支持服务。</value>
   </data>
   <data name="VerifyEnclaveKeyBindingFailed" xml:space="preserve">
-    <value>Enclave attestation failed because the signed enclave report did not bind to the enclave public key used to establish the session. The enclave public key must match the value committed to by the signed report - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details. If correct, contact Customer Support Services.</value>
+    <value>Enclave 证明失败，因为已签名的 enclave 报表未绑定到用于建立会话的 enclave 公钥。Enclave 公钥必须与该签名报表提交的值匹配 - 有关详细信息，请参阅 https://go.microsoft.com/fwlink/?linkid=2160553。如果正确，请联系客户支持服务。</value>
   </data>
   <data name="VerifyEnclaveReportFormatFailed" xml:space="preserve">
     <value>从 SQL Server 收到的 enclave 报告的格式不正确。请联系客户支持服务。</value>
@@ -4664,6 +4664,12 @@
   </data>
   <data name="SQL_RemoteCertificateDoesNotMatchServerCertificate" xml:space="preserve">
     <value>服务器提供的证书与 ServerCertificate 选项提供的证书不匹配。</value>
+  </data>
+  <data name="SQL_ServerCertificateFileLoadFailed" xml:space="preserve">
+    <value>无法加载或解析 "ServerCertificate" 选项指定的证书文件: "{0}"。</value>
+  </data>
+  <data name="SQL_ServerCertificateNotAvailable" xml:space="preserve">
+    <value>已指定 "ServerCertificate" 选项，但服务器未提供可与其比较的证书。</value>
   </data>
   <data name="SQL_JsonDocumentNotSupportedOnColumnType" xml:space="preserve">
     <value>在列 ‘{0}’ 上获取 JsonDocument 的尝试无效。只有 json 类型的列支持 JsonDocument。</value>

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.zh-Hant.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.zh-Hant.resx
@@ -4444,7 +4444,7 @@
     <value>驗證記憶體保護區報表的簽章失敗。報表的簽章與使用 HGS 根憑證計算所得的簽章不符。請驗證端點的 DNS 對應 - 請參閱 https://go.microsoft.com/fwlink/?linkid=2160553 尋求 詳細 資訊。若其正確，請連絡客戶支援服務。</value>
   </data>
   <data name="VerifyEnclaveKeyBindingFailed" xml:space="preserve">
-    <value>Enclave attestation failed because the signed enclave report did not bind to the enclave public key used to establish the session. The enclave public key must match the value committed to by the signed report - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details. If correct, contact Customer Support Services.</value>
+    <value>記憶體保護區證明失敗，因為已簽署的記憶體保護區報表未繫結至用來建立工作階段的記憶體保護區公開金鑰。記憶體保護區公開金鑰必須符合已簽署報表所認可的值 - 如需詳細資料，請參閱 https://go.microsoft.com/fwlink/?linkid=2160553。若其正確，請連絡客戶支援服務。</value>
   </data>
   <data name="VerifyEnclaveReportFormatFailed" xml:space="preserve">
     <value>從 SQL Server 收到的記憶體保護區報表的格式不正確。請連絡客戶支援服務。</value>
@@ -4664,6 +4664,12 @@
   </data>
   <data name="SQL_RemoteCertificateDoesNotMatchServerCertificate" xml:space="preserve">
     <value>伺服器提供的憑證不符合 ServerCertificate 選項所提供的憑證。</value>
+  </data>
+  <data name="SQL_ServerCertificateFileLoadFailed" xml:space="preserve">
+    <value>無法載入或剖析 'ServerCertificate' 選項所指定的憑證檔案: '{0}'。</value>
+  </data>
+  <data name="SQL_ServerCertificateNotAvailable" xml:space="preserve">
+    <value>已指定 'ServerCertificate' 選項，但伺服器未提供可與其比對的憑證。</value>
   </data>
   <data name="SQL_JsonDocumentNotSupportedOnColumnType" xml:space="preserve">
     <value>在資料行 '{0}' 上取得 JsonDocument 的嘗試無效。JsonDocument 僅支援 JSON 類型的資料行。</value>


### PR DESCRIPTION
## Summary

Backports applicable localization updates from `main` to the `release/7.0` branch.

## Changes

- Added localized resources for:
  - `SQL_ServerCertificateFileLoadFailed`
  - `SQL_ServerCertificateNotAvailable`
- Updated `VerifyEnclaveKeyBindingFailed` localized resources, replacing the English fallback text in localized `.resx` files.
- Skipped `main`-only resource keys that are not referenced by the `release/7.0` branch.
- Confirmed the AKV provider resource file has no content changes to backport.

## Validation

- Ran `git diff --check`
- Parsed all modified `.resx` files successfully