### PR TITLE
Disable legacy package-reference pipelines on main

### DIFF
--- a/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
@@ -59,7 +59,9 @@ trigger:
   branches:
     include:
       # GitHub main and release branches.
-      - main
+      #
+      # GOTCHA: Currently disabled on main due to limited resources.
+      #- main
       - release/*
 
       # ADO main and release branches.

--- a/eng/pipelines/sqlclient-pr-package-ref-pipeline.yml
+++ b/eng/pipelines/sqlclient-pr-package-ref-pipeline.yml
@@ -34,9 +34,11 @@ pr:
   branches:
     include:
       # GitHub repo branch targets that will trigger PR validation builds.
-      - dev/*
-      - feat/*
-      - main
+      #
+      # GOTCHA: Currently disabled on all but release/* due to limited resources.
+      #- dev/*
+      #- feat/*
+      #- main
       - release/*
 
   paths:


### PR DESCRIPTION
## Description

Limit the legacy package-reference pipelines so they no longer run:

- For GitHub pull requests targeting `main`, `dev/*`, or `feat/*`.
- From CI push triggers after merges to GitHub `main`.

Package-reference validation remains enabled for release branches. The existing scheduled runs on GitHub `main` and ADO `internal/main` remain enabled, as do CI push triggers for ADO `internal/main` and release branches.

This is an engineering-process-only change with no product API or runtime behavior changes.
