### PR TITLE
Update pipelines for the 7.1 staging branch

### DIFF
--- a/.github/instructions/ado-pipelines.instructions.md
+++ b/.github/instructions/ado-pipelines.instructions.md
@@ -70,14 +70,14 @@ When adding a new build stage, respect the dependency graph and pass artifact na
 ## PR vs CI Pipeline Differences
 
 PR pipelines:
-- Trigger on PRs to `dev/*`, `feat/*`, `main`; exclude `eng/pipelines/onebranch/*` paths
+- Trigger on PRs targeting `release/7.1`; path filters vary by pipeline
 - Use reduced TFM matrix: `[net462, net8.0, net9.0]` (excludes net10.0)
 - Timeout: 90 minutes
 - Package-ref PR disables Always Encrypted tests in Debug config and also disables legacy SQL Server test legs to keep validation fast
 
 CI pipelines:
-- Trigger on push to `main` (GitHub) and `internal/main` (ADO) with `batch: true`
-- Scheduled weekday builds (see individual pipeline files for cron times)
+- Trigger on push to `release/7.1` (GitHub) and `internal/release/7.1` (ADO) with `batch: true`
+- Scheduled daily builds are staggered to avoid main and other release-branch schedules (see individual pipeline files for cron times)
 - Full TFM matrix including net10.0 test legs and legacy SQL Server manual-test coverage
 
 ## Test Configuration

--- a/.github/instructions/onebranch-pipeline-design.instructions.md
+++ b/.github/instructions/onebranch-pipeline-design.instructions.md
@@ -9,7 +9,7 @@ Rules and conventions for editing the OneBranch Azure DevOps YAML pipelines that
 
 ## Pipeline Variants
 
-- `sqlclient-official.yml` — Official pipeline; uses `OneBranch.Official.CrossPlat.yml`; runs on a daily schedule at 04:30 UTC on `internal/main`, with no activity-based trigger (`pr: none`, `trigger: none`)
+- `sqlclient-official.yml` — Official pipeline; uses `OneBranch.Official.CrossPlat.yml`; runs on a daily schedule at 23:00 UTC on `internal/release/7.1`, with no activity-based trigger (`pr: none`, `trigger: none`)
 - `sqlclient-non-official.yml` — Non-Official pipeline; uses `OneBranch.NonOfficial.CrossPlat.yml`; manual only (`pr: none`, `trigger: none`)
 - Both live under `eng/pipelines/onebranch/` and extend OneBranch governed templates
 - Never parameterize the OneBranch template name — hardcode it per pipeline for PRC compliance

--- a/eng/pipelines/ci/kerberos/sqlclient-ci-kerberos-pipeline.yml
+++ b/eng/pipelines/ci/kerberos/sqlclient-ci-kerberos-pipeline.yml
@@ -26,7 +26,7 @@ resources:
       trigger:
         branches:
           include:
-            - internal/main
+            - internal/release/7.1-staging
 
 parameters:
 

--- a/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-pipeline.yml
+++ b/eng/pipelines/ci/managed-instance/sqlclient-ci-managed-instance-pipeline.yml
@@ -42,7 +42,7 @@ resources:
       trigger:
         branches:
           include:
-            - internal/main
+            - internal/release/7.1-staging
 
 # Pipeline parameters, visible in the Azure DevOps UI.
 parameters:

--- a/eng/pipelines/ci/package/sqlclient-ci-package-pipeline.yml
+++ b/eng/pipelines/ci/package/sqlclient-ci-package-pipeline.yml
@@ -7,17 +7,17 @@
 # This pipeline builds all packages using the build.proj Pack target with ReferenceType=Package,
 # then publishes the resulting .nupkg and .snupkg files as a single pipeline artifact.
 #
-# It runs nightly at 00:20 UTC on GitHub dotnet/SqlClient main and ADO.Net dotnet-sqlclient
-# internal/main.
+# It runs daily at 13:00 UTC on GitHub dotnet/SqlClient release/7.1 and at 21:00 UTC on ADO.Net
+# dotnet-sqlclient internal/release/7.1.
 #
