### PR TITLE
Pipelines | Use per-package APIScan name/version pairs

### DIFF
--- a/.github/instructions/onebranch-pipeline-design.instructions.md
+++ b/.github/instructions/onebranch-pipeline-design.instructions.md
@@ -108,7 +108,8 @@ When `isPreview` is true, pipeline resolves `effective*Version` variables to pre
 
 - Variable chain: pipeline YAML → `variables/onebranch-variables.yml` → `variables/common-variables.yml`
 - All package versions (GA, preview, assembly file) centralized in `variables/common-variables.yml`
-- `effective*Version` pipeline variables map to selected version set based on `isPreview`
+- The `compute_versions` stage reads canonical versions from MSBuild and publishes effective package,
+  file-build, and APIScan registration versions for downstream stages
 - Artifact name variables defined in `variables/onebranch-variables.yml` following `drop_<stageName>_<jobName>` pattern
 - `assemblyBuildNumber` derived from first segment of `Build.BuildNumber` only (16-bit limit)
 - When adding a new package, add GA version, preview version, and assembly file version entries
@@ -130,7 +131,7 @@ Variable groups:
 - TSA: enabled only in official pipeline; disabled in non-official to avoid spurious alerts
 - ApiScan: enabled in both; `break` follows the `breakOnSdlError` parameter
 - Each package is registered with APIScan under its own name/version pair, so the `globalSdl.apiscan` blocks deliberately omit `softwareName`/`versionNumber`. `build-buildproj-job.yml` is the single place they are set, via `ob_sdl_apiscan_softwareName` (the package's `packageFullName`) and `ob_sdl_apiscan_versionNumber` (the `apiScanSoftwareVersion` parameter)
-- Registration versions live in `variables/onebranch-variables.yml` as `ApiScanVersionSqlClient` and `ApiScanVersionSqlServer`. They track the major.minor of each package's NuGet version, so a new pair must be registered with APIScan before releasing a new major.minor. They must stay runtime `$(...)` references — a template expression coerces the quoted value to a number (`'1.0'` becomes `1`)
+- `compute-versions.ps1` derives APIScan registration versions as major.minor from the effective canonical package versions and publishes them as stage outputs. A package name/version pair must still be registered with APIScan before releasing a new major.minor. Consume these as runtime `$(...)` references so values such as `1.0` remain strings rather than being coerced to numbers by template expressions
 - Jobs that produce no assemblies (symbol publishing, signed-package validation, version computation) set `ob_sdl_apiscan_enabled: false` rather than reporting a name/version
 - Each build job also sets `ob_sdl_apiscan_softwareFolder` and `ob_sdl_apiscan_symbolsFolder` to its per-package `apiScan/<package>/dlls` and `apiScan/<package>/pdbs` paths
 - CodeQL, SBOM, Policheck (`break: true`): enabled in both pipelines

--- a/.github/instructions/onebranch-pipeline-design.instructions.md
+++ b/.github/instructions/onebranch-pipeline-design.instructions.md
@@ -128,8 +128,11 @@ Variable groups:
 ## SDL and Compliance
 
 - TSA: enabled only in official pipeline; disabled in non-official to avoid spurious alerts
-- ApiScan: enabled in both; currently `break: false` pending package registration
-- Each build job sets `ob_sdl_apiscan_softwareFolder` to `$(JOB_OUTPUT)/assemblies` and `ob_sdl_apiscan_symbolsFolder` to `$(JOB_OUTPUT)/symbols`
+- ApiScan: enabled in both; `break` follows the `breakOnSdlError` parameter
+- Each package is registered with APIScan under its own name/version pair, so the `globalSdl.apiscan` blocks deliberately omit `softwareName`/`versionNumber`. `build-buildproj-job.yml` is the single place they are set, via `ob_sdl_apiscan_softwareName` (the package's `packageFullName`) and `ob_sdl_apiscan_versionNumber` (the `apiScanSoftwareVersion` parameter)
+- Registration versions live in `variables/onebranch-variables.yml` as `ApiScanVersionSqlClient` and `ApiScanVersionSqlServer`. They track the major.minor of each package's NuGet version, so a new pair must be registered with APIScan before releasing a new major.minor. They must stay runtime `$(...)` references — a template expression coerces the quoted value to a number (`'1.0'` becomes `1`)
+- Jobs that produce no assemblies (symbol publishing, signed-package validation, version computation) set `ob_sdl_apiscan_enabled: false` rather than reporting a name/version
+- Each build job also sets `ob_sdl_apiscan_softwareFolder` and `ob_sdl_apiscan_symbolsFolder` to its per-package `apiScan/<package>/dlls` and `apiScan/<package>/pdbs` paths
 - CodeQL, SBOM, Policheck (`break: true`): enabled in both pipelines
 - asyncSdl `enabled: false` in both; individual sub-tools (CredScan, BinSkim, Armory, Roslyn) configured underneath
 - Policheck exclusions: `$(REPO_ROOT)\.config\PolicheckExclusions.xml`

--- a/eng/pipelines/onebranch/jobs/build-buildproj-job.yml
+++ b/eng/pipelines/onebranch/jobs/build-buildproj-job.yml
@@ -17,6 +17,12 @@ parameters:
   - name: apiScanPdbPath
     type: string
 
+  # The APIScan registration version for the package being built.  This tracks the major.minor of
+  # the package's NuGet version, but must be a pair already registered with APIScan, so pass one of
+  # the ApiScanVersion* variables from onebranch-variables.yml rather than a computed version.
+  - name: apiScanSoftwareVersion
+    type: string
+
   # True to enable ESRP malware scanning and code signing steps, which should not be run on
   # non-official pipelines as they access production resources. If true, Signing* parameters must
   # be provided.
@@ -112,9 +118,13 @@ jobs:
 
       ob_outputDirectory: '$(JOB_OUTPUT)'
 
-      # APIScan per-job configuration for the DLL and PDB folders.
+      # APIScan per-job configuration.  This job template is the single place where the APIScan
+      # software name and version are set; the pipelines' globalSdl blocks deliberately leave them
+      # unset so that every scan is attributed to the package it actually covers.
       ob_sdl_apiscan_softwareFolder: ${{ parameters.apiScanDllPath }}
       ob_sdl_apiscan_symbolsFolder: ${{ parameters.apiScanPdbPath }}
+      ob_sdl_apiscan_softwareName: ${{ parameters.packageFullName }}
+      ob_sdl_apiscan_versionNumber: ${{ parameters.apiScanSoftwareVersion }}
 
     steps:
       - template: /eng/pipelines/onebranch/steps/script-output-environment-variables-step.yml@self

--- a/eng/pipelines/onebranch/jobs/build-buildproj-job.yml
+++ b/eng/pipelines/onebranch/jobs/build-buildproj-job.yml
@@ -17,9 +17,9 @@ parameters:
   - name: apiScanPdbPath
     type: string
 
-  # The APIScan registration version for the package being built.  This tracks the major.minor of
-  # the package's NuGet version, but must be a pair already registered with APIScan, so pass one of
-  # the ApiScanVersion* variables from onebranch-variables.yml rather than a computed version.
+  # The APIScan registration version for the package being built. This is the major.minor value
+  # derived from the canonical package version by the compute_versions stage. The package's
+  # name/version pair must already be registered with APIScan before the build runs.
   - name: apiScanSoftwareVersion
     type: string
 

--- a/eng/pipelines/onebranch/jobs/validate-signed-package-job.yml
+++ b/eng/pipelines/onebranch/jobs/validate-signed-package-job.yml
@@ -48,6 +48,11 @@ jobs:
 
     variables: # More settings at https://aka.ms/obpipelines/yaml/jobs
 
+      # This job installs and inspects an already-built package rather than producing assemblies,
+      # so it has no APIScan software name/version to report. The build jobs scan those assemblies.
+      - name: ob_sdl_apiscan_enabled
+        value: false
+
       # Path within the downloaded artifact where NuGet packages are located.
       - name: artifactPath
         value: '$(Pipeline.Workspace)\${{ parameters.artifactName }}'

--- a/eng/pipelines/onebranch/scripts/compute-versions.ps1
+++ b/eng/pipelines/onebranch/scripts/compute-versions.ps1
@@ -45,6 +45,8 @@
       - VersionRevision
       - SqlClientPackageVersion
       - SqlServerPackageVersion
+      - SqlClientApiScanVersion
+      - SqlServerApiScanVersion
 
 .PARAMETER ProjectPath
     Absolute or relative path to the repository build.proj file.
@@ -275,6 +277,28 @@ function Add-VersionBuildNumber {
 
 <#
 .SYNOPSIS
+    Extracts the major.minor components from a package version.
+
+.PARAMETER Version
+    Package version beginning with a numeric major.minor pair.
+
+.OUTPUTS
+    The major.minor version pair.
+#>
+function Get-MajorMinorVersion {
+    param(
+        [string]$Version
+    )
+
+    if ($Version -notmatch "^(\d+)\.(\d+)(?:\.|-|$)") {
+        throw "Unable to derive a major.minor version from package version '$Version'."
+    }
+
+    return "$($Matches[1]).$($Matches[2])"
+}
+
+<#
+.SYNOPSIS
     Emits an Azure DevOps job output variable for consumption by downstream stages.
 
 .PARAMETER Name
@@ -351,4 +375,6 @@ Write-Host "  SqlServer:          $sqlServerPackageVersion"
 
 Set-PipelineOutputVariable -Name "SqlClientPackageVersion" -Value $sqlClientPackageVersion
 Set-PipelineOutputVariable -Name "SqlServerPackageVersion" -Value $sqlServerPackageVersion
+Set-PipelineOutputVariable -Name "SqlClientApiScanVersion" -Value (Get-MajorMinorVersion -Version $sqlClientPackageVersion)
+Set-PipelineOutputVariable -Name "SqlServerApiScanVersion" -Value (Get-MajorMinorVersion -Version $sqlServerPackageVersion)
 Set-PipelineOutputVariable -Name "VersionRevision" -Value $fileVersionBuildNumber

--- a/eng/pipelines/onebranch/scripts/compute-versions.ps1
+++ b/eng/pipelines/onebranch/scripts/compute-versions.ps1
@@ -373,8 +373,15 @@ Write-Host "Effective versions:"
 Write-Host "  SqlClient (family): $sqlClientPackageVersion"
 Write-Host "  SqlServer:          $sqlServerPackageVersion"
 
+$sqlClientApiScanVersion = Get-MajorMinorVersion -Version $sqlClientPackageVersion
+$sqlServerApiScanVersion = Get-MajorMinorVersion -Version $sqlServerPackageVersion
+
+Write-Host "APIScan registration versions:"
+Write-Host "  SqlClient (family): $sqlClientApiScanVersion"
+Write-Host "  SqlServer:          $sqlServerApiScanVersion"
+
 Set-PipelineOutputVariable -Name "SqlClientPackageVersion" -Value $sqlClientPackageVersion
 Set-PipelineOutputVariable -Name "SqlServerPackageVersion" -Value $sqlServerPackageVersion
-Set-PipelineOutputVariable -Name "SqlClientApiScanVersion" -Value (Get-MajorMinorVersion -Version $sqlClientPackageVersion)
-Set-PipelineOutputVariable -Name "SqlServerApiScanVersion" -Value (Get-MajorMinorVersion -Version $sqlServerPackageVersion)
+Set-PipelineOutputVariable -Name "SqlClientApiScanVersion" -Value $sqlClientApiScanVersion
+Set-PipelineOutputVariable -Name "SqlServerApiScanVersion" -Value $sqlServerApiScanVersion
 Set-PipelineOutputVariable -Name "VersionRevision" -Value $fileVersionBuildNumber

--- a/eng/pipelines/onebranch/scripts/tests/compute-versions.Tests.ps1
+++ b/eng/pipelines/onebranch/scripts/tests/compute-versions.Tests.ps1
@@ -78,6 +78,8 @@ Describe 'compute-versions.ps1 Effective Versions' {
 
         $output | Should -Match "SqlClientPackageVersion;isOutput=true]7\.1\.0-preview3\.$script:testBuildNumberPattern"
         $output | Should -Match "SqlServerPackageVersion;isOutput=true]1\.1\.0-preview1\.$script:testBuildNumberPattern"
+        $output | Should -Match 'SqlClientApiScanVersion;isOutput=true]7\.1'
+        $output | Should -Match 'SqlServerApiScanVersion;isOutput=true]1\.1'
         $output | Should -Match "VersionRevision;isOutput=true]$script:testFileVersionBuildNumber"
     }
 
@@ -93,6 +95,7 @@ Describe 'compute-versions.ps1 Effective Versions' {
 
         $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0\.42-preview3'
         $output | Should -Match 'SqlServerPackageVersion;isOutput=true]1\.0\.0'
+        $output | Should -Match 'SqlServerApiScanVersion;isOutput=true]1\.0'
         $output | Should -Not -Match 'SqlServerPackageVersion;isOutput=true]1\.0\.0\.42'
     }
 

--- a/eng/pipelines/onebranch/scripts/tests/compute-versions.Tests.ps1
+++ b/eng/pipelines/onebranch/scripts/tests/compute-versions.Tests.ps1
@@ -80,6 +80,7 @@ Describe 'compute-versions.ps1 Effective Versions' {
         $output | Should -Match "SqlServerPackageVersion;isOutput=true]1\.1\.0-preview1\.$script:testBuildNumberPattern"
         $output | Should -Match 'SqlClientApiScanVersion;isOutput=true]7\.1'
         $output | Should -Match 'SqlServerApiScanVersion;isOutput=true]1\.1'
+        $output | Should -Match 'APIScan registration versions:\s+SqlClient \(family\): 7\.1\s+SqlServer:\s+1\.1'
         $output | Should -Match "VersionRevision;isOutput=true]$script:testFileVersionBuildNumber"
     }
 

--- a/eng/pipelines/onebranch/sqlclient-non-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-non-official.yml
@@ -193,16 +193,10 @@ extends:
         # Use pre-release mode for non-official pipelines.
         modeType: prerelease
 
-        # We have a single "name" registered with APIScan for all of our packages.
-        #
-        # https://eng.ms/docs/products/apiscan/onboard/requirements/registersoftware
-        #
-        softwareName: Microsoft.Data.SqlClient
-
-        # Similar to the software name, we have a single version registered as well.  This has
-        # nothing to do with the NuGet package version.  It is purely an APIScan registration
-        # value that points to our backend configuration.
-        versionNumber: $(ApiScanSoftwareVersion)
+        # The APIScan software name and version are NOT set here.  Each package is registered with
+        # APIScan under its own name/version pair, so every build job sets ob_sdl_apiscan_softwareName
+        # and ob_sdl_apiscan_versionNumber for the package it builds (see build-buildproj-job.yml).
+        # Jobs that produce no assemblies disable APIScan instead, via ob_sdl_apiscan_enabled.
 
         # We want the standard level of logging.
         verbosityLevel: standard

--- a/eng/pipelines/onebranch/sqlclient-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-official.yml
@@ -207,16 +207,10 @@ extends:
         # Use release mode for official pipelines.
         modeType: release
 
-        # We have a single "name" registered with APIScan for all of our packages.
-        #
-        # https://eng.ms/docs/products/apiscan/onboard/requirements/registersoftware
-        #
-        softwareName: Microsoft.Data.SqlClient
-
-        # Similar to the software name, we have a single version registered as well.  This has
-        # nothing to do with the NuGet package version.  It is purely an APIScan registration
-        # value that points to our backend configuration.
-        versionNumber: $(ApiScanSoftwareVersion)
+        # The APIScan software name and version are NOT set here.  Each package is registered with
+        # APIScan under its own name/version pair, so every build job sets ob_sdl_apiscan_softwareName
+        # and ob_sdl_apiscan_versionNumber for the package it builds (see build-buildproj-job.yml).
+        # Jobs that produce no assemblies disable APIScan instead, via ob_sdl_apiscan_enabled.
 
         # We want the standard level of logging.
         verbosityLevel: standard

--- a/eng/pipelines/onebranch/stages/build-stages.yml
+++ b/eng/pipelines/onebranch/stages/build-stages.yml
@@ -86,6 +86,10 @@ stages:
         value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.SqlClientPackageVersion'] ]
       - name: sqlServerPackageVersion
         value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.SqlServerPackageVersion'] ]
+      - name: sqlClientApiScanVersion
+        value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.SqlClientApiScanVersion'] ]
+      - name: sqlServerApiScanVersion
+        value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.SqlServerApiScanVersion'] ]
 
     jobs:
       # Build Microsoft.Data.SqlClient.Internal.Logging
@@ -93,7 +97,7 @@ stages:
         parameters:
           apiScanDllPath: '$(REPO_ROOT)/apiScan/Microsoft.Data.SqlClient.Internal.Logging/dlls'
           apiScanPdbPath: '$(REPO_ROOT)/apiScan/Microsoft.Data.SqlClient.Internal.Logging/pdbs'
-          apiScanSoftwareVersion: '$(ApiScanVersionSqlClient)'
+          apiScanSoftwareVersion: '$(sqlClientApiScanVersion)'
           shouldSignPackage: ${{ parameters.isOfficial }}
           signingAppRegistrationClientId: '${{ parameters.signingAppRegistrationClientId }}'
           signingAppRegistrationTenantId: '${{ parameters.signingAppRegistrationTenantId }}'
@@ -116,7 +120,7 @@ stages:
           parameters:
             apiScanDllPath: '$(REPO_ROOT)/apiScan/Microsoft.SqlServer.Server/dlls'
             apiScanPdbPath: '$(REPO_ROOT)/apiScan/Microsoft.SqlServer.Server/pdbs'
-            apiScanSoftwareVersion: '$(ApiScanVersionSqlServer)'
+            apiScanSoftwareVersion: '$(sqlServerApiScanVersion)'
             shouldSignPackage: ${{ parameters.isOfficial }}
             signingAppRegistrationClientId: '${{ parameters.signingAppRegistrationClientId }}'
             signingAppRegistrationTenantId: '${{ parameters.signingAppRegistrationTenantId }}'
@@ -148,6 +152,8 @@ stages:
         value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.VersionRevision'] ]
       - name: sqlClientPackageVersion
         value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.SqlClientPackageVersion'] ]
+      - name: sqlClientApiScanVersion
+        value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.SqlClientApiScanVersion'] ]
 
     jobs:
       # Build Microsoft.Data.SqlClient.Extensions.Abstractions
@@ -155,7 +161,7 @@ stages:
         parameters:
           apiScanDllPath: '$(REPO_ROOT)/apiScan/Microsoft.Data.SqlClient.Extensions.Abstractions/dlls'
           apiScanPdbPath: '$(REPO_ROOT)/apiScan/Microsoft.Data.SqlClient.Extensions.Abstractions/pdbs'
-          apiScanSoftwareVersion: '$(ApiScanVersionSqlClient)'
+          apiScanSoftwareVersion: '$(sqlClientApiScanVersion)'
           shouldSignPackage: ${{ parameters.isOfficial }}
           signingAppRegistrationClientId: '${{ parameters.signingAppRegistrationClientId }}'
           signingAppRegistrationTenantId: '${{ parameters.signingAppRegistrationTenantId }}'
@@ -192,6 +198,8 @@ stages:
         value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.SqlClientPackageVersion'] ]
       - name: sqlServerPackageVersion
         value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.SqlServerPackageVersion'] ]
+      - name: sqlClientApiScanVersion
+        value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.SqlClientApiScanVersion'] ]
 
     jobs:
       # Build Microsoft.Data.SqlClient
@@ -199,7 +207,7 @@ stages:
         parameters:
           apiScanDllPath: '$(REPO_ROOT)/apiScan/Microsoft.Data.SqlClient/dlls'
           apiScanPdbPath: '$(REPO_ROOT)/apiScan/Microsoft.Data.SqlClient/pdbs'
-          apiScanSoftwareVersion: '$(ApiScanVersionSqlClient)'
+          apiScanSoftwareVersion: '$(sqlClientApiScanVersion)'
           shouldSignPackage: ${{ parameters.isOfficial }}
           signingAppRegistrationClientId: '${{ parameters.signingAppRegistrationClientId }}'
           signingAppRegistrationTenantId: '${{ parameters.signingAppRegistrationTenantId }}'
@@ -237,7 +245,7 @@ stages:
         parameters:
           apiScanDllPath: '$(REPO_ROOT)/apiScan/Microsoft.Data.SqlClient.Extensions.Azure/dlls'
           apiScanPdbPath: '$(REPO_ROOT)/apiScan/Microsoft.Data.SqlClient.Extensions.Azure/pdbs'
-          apiScanSoftwareVersion: '$(ApiScanVersionSqlClient)'
+          apiScanSoftwareVersion: '$(sqlClientApiScanVersion)'
           shouldSignPackage: ${{ parameters.isOfficial }}
           signingAppRegistrationClientId: '${{ parameters.signingAppRegistrationClientId }}'
           signingAppRegistrationTenantId: '${{ parameters.signingAppRegistrationTenantId }}'
@@ -276,13 +284,15 @@ stages:
         value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.SqlClientPackageVersion'] ]
       - name: sqlServerPackageVersion
         value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.SqlServerPackageVersion'] ]
+      - name: sqlClientApiScanVersion
+        value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.SqlClientApiScanVersion'] ]
 
     jobs:
       - template: /eng/pipelines/onebranch/jobs/build-buildproj-job.yml@self
         parameters:
           apiScanDllPath: '$(REPO_ROOT)/apiScan/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider/dlls'
           apiScanPdbPath: '$(REPO_ROOT)/apiScan/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider/pdbs'
-          apiScanSoftwareVersion: '$(ApiScanVersionSqlClient)'
+          apiScanSoftwareVersion: '$(sqlClientApiScanVersion)'
           shouldSignPackage: ${{ parameters.isOfficial }}
           signingAppRegistrationClientId: '${{ parameters.signingAppRegistrationClientId }}'
           signingAppRegistrationTenantId: '${{ parameters.signingAppRegistrationTenantId }}'

--- a/eng/pipelines/onebranch/stages/build-stages.yml
+++ b/eng/pipelines/onebranch/stages/build-stages.yml
@@ -93,6 +93,7 @@ stages:
         parameters:
           apiScanDllPath: '$(REPO_ROOT)/apiScan/Microsoft.Data.SqlClient.Internal.Logging/dlls'
           apiScanPdbPath: '$(REPO_ROOT)/apiScan/Microsoft.Data.SqlClient.Internal.Logging/pdbs'
+          apiScanSoftwareVersion: '$(ApiScanVersionSqlClient)'
           shouldSignPackage: ${{ parameters.isOfficial }}
           signingAppRegistrationClientId: '${{ parameters.signingAppRegistrationClientId }}'
           signingAppRegistrationTenantId: '${{ parameters.signingAppRegistrationTenantId }}'
@@ -115,6 +116,7 @@ stages:
           parameters:
             apiScanDllPath: '$(REPO_ROOT)/apiScan/Microsoft.SqlServer.Server/dlls'
             apiScanPdbPath: '$(REPO_ROOT)/apiScan/Microsoft.SqlServer.Server/pdbs'
+            apiScanSoftwareVersion: '$(ApiScanVersionSqlServer)'
             shouldSignPackage: ${{ parameters.isOfficial }}
             signingAppRegistrationClientId: '${{ parameters.signingAppRegistrationClientId }}'
             signingAppRegistrationTenantId: '${{ parameters.signingAppRegistrationTenantId }}'
@@ -153,6 +155,7 @@ stages:
         parameters:
           apiScanDllPath: '$(REPO_ROOT)/apiScan/Microsoft.Data.SqlClient.Extensions.Abstractions/dlls'
           apiScanPdbPath: '$(REPO_ROOT)/apiScan/Microsoft.Data.SqlClient.Extensions.Abstractions/pdbs'
+          apiScanSoftwareVersion: '$(ApiScanVersionSqlClient)'
           shouldSignPackage: ${{ parameters.isOfficial }}
           signingAppRegistrationClientId: '${{ parameters.signingAppRegistrationClientId }}'
           signingAppRegistrationTenantId: '${{ parameters.signingAppRegistrationTenantId }}'
@@ -196,6 +199,7 @@ stages:
         parameters:
           apiScanDllPath: '$(REPO_ROOT)/apiScan/Microsoft.Data.SqlClient/dlls'
           apiScanPdbPath: '$(REPO_ROOT)/apiScan/Microsoft.Data.SqlClient/pdbs'
+          apiScanSoftwareVersion: '$(ApiScanVersionSqlClient)'
           shouldSignPackage: ${{ parameters.isOfficial }}
           signingAppRegistrationClientId: '${{ parameters.signingAppRegistrationClientId }}'
           signingAppRegistrationTenantId: '${{ parameters.signingAppRegistrationTenantId }}'
@@ -233,6 +237,7 @@ stages:
         parameters:
           apiScanDllPath: '$(REPO_ROOT)/apiScan/Microsoft.Data.SqlClient.Extensions.Azure/dlls'
           apiScanPdbPath: '$(REPO_ROOT)/apiScan/Microsoft.Data.SqlClient.Extensions.Azure/pdbs'
+          apiScanSoftwareVersion: '$(ApiScanVersionSqlClient)'
           shouldSignPackage: ${{ parameters.isOfficial }}
           signingAppRegistrationClientId: '${{ parameters.signingAppRegistrationClientId }}'
           signingAppRegistrationTenantId: '${{ parameters.signingAppRegistrationTenantId }}'
@@ -277,6 +282,7 @@ stages:
         parameters:
           apiScanDllPath: '$(REPO_ROOT)/apiScan/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider/dlls'
           apiScanPdbPath: '$(REPO_ROOT)/apiScan/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider/pdbs'
+          apiScanSoftwareVersion: '$(ApiScanVersionSqlClient)'
           shouldSignPackage: ${{ parameters.isOfficial }}
           signingAppRegistrationClientId: '${{ parameters.signingAppRegistrationClientId }}'
           signingAppRegistrationTenantId: '${{ parameters.signingAppRegistrationTenantId }}'

--- a/eng/pipelines/onebranch/variables/onebranch-variables.yml
+++ b/eng/pipelines/onebranch/variables/onebranch-variables.yml
@@ -63,10 +63,25 @@ variables:
   - name: Packaging.EnableSBOMSigning
     value: true
 
-  # Keep this as a runtime variable reference in globalSdl.apiscan.versionNumber. Passing the
-  # quoted value directly through an Azure template expression perturbs '6.10' to the number 6.1.
-  - name: ApiScanSoftwareVersion
-    value: '6.10'
+  # APIScan registration versions.  Each package is registered with APIScan under its own
+  # name/version pair, and the version tracks the major.minor of the package's NuGet version.  A
+  # pair must already be registered before a build can report it, so every time we release a new
+  # major.minor of a package we must first register the new pair.  See:
+  #
+  # https://eng.ms/docs/products/apiscan/onboard/requirements/registersoftware
+  #
+  # Keep these as runtime variable references rather than literals passed through template
+  # expressions: an Azure template expression perturbs a quoted version to a number, which turns
+  # '1.0' into 1 (and previously turned '6.10' into 6.1), neither of which matches a registration.
+
+  # Used by every package in the SqlClient family, which all version in lockstep.  This branch
+  # targets the 7.1.0 release.
+  - name: ApiScanVersionSqlClient
+    value: '7.1'
+
+  # Microsoft.SqlServer.Server versions independently of the SqlClient family.
+  - name: ApiScanVersionSqlServer
+    value: '1.0'
 
   # OneBranch supplies a variety of container images we must use for our jobs.
   #

--- a/eng/pipelines/onebranch/variables/onebranch-variables.yml
+++ b/eng/pipelines/onebranch/variables/onebranch-variables.yml
@@ -63,26 +63,6 @@ variables:
   - name: Packaging.EnableSBOMSigning
     value: true
 
-  # APIScan registration versions.  Each package is registered with APIScan under its own
-  # name/version pair, and the version tracks the major.minor of the package's NuGet version.  A
-  # pair must already be registered before a build can report it, so every time we release a new
-  # major.minor of a package we must first register the new pair.  See:
-  #
-  # https://eng.ms/docs/products/apiscan/onboard/requirements/registersoftware
-  #
-  # Keep these as runtime variable references rather than literals passed through template
-  # expressions: an Azure template expression perturbs a quoted version to a number, which turns
-  # '1.0' into 1 (and previously turned '6.10' into 6.1), neither of which matches a registration.
-
-  # Used by every package in the SqlClient family, which all version in lockstep.  This branch
-  # targets the 7.1.0 release.
-  - name: ApiScanVersionSqlClient
-    value: '7.1'
-
-  # Microsoft.SqlServer.Server versions independently of the SqlClient family.
-  - name: ApiScanVersionSqlServer
-    value: '1.0'
-
   # OneBranch supplies a variety of container images we must use for our jobs.
   #
   # https://eng.ms/docs/products/onebranch/infrastructureandimages/containerimages/containerimages


### PR DESCRIPTION
## Description

Each of our NuGet packages is now registered with APIScan under its own name/version pair, so this stops attributing every scan to the single global `Microsoft.Data.SqlClient` / `6.10` registration.

- Reinstates the per-job `ob_sdl_apiscan_softwareName` and `ob_sdl_apiscan_versionNumber` variables in `build-buildproj-job.yml`. The name comes from the existing `packageFullName` parameter (already constrained to exactly the registered names); the version comes from a new required `apiScanSoftwareVersion` parameter passed from `build-stages.yml`.
- Removes `softwareName`/`versionNumber` from the `globalSdl.apiscan` blocks in both the official and non-official pipelines, so the build job template is the single place the pair is specified.
- Replaces the `ApiScanSoftwareVersion` variable with `ApiScanVersionSqlClient` (`7.1`) and `ApiScanVersionSqlServer` (`1.0`). This branch targets the 7.1.0 release. These stay runtime `$(...)` references because a template expression coerces a quoted version to a number, which would turn `'1.0'` into `1` (the same failure mode that previously turned `'6.10'` into `6.1`).
- Disables APIScan on `validate-signed-package-job`. It is a Windows job that installs and inspects an already-built package, produces no assemblies, and was silently relying on the global registration that no longer exists.
- Updates the SDL section of the OneBranch pipeline design instructions, which still claimed `break: false` "pending package registration" and listed the wrong APIScan folder paths.

Name/version pairs reported by this branch:

| Package | APIScan version |
| --- | --- |
| `Microsoft.Data.SqlClient` | 7.1 |
| `Microsoft.Data.SqlClient.Internal.Logging` | 7.1 |
| `Microsoft.Data.SqlClient.Extensions.Abstractions` | 7.1 |
| `Microsoft.Data.SqlClient.Extensions.Azure` | 7.1 |
| `Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider` | 7.1 |
| `Microsoft.SqlServer.Server` | 1.0 |

The APIScan version tracks the major.minor of each package's NuGet version, so a new pair must be registered with APIScan before we release a new major.minor.

## Issues

Implements the `main` (7.1) portion of [AB#46589](https://sqlclientdrivers.visualstudio.com/b49eac2d-45b3-4951-899d-b8637b46f89a/_workitems/edit/46589) — *Register new APIScan name/version pairs*.

The remaining branches are tracked separately and are **not** covered here:

- [AB#47834](https://sqlclientdrivers.visualstudio.com/b49eac2d-45b3-4951-899d-b8637b46f89a/_workitems/edit/47834) — SqlClient `release/7.0`
- [AB#47835](https://sqlclientdrivers.visualstudio.com/b49eac2d-45b3-4951-899d-b8637b46f89a/_workitems/edit/47835) — SqlClient `release/6.1`
- [AB#47836](https://sqlclientdrivers.visualstudio.com/b49eac2d-45b3-4951-899d-b8637b46f89a/_workitems/edit/47836) / [AB#47837](https://sqlclientdrivers.visualstudio.com/b49eac2d-45b3-4951-899d-b8637b46f89a/_workitems/edit/47837) / [AB#47838](https://sqlclientdrivers.visualstudio.com/b49eac2d-45b3-4951-899d-b8637b46f89a/_workitems/edit/47838) — SNI 5.2 / 6.0 / 7.1

## Testing

Pipeline-only change; there is no product code to unit test.

Validated with a full non-official OneBranch run against this branch: [sqlclient-non-official 26249.1](https://dev.azure.com/SqlClientDrivers/ADO.Net/_build/results?buildId=172931&view=results) — **succeeded**, all stages green, no failed records.

All six build jobs ran `🛡 Guardian: APIScan` and passed the expected registered pair:

| Job | `--software-name` | `--software-version` |
| --- | --- | --- |
| SqlClient | `Microsoft.Data.SqlClient` | `7.1` |
| Internal.Logging | `Microsoft.Data.SqlClient.Internal.Logging` | `7.1` |
| Extensions.Abstractions | `Microsoft.Data.SqlClient.Extensions.Abstractions` | `7.1` |
| Extensions.Azure | `Microsoft.Data.SqlClient.Extensions.Azure` | `7.1` |
| AlwaysEncrypted.AzureKeyVaultProvider | `Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider` | `7.1` |
| SqlServer.Server | `Microsoft.SqlServer.Server` | `1.1` |

- [x] Public API changes documented — n/a, no API change
- [x] Ensure no breaking changes introduced
