### PR TITLE
Use official name for US English locale

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml
@@ -505,7 +505,7 @@ The following example creates multiple instances of <xref:Microsoft.Data.SqlClie
           {
               SqlParameter parameter = new SqlParameter("pName", SqlDbType.VarChar);
               parameter.LocaleId = 1033;
-              // English - United States
+              // English (United States)
           }
         </code>
       </remarks>


### PR DESCRIPTION
## Summary

- updates the LCID 1033 documentation comment to use the official Windows locale name `English (United States)`
- addresses the only mismatch found while reviewing language and locale names for Microsoft.Data.SqlClient 7.1 GA
- leaves runtime behavior, public APIs, localized resources, package metadata, and `Current Language` connection-string handling unchanged

Azure DevOps task: [45863 - Review Language Names](https://sqlclientdrivers.visualstudio.com/ADO.Net/_workitems/edit/45863)
Parent story: [45850 - Global Readiness for GA Release 7.1](https://sqlclientdrivers.visualstudio.com/ADO.Net/_workitems/edit/45850)

## Review evidence

The requirement is applicable rather than N/A because a shipped documentation sample displayed LCID 1033 as `English - United States`. Microsoft Windows documentation names this locale `English (United States)`.

The broader review found no other curated language or locale name mismatch. `Current Language` is an opaque SQL Server language-record name or alias passed through to the TDS login, LCID tables contain numeric protocol mappings, and satellite resource paths use technical culture identifiers.

## Checklist

- [x] Tests added or updated — not applicable; documentation-only comment correction
- [x] Public API changes documented — no public API changes
- [x] Verified against customer repro — not applicable; compliance review
- [x] Ensure no breaking changes introduced