-# On internal/main the strong-name signing key is downloaded and used to sign assemblies during the
-# build.
+# On internal/release/7.1 the strong-name signing key is downloaded and used to sign assemblies
+# during the build.
 #
 # GOTCHA: This pipeline definition is triggered by GitHub _and_ ADO.NET CI.  We distinguish the two
 # via branch filters:
 #
-#   - Only the GitHub repo has a 'main' branch.
-#   - Only the ADO repo has an 'internal/main' branch.
+#   - Only the GitHub repo has a 'release/7.1' branch.
+#   - Only the ADO repo has an 'internal/release/7.1' branch.
 
 name: $(DayOfYear)$(Rev:rr)
 
@@ -25,14 +25,22 @@ name: $(DayOfYear)$(Rev:rr)
 pr: none
 trigger: none
 
-# Nightly schedule at 00:20 UTC.
+# Stagger the GitHub and ADO builds so their downstream completion-triggered pipelines do not start
+# at the same time.
 schedules:
-  - cron: '20 0 * * *'
-    displayName: Nightly Build
+  - cron: '0 13 * * *'
+    displayName: 7.1 GitHub Daily Package Build (13:00 UTC)
     branches:
       include:
-        - main
-        - internal/main
+        - release/7.1-staging
+
+    always: true
+
+  - cron: '0 21 * * *'
+    displayName: 7.1 ADO Daily Package Build (21:00 UTC)
+    branches:
+      include:
+        - internal/release/7.1-staging
     always: true
 
 # Pipeline parameters visible in the Azure DevOps UI.

--- a/eng/pipelines/ci/stress/sqlclient-ci-stress-pipeline.yml
+++ b/eng/pipelines/ci/stress/sqlclient-ci-stress-pipeline.yml
@@ -49,8 +49,8 @@ resources:
       trigger:
         branches:
           include:
-            - main
-            - internal/main
+            - release/7.1-staging
+            - internal/release/7.1-staging
 
 # Pipeline parameters, visible in the Azure DevOps UI.
 parameters:

--- a/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
@@ -14,7 +14,7 @@
 # It runs via CI push triggers and schedules and uses the Release build
 # configuration:
 #
-#   - Commits to the GitHub release/7.1 branch
+#   - GitHub CI push trigger disabled due to limited resources
 #   - Commits to the ADO internal/release/7.1 branch
 #   - Daily at 11:00 UTC on GitHub release/7.1
 #   - Daily at 19:00 UTC on ADO internal/release/7.1
@@ -58,7 +58,9 @@ trigger:
   branches:
     include:
       # GitHub release branch.
-      - release/7.1-staging
+      #
+      # GOTCHA: Currently disabled due to limited resources.
+      #- release/7.1-staging
 
       # ADO release branch.
       - internal/release/7.1-staging

--- a/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
@@ -14,18 +14,17 @@
 # It runs via CI push triggers and schedules and uses the Release build
 # configuration:
 #
-#   - Commits to GitHub main and release/* branches
-#   - Commits to ADO internal/main and internal/release/* branches
-#   - Daily at 03:00 UTC on GitHub main
-#   - Daily at 07:00 UTC on ADO internal/main
+#   - Commits to the GitHub release/7.1 branch
+#   - Commits to the ADO internal/release/7.1 branch
+#   - Daily at 11:00 UTC on GitHub release/7.1
+#   - Daily at 19:00 UTC on ADO internal/release/7.1
 #
 # GOTCHA: This pipeline definition is triggered by GitHub _and_ ADO CI.  We are
 # able to define different triggers and schedules using branch filters:
 #
-#   - Only the GitHub repo has a 'main' branch, so its presence indicates that
-#     the pipeline run was triggered via GitHub.
+#   - The GitHub registration uses the release/7.1 branch filters.
 #
-#   - Only the ADO repo has an 'internal/main' branch.
+#   - The ADO registration uses the internal/release/7.1 branch filters.
 #
 # Changes are batched together to ensure that the pipline never runs
 # concurrently.
@@ -58,31 +57,29 @@ trigger:
 
   branches:
     include:
-      # GitHub main and release branches.
-      - main
-      - release/*
+      # GitHub release branch.
+      - release/7.1-staging
 
-      # ADO main and release branches.
-      - internal/main
-      - internal/release/*
+      # ADO release branch.
+      - internal/release/7.1-staging
 
 # Trigger this pipeline on a schedule.
 schedules:
 
-  # GitHub main daily.
-  - cron: '0 3 * * *'
-    displayName: Daily Run (Release Config)
+  # GitHub release/7.1 daily.
+  - cron: '0 11 * * *'
+    displayName: 7.1 GitHub Package-Reference Daily Run (11:00 UTC)
     branches:
       include:
-      - main
+      - release/7.1-staging
     always: true
 
-  # ADO internal/main daily.
-  - cron: '0 7 * * *'
-    displayName: Daily Run (Release Config)
+  # ADO internal/release/7.1 daily.
+  - cron: '0 19 * * *'
+    displayName: 7.1 ADO Package-Reference Daily Run (19:00 UTC)
     branches:
       include:
-      - internal/main
+      - internal/release/7.1-staging
     always: true
 
 # Pipeline parameters, visible in the Azure DevOps UI.

--- a/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
@@ -14,18 +14,17 @@
 # It runs via CI push triggers and schedules and uses the Release build
 # configuration:
 #
-#   - Commits to GitHub main and release/* branches
-#   - Commits to ADO internal/main and internal/release/* branches
-#   - Daily at 01:00 UTC on GitHub main
-#   - Daily at 05:00 UTC on ADO internal/main
+#   - Commits to the GitHub release/7.1 branch
+#   - Commits to the ADO internal/release/7.1 branch
+#   - Daily at 09:00 UTC on GitHub release/7.1
+#   - Daily at 17:00 UTC on ADO internal/release/7.1
 #
 # GOTCHA: This pipeline definition is triggered by GitHub _and_ ADO CI.  We are
 # able to define different triggers and schedules using branch filters:
 #
-#   - Only the GitHub repo has a 'main' branch, so its presence indicates that
-#     the pipeline run was triggered via GitHub.
+#   - The GitHub registration uses the release/7.1 branch filters.
 #
-#   - Only the ADO repo has an 'internal/main' branch.
+#   - The ADO registration uses the internal/release/7.1 branch filters.
 #
 # Changes are batched together to ensure that the pipline never runs
 # concurrently.
@@ -58,31 +57,29 @@ trigger:
 
   branches:
     include:
-      # GitHub main and release branches.
-      - main
-      - release/*
+      # GitHub release branch.
+      - release/7.1-staging
 
-      # ADO main and release branches.
-      - internal/main
-      - internal/release/*
+      # ADO release branch.
+      - internal/release/7.1-staging
 
 # Trigger this pipeline on a schedule.
 schedules:
 
-  # GitHub main daily.
-  - cron: '0 1 * * *'
-    displayName: Daily Run (Release Config)
+  # GitHub release/7.1 daily.
+  - cron: '0 9 * * *'
+    displayName: 7.1 GitHub Project-Reference Daily Run (09:00 UTC)
     branches:
       include:
-      - main
+      - release/7.1-staging
     always: true
 
-  # ADO internal/main daily.
-  - cron: '0 5 * * *'
-    displayName: Daily Run (Release Config)
+  # ADO internal/release/7.1 daily.
+  - cron: '0 17 * * *'
+    displayName: 7.1 ADO Project-Reference Daily Run (17:00 UTC)
     branches:
       include:
-      - internal/main
+      - internal/release/7.1-staging
     always: true
 
 # Pipeline parameters, visible in the Azure DevOps UI.

--- a/eng/pipelines/github-sync-pipeline.yml
+++ b/eng/pipelines/github-sync-pipeline.yml
@@ -4,14 +4,14 @@
 # See the LICENSE file in the project root for more information.                #
 #################################################################################
 
-# This pipeline synchronizes the GitHub dotnet/SqlClient repository's main
+# This pipeline synchronizes the GitHub dotnet/SqlClient repository's release/7.1
 # branch into the internal ADO repository by:
 #
-#   1. Fetching the latest commits from GitHub main.
-#   2. Pushing them to a dev/autosync/github-main branch in ADO.
-#   3. Creating (or updating) a pull request targeting internal/main.
+#   1. Fetching the latest commits from GitHub release/7.1.
+#   2. Pushing them to a dev/autosync/github-release-7.1 branch in ADO.
+#   3. Creating (or updating) a pull request targeting internal/release/7.1.
 #
-# It runs on a daily schedule at 02:00 UTC and can also be triggered manually.
+# It runs on a daily schedule at 15:00 UTC and can also be triggered manually.
 # The pipeline does not auto-complete the PR — changes must be reviewed and
 # merged manually.
 #
@@ -35,11 +35,11 @@ pr: none
 
 # Trigger this pipeline on a daily schedule.
 schedules:
-  - cron: '0 2 * * *'
-    displayName: Daily GitHub Sync (02:00 UTC)
+  - cron: '0 15 * * *'
+    displayName: 7.1 Daily GitHub Sync (15:00 UTC)
     branches:
       include:
-        - internal/main
+        - internal/release/7.1-staging
     always: true
 
 # Pipeline parameters, visible in the Azure DevOps UI.
@@ -49,17 +49,17 @@ parameters:
   - name: githubBranch
     displayName: GitHub Branch
     type: string
-    default: main
+    default: release/7.1-staging
 
   # The ADO target branch to create the PR against.
   - name: targetBranch
     displayName: ADO Target Branch
     type: string
-    default: internal/main
+    default: internal/release/7.1-staging
 
 jobs:
   - job: SyncGitHub
-    displayName: Sync GitHub to ADO
+    displayName: Sync GitHub release/7.1 to ADO internal/release/7.1
     pool:
       vmImage: 'ubuntu-latest'
 
@@ -71,14 +71,14 @@ jobs:
 
       # Run the sync script.
       - task: PowerShell@2
-        displayName: Sync GitHub main to ADO
+        displayName: Sync GitHub release/7.1 to ADO
         inputs:
           filePath: $(Build.SourcesDirectory)/eng/pipelines/scripts/Sync-GitHubToAdo.ps1
           arguments: >-
             -GitHubRepoUrl "https://github.com/dotnet/SqlClient.git"
             -GitHubBranch "${{ parameters.githubBranch }}"
             -TargetBranch "${{ parameters.targetBranch }}"
-            -SyncBranchName "dev/autosync/github-${{ parameters.githubBranch }}"
+            -SyncBranchName "dev/autosync/github-${{ replace(parameters.githubBranch, '/', '-') }}"
             -AdoOrgUrl "$(System.CollectionUri)"
             -AdoProject "$(System.TeamProject)"
             -AdoRepoName "$(Build.Repository.Name)"

--- a/eng/pipelines/onebranch/sqlclient-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-official.yml
@@ -13,11 +13,11 @@ trigger: none
 
 # We run this pipeline on a daily schedule.
 schedules:
-  - cron: "30 4 * * *"
-    displayName: Daily 04:30 UTC Build
+  - cron: "0 23 * * *"
+    displayName: 7.1 Daily Official Build (23:00 UTC)
     branches:
       include:
-        - internal/main
+        - internal/release/7.1-staging
     always: true
 
 # These parameters are visible in the Azure DevOps pipeline UI when a new run is queued.

--- a/eng/pipelines/perf/sqlclient-perf-pr-pipeline.yml
+++ b/eng/pipelines/perf/sqlclient-perf-pr-pipeline.yml
@@ -64,7 +64,7 @@ parameters:
   - name: baselineSourceRef
     displayName: Baseline Source Ref (branch)
     type: string
-    default: main
+    default: release/7.1-staging
 
   # Remote used to obtain the baseline ref when it cannot be fetched from the VM copy of the
   # checkout's own 'origin' (e.g. the source tree reached the VM without its .git directory, or

--- a/eng/pipelines/pr/sqlclient-pr-pipeline.yml
+++ b/eng/pipelines/pr/sqlclient-pr-pipeline.yml
@@ -9,8 +9,7 @@
 # environments to provide complete coverage. Instead, this PR strikes a balance between complete
 # confidence and speed of PR validation.
 #
-# It is triggered by pushes to PRs that target the main, dev/*, feat/*, and release/* branches in
-# GitHub. The dev/* pattern includes dev/automation/* branches created by AI agents.
+# It is triggered by pushes to PRs that target the release/7.1 branch in GitHub.
 #
 # It maps to the "sqlclient-pr" pipeline in the Public ADO project:
 #    https://sqlclientdrivers.visualstudio.com/public/_build?definitionId=2281
@@ -25,11 +24,7 @@ name: $(DayOfYear)$(Rev:rr)
 pr:
   branches:
     include:
-      # GitHub repo branch targets that will trigger PR validation builds.
-      - dev/*
-      - feat/*
-      - main
-      - release/*
+      - release/7.1-staging
 
   paths:
     include:

--- a/eng/pipelines/sqlclient-pr-package-ref-pipeline.yml
+++ b/eng/pipelines/sqlclient-pr-package-ref-pipeline.yml
@@ -11,7 +11,7 @@
 #   - Microsoft.Data.SqlClient
 #   - Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider
 #
-# It is triggered by pushes to PRs that target the release/7.1 branch in GitHub.
+# PR validation is disabled on the release/7.1 branch due to limited resources.
 #
 # It maps to the "PR-SqlClient-Package" pipeline in the Public project:
 #
@@ -30,9 +30,12 @@ name: $(DayOfYear)$(Rev:rr)
 #
 pr:
   branches:
-    include:
+    include: [
       # GitHub repo branch targets that will trigger PR validation builds.
-      - release/7.1-staging
+      #
+      # GOTCHA: Currently disabled due to limited resources.
+      # release/7.1-staging
+    ]
 
   paths:
     include:

--- a/eng/pipelines/sqlclient-pr-package-ref-pipeline.yml
+++ b/eng/pipelines/sqlclient-pr-package-ref-pipeline.yml
@@ -11,9 +11,7 @@
 #   - Microsoft.Data.SqlClient
 #   - Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider
 #
-# It is triggered by pushes to PRs that target the main, dev/*, feat/*, and
-# release/* branches in GitHub.  The dev/* pattern includes dev/automation/*
-# branches created by AI agents.
+# It is triggered by pushes to PRs that target the release/7.1 branch in GitHub.
 #
 # It maps to the "PR-SqlClient-Package" pipeline in the Public project:
 #
@@ -34,10 +32,7 @@ pr:
   branches:
     include:
       # GitHub repo branch targets that will trigger PR validation builds.
-      - dev/*
-      - feat/*
-      - main
-      - release/*
+      - release/7.1-staging
 
   paths:
     include:

--- a/eng/pipelines/sqlclient-pr-project-ref-pipeline.yml
+++ b/eng/pipelines/sqlclient-pr-project-ref-pipeline.yml
@@ -11,9 +11,7 @@
 #   - Microsoft.Data.SqlClient
 #   - Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider
 #
-# It is triggered by pushes to PRs that target the main, dev/*, feat/*, and
-# release/* branches in GitHub.  The dev/* pattern includes dev/automation/*
-# branches created by AI agents.
+# It is triggered by pushes to PRs that target the release/7.1 branch in GitHub.
 #
 # It maps to the "PR-SqlClient-Project" pipeline in the Public project:
 #
@@ -34,10 +32,7 @@ pr:
   branches:
     include:
       # GitHub repo branch targets that will trigger PR validation builds.
-      - dev/*
-      - feat/*
-      - main
-      - release/*
+      - release/7.1-staging
 
   paths:
     include:


### PR DESCRIPTION
## Description

Update Azure DevOps pipeline branch specifications for the 7.1 staging branch:

- Restrict PR, CI, schedule, and pipeline-completion triggers to `release/7.1-staging` and `internal/release/7.1-staging`.
- Disable the legacy package-reference PR and GitHub CI triggers due to limited resources, matching #4647; their branch entries remain commented for easy re-enablement, while scheduled and ADO internal CI runs remain active.
- Stagger 7.1 schedules between 09:00 and 23:00 UTC to avoid trigger-time overlap with `main` and existing release branches.
- Update GitHub Sync source and target defaults and sanitize `/` as `-` in its generated sync branch name.
- Refresh nearby pipeline guidance and comments for the 7.1 schedule and trigger configuration.

There are no public API or product behavior changes.

## Testing

I will be manually running the affected pipelines in the Public and ADO.Net projects, and confirming their calculated triggers.  I will list successful runs here as they complete.