### PR TITLE
Pipelines | Pre-compute all OneBranch package and file versions

### DIFF
--- a/.github/instructions/onebranch-pipeline-design.instructions.md
+++ b/.github/instructions/onebranch-pipeline-design.instructions.md
@@ -135,6 +135,7 @@ Variable groups:
 - Jobs that produce no assemblies (symbol publishing, signed-package validation, version computation) set `ob_sdl_apiscan_enabled: false` rather than reporting a name/version
 - Each build job also sets `ob_sdl_apiscan_softwareFolder` and `ob_sdl_apiscan_symbolsFolder` to its per-package `apiScan/<package>/dlls` and `apiScan/<package>/pdbs` paths
 - CodeQL, SBOM, Policheck (`break: true`): enabled in both pipelines
+- SBOM package name/version are resolvable **only** from the pipeline's `globalSdl.sbom` block — OneBranch's artifact-publishing path reads `globalSdl.sbom.packageName`/`packageVersion` directly and has no per-job equivalent (the `templateContext.sdl.sbom` override only applies to the native 1ES Stages entry point, which this repo does not use). Because the pipeline produces six differently-named and independently-versioned packages, `globalSdl.sbom` indirects through the `$(sbomPackageName)` / `$(sbomPackageVersion)` variables, which each build job sets to its own `packageFullName` and computed `packageVersion`. Jobs that publish no packages (version computation, symbol publishing) set `ob_sdl_sbom_enabled: false` alongside their existing APIScan/BinSkim opt-outs, so the variables never need pipeline-level defaults
 - asyncSdl `enabled: false` in both; individual sub-tools (CredScan, BinSkim, Armory, Roslyn) configured underneath
 - Policheck exclusions: `$(REPO_ROOT)\.config\PolicheckExclusions.xml`
 - CredScan suppressions: `$(REPO_ROOT)/.config/CredScanSuppressions.json`

--- a/.github/instructions/sqlclient-package-versions.instructions.md
+++ b/.github/instructions/sqlclient-package-versions.instructions.md
@@ -40,7 +40,7 @@ Each `Versions.props` uses a 3-tier `<Choose>` block:
 | Priority | Condition | PackageVersion | FileVersion |
 |----------|-----------|----------------|-------------|
 | 1 | `<Pkg>PackageVersion` explicitly provided | Used as-is | Strip prerelease + append BuildNumber |
-| 2 | `BuildNumber` provided (non-zero) | `NextVersion[-BuildSuffix+BuildNumber]` | `NextVersion.Split('-')[0].BuildNumber` |
+| 2 | `BuildNumber` provided (non-zero) | `NextVersion[-BuildSuffix]`, then `.BuildNumber` appended if that carries a prerelease tag | `NextVersion.Split('-')[0].BuildNumber` |
 | 3 | Nothing provided | `NextVersion-dev` | `NextVersion.Split('-')[0].0` |
 
 For every family package, `<Pkg>` is `SqlClient` (e.g. `-p:SqlClientPackageVersion=...`); for
@@ -79,7 +79,7 @@ Microsoft.SqlServer.Server it is `SqlServer`.
 
 - Versions computed in `compute-versions-ci-stage.yml` (runs `GetVersions*` targets with `-p:BuildSuffix=pr -p:BuildNumber=...`)
 - Falls into Priority 2 with BuildSuffix present.
-- **Result:** `7.1.0-preview1-pr15401` / FileVersion `7.1.0.15401`
+- **Result:** `7.1.0-preview1-pr.15401` / FileVersion `7.1.0.15401`
 - Dependencies are project references — all packages built together in-tree.
 
 **Mode:** Package (PR package-ref validation)
@@ -93,7 +93,7 @@ Microsoft.SqlServer.Server it is `SqlServer`.
 
 Same structure as PR but passes `buildSuffix: 'ci'` explicitly.
 
-- **Result:** `7.1.0-preview1-ci15401` / FileVersion `7.1.0.15401`
+- **Result:** `7.1.0-preview1-ci.15401` / FileVersion `7.1.0.15401`
 
 ### OneBranch Pipeline (official)
 
@@ -104,8 +104,8 @@ Uses the full `compute-versions-stage.yml` machinery:
 #### Step A: Compute Versions (dedicated early stage)
 
 1. Runs the `GetVersionsSqlClient` and `GetVersionsSqlServer` MSBuild targets against `build.proj`.
-2. Each target calls `dotnet build <project> -getProperty:<Pkg>PackageVersion` with `BuildNumber` but **no BuildSuffix**.
-3. Falls into Priority 2 without BuildSuffix → `PackageVersion = NextVersion` as-is (e.g. `7.1.0-preview1`).
+2. Each target calls `dotnet build <project> -getProperty:<Pkg>PackageVersion` and `-getProperty:<Pkg>FileVersion` with `BuildNumber` but **no BuildSuffix**.
+3. Falls into Priority 2 without BuildSuffix. `NextVersion` already carries a prerelease tag on `main`, so the build number is appended (e.g. `7.1.0-preview1.26238.3`); on a release branch the stable `NextVersion` is used as-is (e.g. `7.1.0`).
 4. `GetVersionsSqlServer` also extracts `SqlServerPublishedVersion` (the SqlClient family has no published version).
 
 #### Step B: Resolve Effective Versions
@@ -136,15 +136,12 @@ Each downstream build job receives:
 
 Since an explicit `<Pkg>PackageVersion` is provided, Versions.props hits Priority 1 — uses the value verbatim.
 
-#### Package Version Shapes: `addRevision`
+#### Package Version Shapes
 
-Both OneBranch pipelines expose `addRevision` (default `false`), which selects between two mutually
-exclusive package version shapes. Their human-readable run name is `$(Year:YY)$(DayOfYear)$(Rev:.r)`,
-and the compute stage receives both that run name (as `Build.BuildNumber`) and the globally unique
-`Build.BuildId` (as the revision).
-
-**Default path — `addRevision: false`.** The pipeline run name is appended after any prerelease
-suffix, reproducing the shape shipped by earlier previews. `Build.BuildId` is not used:
+Both OneBranch pipelines use the human-readable run name `$(Year:YY)$(DayOfYear)$(Rev:.r)`, which the
+compute stage receives as `Build.BuildNumber`. That run name drives the single supported package
+version shape: it is appended after any prerelease suffix, reproducing the shape shipped by earlier
+previews.
 
 - `1.2.3` stays `1.2.3` — non-preview releases are never stamped with a build number
 - `1.2.3-preview1` becomes `1.2.3-preview1.<build_number>`, e.g. `7.1.0-preview3.26238.3`
@@ -152,34 +149,15 @@ suffix, reproducing the shape shipped by earlier previews. `Build.BuildId` is no
 
 Note the asymmetry: the *package* version omits the build number for non-preview releases, but the
 *file* version always carries one in its fourth component. This keeps every shipped assembly
-date-encoded and traceable to the run that produced it, while preserving the released package
-version customers expect.
+date-encoded, while preserving the released package version customers expect.
 
-**Opt-in path — `addRevision: true`.** Version revisions come from `Build.BuildId` instead, which is
-mapped into the unsigned 16-bit file-version range before canonical file versions are evaluated:
+The file version's fourth component is only the *date* segment of the run name, because a four-part
+file version cannot hold the full `<date>.<run>` value. Repeated runs on the same day therefore share
+a file version even though their package versions differ.
 
-```text
-revision = ((Build.BuildId - 1) % 65535) + 1
-```
-
-Build IDs `1` through `65535` map directly; subsequent IDs wrap back through that range. The compute
-stage logs the mapping whenever wrapping occurs because the revision can then collide with an earlier
-run. The mapped value is inserted before any package prerelease suffix so package and file versions
-use the same revision:
-
-- `1.2.3` becomes `1.2.3.<revision>`
-- `1.2.3-preview1` becomes `1.2.3.<revision>-preview1`
-- The matching file version is `1.2.3.<revision>`
-
-This shape exists for repeated test publishes of the same base version, where each run needs a
-distinct package version. `Build.BuildNumber` is not used on this path.
-
-Only packages built in the current run are revised or stamped. When `buildSqlServer` is `false`, the
-effective SqlServer version remains `SqlServerPublishedVersion` so dependency restore continues to
-request the package that actually exists on NuGet.
-
-An explicit four-part package version is also treated as the complete file version base by both
-canonical Versions.props files; they do not append `FileVersionBuildNumber` as a fifth component.
+Only packages built in the current run are stamped. When `buildSqlServer` is `false`, the effective
+SqlServer version remains `SqlServerPublishedVersion` so dependency restore continues to request the
+package that actually exists on NuGet.
 
 #### Summary
 

--- a/build.proj
+++ b/build.proj
@@ -97,6 +97,21 @@
     -->
 
     <!--
+      SqlClientNextVersion
+      Applies to:     GetVersionsSqlClient
+      Description:    Overrides the source-declared base version used to calculate the SqlClient
+                      family package and file versions. BuildNumber and BuildSuffix are applied to
+                      this value by Versions.props. An explicit PackageVersionSqlClient remains
+                      higher precedence for build and pack targets.
+      Default value:  The value declared in src/Microsoft.Data.SqlClient/Versions.props
+      Example:        7.1.0-preview3
+    -->
+    <SqlClientNextVersion Condition="'$(SqlClientNextVersion)' == ''" />
+    <SqlClientNextVersionArgument Condition="'$(SqlClientNextVersion)' != ''">
+      -p:SqlClientNextVersion=$(SqlClientNextVersion)
+    </SqlClientNextVersionArgument>
+
+    <!--
       PackageVersionSqlClient
       Applies to:
         Build:        BuildSqlClient*, BuildLogging, BuildAbstractions, BuildAzure, BuildAkvProvider
@@ -134,6 +149,21 @@
     <FileVersionSqlClientArgument Condition="'$(FileVersionSqlClient)' != ''">
       -p:SqlClientFileVersion=$(FileVersionSqlClient)
     </FileVersionSqlClientArgument>
+
+    <!--
+      SqlServerNextVersion
+      Applies to:     GetVersionsSqlServer
+      Description:    Overrides the source-declared base version used to calculate the
+                      Microsoft.SqlServer.Server package and file versions. BuildNumber and
+                      BuildSuffix are applied to this value by Versions.props. An explicit
+                      PackageVersionSqlServer remains higher precedence for build and pack targets.
+      Default value:  The value declared in src/Microsoft.SqlServer.Server/Versions.props
+      Example:        1.1.0-preview1
+    -->
+    <SqlServerNextVersion Condition="'$(SqlServerNextVersion)' == ''" />
+    <SqlServerNextVersionArgument Condition="'$(SqlServerNextVersion)' != ''">
+      -p:SqlServerNextVersion=$(SqlServerNextVersion)
+    </SqlServerNextVersionArgument>
 
     <!--
       PackageVersionSqlServer
@@ -486,14 +516,14 @@
 
   <Target Name="GetVersionsSqlClient">
     <PropertyGroup>
-      <_Cmd>"$(DotnetPath)dotnet" build "$(SqlClientProjectPath)" -getProperty:SqlClientPackageVersion $(BuildNumberArgument) $(BuildSuffixArgument)</_Cmd>
+      <_Cmd>"$(DotnetPath)dotnet" build "$(SqlClientProjectPath)" -getProperty:SqlClientPackageVersion $(BuildNumberArgument) $(BuildSuffixArgument) $(SqlClientNextVersionArgument)</_Cmd>
       <_Cmd>$([System.Text.RegularExpressions.Regex]::Replace($(_Cmd), "\s+", " "))</_Cmd>
     </PropertyGroup>
     <Exec Command="$(_Cmd)" ConsoleToMsBuild="true" StandardOutputImportance="High">
       <Output TaskParameter="ConsoleOutput" PropertyName="_PackageVersion" />
     </Exec>
     <PropertyGroup>
-      <_Cmd>"$(DotnetPath)dotnet" build "$(SqlClientProjectPath)" -getProperty:SqlClientFileVersion $(BuildNumberArgument) $(BuildSuffixArgument)</_Cmd>
+      <_Cmd>"$(DotnetPath)dotnet" build "$(SqlClientProjectPath)" -getProperty:SqlClientFileVersion $(BuildNumberArgument) $(BuildSuffixArgument) $(SqlClientNextVersionArgument)</_Cmd>
       <_Cmd>$([System.Text.RegularExpressions.Regex]::Replace($(_Cmd), "\s+", " "))</_Cmd>
     </PropertyGroup>
     <Exec Command="$(_Cmd)" ConsoleToMsBuild="true" StandardOutputImportance="High">
@@ -505,7 +535,7 @@
 
   <Target Name="GetVersionsSqlServer">
     <PropertyGroup>
-      <_Cmd>"$(DotnetPath)dotnet" build "$(SqlServerProjectPath)" -getProperty:SqlServerPackageVersion $(BuildNumberArgument) $(BuildSuffixArgument)</_Cmd>
+      <_Cmd>"$(DotnetPath)dotnet" build "$(SqlServerProjectPath)" -getProperty:SqlServerPackageVersion $(BuildNumberArgument) $(BuildSuffixArgument) $(SqlServerNextVersionArgument)</_Cmd>
       <_Cmd>$([System.Text.RegularExpressions.Regex]::Replace($(_Cmd), "\s+", " "))</_Cmd>
     </PropertyGroup>
     <Exec Command="$(_Cmd)" ConsoleToMsBuild="true" StandardOutputImportance="High">
@@ -515,7 +545,7 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="_PublishedVersion" />
     </Exec>
     <PropertyGroup>
-      <_Cmd>"$(DotnetPath)dotnet" build "$(SqlServerProjectPath)" -getProperty:SqlServerFileVersion $(BuildNumberArgument) $(BuildSuffixArgument)</_Cmd>
+      <_Cmd>"$(DotnetPath)dotnet" build "$(SqlServerProjectPath)" -getProperty:SqlServerFileVersion $(BuildNumberArgument) $(BuildSuffixArgument) $(SqlServerNextVersionArgument)</_Cmd>
       <_Cmd>$([System.Text.RegularExpressions.Regex]::Replace($(_Cmd), "\s+", " "))</_Cmd>
     </PropertyGroup>
     <Exec Command="$(_Cmd)" ConsoleToMsBuild="true" StandardOutputImportance="High">

--- a/build.proj
+++ b/build.proj
@@ -510,7 +510,7 @@
        Usage:
          dotnet build build.proj -t:GetVersionsSqlClient -v:m -nologo -p:BuildNumber=1234
          # stdout contains:
-         #   PackageVersion: 7.1.0-preview1
+         #   PackageVersion: 7.1.0-preview1.1234
          #   FileVersion: 7.1.0.1234
   -->
 

--- a/build.proj
+++ b/build.proj
@@ -121,6 +121,21 @@
     </PackageVersionSqlClientArgument>
 
     <!--
+      FileVersionSqlClient
+      Applies to:     The same targets as PackageVersionSqlClient.
+      Description:    Specifies the assembly file version stamped on the SqlClient *family*.  When
+                      omitted, Versions.props derives it from the package version and BuildNumber.
+                      Supply it to stamp a pre-computed value instead, so no consumer has to
+                      re-derive it.  The assembly version is always derived from this value.
+      Default value:  [blank]
+      Example:        7.1.0.26238
+    -->
+    <FileVersionSqlClient Condition="'$(FileVersionSqlClient)' == ''" />
+    <FileVersionSqlClientArgument Condition="'$(FileVersionSqlClient)' != ''">
+      -p:SqlClientFileVersion=$(FileVersionSqlClient)
+    </FileVersionSqlClientArgument>
+
+    <!--
       PackageVersionSqlServer
       Applies to:
         Build:        BuildSqlServer and BuildSqlClient* in Package reference mode
@@ -136,6 +151,20 @@
     <PackageVersionSqlServerArgument Condition="'$(PackageVersionSqlServer)' != ''">
       -p:SqlServerPackageVersion=$(PackageVersionSqlServer)
     </PackageVersionSqlServerArgument>
+
+    <!--
+      FileVersionSqlServer
+      Applies to:     The same targets as PackageVersionSqlServer.
+      Description:    Specifies the assembly file version stamped on Microsoft.SqlServer.Server.
+                      When omitted, Versions.props derives it from the package version and
+                      BuildNumber.  Supply it to stamp a pre-computed value instead.
+      Default value:  [blank]
+      Example:        1.1.0.26238
+    -->
+    <FileVersionSqlServer Condition="'$(FileVersionSqlServer)' == ''" />
+    <FileVersionSqlServerArgument Condition="'$(FileVersionSqlServer)' != ''">
+      -p:SqlServerFileVersion=$(FileVersionSqlServer)
+    </FileVersionSqlServerArgument>
 
     <!--
       ReferenceType
@@ -574,6 +603,7 @@
         $(BuildNumberArgument)
         $(BuildSuffixArgument)
         $(PackageVersionSqlClientArgument)
+        $(FileVersionSqlClientArgument)
 
         <!-- Reference Type Arguments -->
         $(ReferenceTypeArgument)
@@ -605,6 +635,7 @@
         $(BuildNumberArgument)
         $(BuildSuffixArgument)
         $(PackageVersionSqlClientArgument)
+        $(FileVersionSqlClientArgument)
 
         <!-- Reference type arguments -->
         $(ReferenceTypeArgument)
@@ -636,6 +667,7 @@
         $(BuildNumberArgument)
         $(BuildSuffixArgument)
         $(PackageVersionSqlClientArgument)
+        $(FileVersionSqlClientArgument)
 
         <!-- Reference Type Arguments -->
         $(ReferenceTypeArgument)
@@ -679,6 +711,7 @@
         $(BuildNumberArgument)
         $(BuildSuffixArgument)
         $(PackageVersionSqlClientArgument)
+        $(FileVersionSqlClientArgument)
 
         <!-- Reference Type Arguments -->
         $(ReferenceTypeArgument)
@@ -839,6 +872,7 @@
         $(BuildNumberArgument)
         $(BuildSuffixArgument)
         $(PackageVersionSqlClientArgument)
+        $(FileVersionSqlClientArgument)
 
         <!-- Reference type arguments -->
         $(ReferenceTypeArgument)
@@ -866,6 +900,7 @@
         $(BuildNumberArgument)
         $(BuildSuffixArgument)
         $(PackageVersionSqlClientArgument)
+        $(FileVersionSqlClientArgument)
 
         <!-- Reference Type Arguments -->
         $(ReferenceTypeArgument)
@@ -946,6 +981,7 @@
         $(BuildNumberArgument)
         $(BuildSuffixArgument)
         $(PackageVersionSqlClientArgument)
+        $(FileVersionSqlClientArgument)
 
         <!-- Reference Type Arguments -->
         $(ReferenceTypeArgument)
@@ -972,6 +1008,7 @@
         $(BuildNumberArgument)
         $(BuildSuffixArgument)
         $(PackageVersionSqlClientArgument)
+        $(FileVersionSqlClientArgument)
 
         <!-- Reference Type Arguments -->
         $(ReferenceTypeArgument)
@@ -1051,6 +1088,7 @@
         $(BuildNumberArgument)
         $(BuildSuffixArgument)
         $(PackageVersionSqlClientArgument)
+        $(FileVersionSqlClientArgument)
 
         <!-- Reference type arguments -->
         $(ReferenceTypeArgument)
@@ -1077,6 +1115,7 @@
         $(BuildNumberArgument)
         $(BuildSuffixArgument)
         $(PackageVersionSqlClientArgument)
+        $(FileVersionSqlClientArgument)
 
         <!-- Reference Type Arguments -->
         $(ReferenceTypeArgument)
@@ -1153,6 +1192,7 @@
         $(BuildNumberArgument)
         $(BuildSuffixArgument)
         $(PackageVersionSqlClientArgument)
+        $(FileVersionSqlClientArgument)
       </DotnetCommand>
       <!-- Convert more than one whitespace character into one space -->
       <DotnetCommand>$([System.Text.RegularExpressions.Regex]::Replace($(DotnetCommand), "\s+", " "))</DotnetCommand>
@@ -1176,6 +1216,7 @@
         $(BuildNumberArgument)
         $(BuildSuffixArgument)
         $(PackageVersionSqlClientArgument)
+        $(FileVersionSqlClientArgument)
       </DotnetCommand>
       <!-- Convert more than one whitespace character into one space -->
       <DotnetCommand>$([System.Text.RegularExpressions.Regex]::Replace($(DotnetCommand), "\s+", " "))</DotnetCommand>
@@ -1219,6 +1260,7 @@
         $(BuildNumberArgument)
         $(BuildSuffixArgument)
         $(PackageVersionSqlServerArgument)
+        $(FileVersionSqlServerArgument)
       </DotnetCommand>
       <!-- Convert more than one whitespace character into one space -->
       <DotnetCommand>$([System.Text.RegularExpressions.Regex]::Replace($(DotnetCommand), "\s+", " "))</DotnetCommand>
@@ -1242,6 +1284,7 @@
         $(BuildNumberArgument)
         $(BuildSuffixArgument)
         $(PackageVersionSqlServerArgument)
+        $(FileVersionSqlServerArgument)
       </DotnetCommand>
       <!-- Convert more than one whitespace character into one space -->
       <DotnetCommand>$([System.Text.RegularExpressions.Regex]::Replace($(DotnetCommand), "\s+", " "))</DotnetCommand>

--- a/eng/pipelines/onebranch/jobs/build-buildproj-job.yml
+++ b/eng/pipelines/onebranch/jobs/build-buildproj-job.yml
@@ -66,8 +66,9 @@ parameters:
     type: object
     default: []
 
-  # Positive unsigned 16-bit revision used by build.proj to derive assembly file versions.
-  - name: revision
+  # Assembly file version to stamp (required). Pre-computed by the compute-versions stage so no
+  # build job re-derives it. The assembly version is derived from this by Versions.props.
+  - name: fileVersion
     type: string
 
   # The full name of the package. This is used in the job name, and to form DLL and PDB filenames
@@ -126,6 +127,13 @@ jobs:
       ob_sdl_apiscan_softwareName: ${{ parameters.packageFullName }}
       ob_sdl_apiscan_versionNumber: ${{ parameters.apiScanSoftwareVersion }}
 
+      # SBOM identity for this job's artifact.  OneBranch reads the SBOM package name/version only
+      # from the pipeline's globalSdl block, which has no per-job form, so that block indirects
+      # through these variables and each build job supplies its own values.  Jobs that publish no
+      # packages set ob_sdl_sbom_enabled to false instead.
+      sbomPackageName: ${{ parameters.packageFullName }}
+      sbomPackageVersion: ${{ parameters.packageVersion }}
+
     steps:
       - template: /eng/pipelines/onebranch/steps/script-output-environment-variables-step.yml@self
 
@@ -166,7 +174,7 @@ jobs:
         parameters:
           dependencyArguments: $(sqlServerVersionArgument)
           packageShortName: ${{ parameters.packageShortName }}
-          revision: ${{ parameters.revision }}
+          fileVersion: ${{ parameters.fileVersion }}
           versionPropertySuffix: ${{ parameters.versionPropertySuffix }}
           packageVersion: ${{ parameters.packageVersion }}
 
@@ -176,7 +184,7 @@ jobs:
           buildConfiguration: Release
           dependencyArguments: $(sqlServerVersionArgument)
           packageShortName: ${{ parameters.packageShortName }}
-          revision: ${{ parameters.revision }}
+          fileVersion: ${{ parameters.fileVersion }}
           versionPropertySuffix: ${{ parameters.versionPropertySuffix }}
           packageVersion: ${{ parameters.packageVersion }}
 
@@ -224,7 +232,7 @@ jobs:
           dependencyArguments: $(sqlServerVersionArgument)
           packageFullName: ${{ parameters.packageFullName }}
           packageShortName: ${{ parameters.packageShortName }}
-          revision: ${{ parameters.revision }}
+          fileVersion: ${{ parameters.fileVersion }}
           versionPropertySuffix: ${{ parameters.versionPropertySuffix }}
           packageVersion: ${{ parameters.packageVersion }}
 

--- a/eng/pipelines/onebranch/jobs/publish-nuget-package-job.yml
+++ b/eng/pipelines/onebranch/jobs/publish-nuget-package-job.yml
@@ -74,6 +74,11 @@ jobs:
       - name: ob_outputDirectory
         value: $(JOB_OUTPUT)
 
+      # This job republishes an already-built package, whose SBOM came from its build job. It sets
+      # no sbomPackage* values, so leaving SBOM enabled would emit one with unresolved macros.
+      - name: ob_sdl_sbom_enabled
+        value: false
+
       - name: artifactPath
         value: $(Pipeline.Workspace)/${{ parameters.artifactName }}
 

--- a/eng/pipelines/onebranch/jobs/publish-symbols-job.yml
+++ b/eng/pipelines/onebranch/jobs/publish-symbols-job.yml
@@ -64,6 +64,9 @@ jobs:
         value: false
       - name: ob_sdl_binskim_enabled
         value: false
+      # No packages are published here, so there is nothing to describe in an SBOM.
+      - name: ob_sdl_sbom_enabled
+        value: false
       # Path where the downloaded artifact will be placed.
       - name: artifactPath
         value: '$(Pipeline.Workspace)/${{ parameters.packageFullName }}'

--- a/eng/pipelines/onebranch/jobs/validate-signed-package-job.yml
+++ b/eng/pipelines/onebranch/jobs/validate-signed-package-job.yml
@@ -53,6 +53,10 @@ jobs:
       - name: ob_sdl_apiscan_enabled
         value: false
 
+      # Likewise it produces no package, and sets no sbomPackage* values for globalSdl to resolve.
+      - name: ob_sdl_sbom_enabled
+        value: false
+
       # Path within the downloaded artifact where NuGet packages are located.
       - name: artifactPath
         value: '$(Pipeline.Workspace)\${{ parameters.artifactName }}'

--- a/eng/pipelines/onebranch/scripts/compute-versions.ps1
+++ b/eng/pipelines/onebranch/scripts/compute-versions.ps1
@@ -12,62 +12,38 @@
     The published SqlServer version is needed when SqlServer is not built because downstream
     SqlClient projects restore that existing package from NuGet.
 
-    Two mutually exclusive package version shapes are supported:
-
-    When AddRevision is true, BuildNumber is ignored if specified. For non-preview releases, versions
-    will be 1.2.3.<revision>. For preview releases, versions will be 1.2.3.<revision>-previewX.
-
-    When AddRevision is false, BuildNumber must be specified. Non-preview versions will be 1.2.3, and
-    preview releases will be 1.2.3-previewX.<build_number>.
-
-    This asymmetry maintains the existing package versioning practice where previews include a
-    date-coded build number, but normal releases do not.
+    Package versions take a single shape, produced by Versions.props from the pipeline build number.
+    Preview versions carry the full build number after the prerelease suffix, such as
+    1.2.3-preview1.26238.3. Stable versions are left exactly as declared in Versions.props, such as
+    1.2.3, because released packages are not stamped with a build number.
 
     File versions are always four-part and always carry a build number in the fourth component, even
-    when the package version does not:
+    when the package version does not. Versions.props derives that component from the date segment of
+    BuildNumber, so a package version of 1.2.3-preview1.26238.3 has file version 1.2.3.26238, and a
+    stable package version of 1.2.3 still has file version 1.2.3.26238. That segment is date-coded,
+    so repeated runs on the same day share a file version even though their package versions differ.
 
-      - AddRevision true. The fourth component is the mapped revision, so package and file versions
-        agree. A package version of 1.2.3.34430-preview1 has file version 1.2.3.34430.
-
-      - AddRevision false. The fourth component is the first segment of BuildNumber. A package
-        version of 1.2.3-preview1.26238.3 has file version 1.2.3.26238, and a stable package version
-        of 1.2.3 still has file version 1.2.3.26238. This keeps every file version date-encoded and
-        traceable back to the run that produced it.
-
-    The supplied revision is mapped to the range 1 through 65535 before canonical versions
-    are evaluated so every file version has a valid fourth component. Revisions above 65535 wrap
-    through the valid unsigned 16-bit file-version range. When AddRevision is true the script logs
-    the mapping because the revision may then collide with an earlier run. An unbuilt SqlServer
-    package is never revised or stamped with a build number because its effective version must
-    continue to identify the package that already exists on NuGet.
+    An unbuilt SqlServer package is never stamped with a build number because its effective version
+    must continue to identify the package that already exists on NuGet.
 
     The script emits these output variables for downstream stages:
-      - VersionRevision
       - SqlClientPackageVersion
+      - SqlClientFileVersion
       - SqlServerPackageVersion
+      - SqlServerFileVersion
       - SqlClientApiScanVersion
       - SqlServerApiScanVersion
 
 .PARAMETER ProjectPath
     Absolute or relative path to the repository build.proj file.
 
-.PARAMETER Revision
-    Positive integer used to distinguish versions. Values above 65535 are wrapped into the unsigned
-    16-bit revision range. Only consumed when AddRevision is true.
-
 .PARAMETER BuildNumber
-    Pipeline build number in the form <date>.<run>, such as 26238.3. Required when AddRevision is
-    false, and ignored when AddRevision is true. When required, it is appended to prerelease package
-    versions and its first segment becomes the file-version build number, so file versions remain
-    date-encoded.
+    Pipeline build number in the form <date>.<run>, such as 26238.3. Versions.props appends it to
+    prerelease package versions and derives the file-version build number from its date segment.
 
 .PARAMETER BuildSqlServer
     Whether this run builds Microsoft.SqlServer.Server. When false, the effective SqlServer package
     version is its last published version and its file version is not consumed downstream.
-
-.PARAMETER AddRevision
-    Whether to insert the revision into package versions built during this run.
-    Defaults to false in both top-level OneBranch pipelines.
 
 .PARAMETER DotnetPath
     dotnet executable to invoke. Defaults to the dotnet command resolved from PATH. This parameter
@@ -76,33 +52,19 @@
 .EXAMPLE
     ./compute-versions.ps1 `
         -ProjectPath ./build.proj `
-        -Revision 165500 `
         -BuildNumber 26238.3 `
-        -BuildSqlServer $true `
-        -AddRevision $false
+        -BuildSqlServer $true
 
-    Computes versions for an official-style run that builds SqlServer. Prerelease package versions
-    become 7.1.0-preview3.26238.3 and file versions become 7.1.0.26238.
-
-.EXAMPLE
-    ./compute-versions.ps1 `
-        -ProjectPath ./build.proj `
-        -Revision 165500 `
-        -BuildSqlServer $true `
-        -AddRevision $true
-
-    Computes versions for a run that builds SqlServer and appends mapped revision 34430 to both
-    package families and their file versions. BuildNumber is not supplied because AddRevision is
-    true.
+    Computes versions for a run that builds SqlServer. Prerelease package versions become
+    7.1.0-preview3.26238.3 and file versions become 7.1.0.26238.
 
 .EXAMPLE
     ./compute-versions.ps1 `
         -ProjectPath ./build.proj `
-        -Revision 165500 `
-        -BuildSqlServer $false `
-        -AddRevision $true
+        -BuildNumber 26238.3 `
+        -BuildSqlServer $false
 
-    Revises the SqlClient family versions while retaining SqlServerPublishedVersion for dependency
+    Stamps the SqlClient family versions while retaining SqlServerPublishedVersion for dependency
     restore because SqlServer is not built in this run.
 
 .NOTES
@@ -117,19 +79,12 @@ param(
     [ValidateScript({ Test-Path -LiteralPath $_ -PathType Leaf })]
     [string]$ProjectPath,
 
-    [Parameter(Mandatory = $true, HelpMessage = "Positive integer version revision.")]
-    [ValidateRange(1, [long]::MaxValue)]
-    [long]$Revision,
-
-    [Parameter(HelpMessage = "Pipeline build number, such as 26238.3. Required when AddRevision is false.")]
-    [ValidatePattern("^$|^\d+\.\d+$")]
-    [string]$BuildNumber = "",
+    [Parameter(Mandatory = $true, HelpMessage = "Pipeline build number, such as 26238.3.")]
+    [ValidatePattern("^\d+\.\d+$")]
+    [string]$BuildNumber,
 
     [Parameter(Mandatory = $true, HelpMessage = "Whether Microsoft.SqlServer.Server is built in this run.")]
     [bool]$BuildSqlServer,
-
-    [Parameter(Mandatory = $true, HelpMessage = "Whether to append the revision to built package versions.")]
-    [bool]$AddRevision,
 
     [Parameter(HelpMessage = "dotnet executable to invoke.")]
     [ValidateNotNullOrEmpty()]
@@ -138,11 +93,6 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
-
-$wrappedRevision = (($Revision - 1) % 65535) + 1
-if ($AddRevision -and $Revision -gt 65535) {
-    Write-Host "Revision $Revision exceeds the unsigned 16-bit limit and wrapped to $wrappedRevision; this revision may collide with an earlier run."
-}
 
 <#
 .SYNOPSIS
@@ -179,7 +129,7 @@ function Get-LabeledValue {
     GetVersions target suffix: SqlClient or SqlServer.
 
 .OUTPUTS
-    An object containing PackageVersion and PublishedVersion.
+    An object containing PackageVersion, FileVersion, and PublishedVersion.
 #>
 function Get-CanonicalVersions {
     param(
@@ -188,91 +138,26 @@ function Get-CanonicalVersions {
     )
 
     $output = & $DotnetPath build $ProjectPath `
-        -t:"GetVersions${Label}" -v:m -nologo -p:BuildNumber=$wrappedRevision 2>&1
+        -t:"GetVersions${Label}" -v:m -nologo -p:BuildNumber=$BuildNumber 2>&1
     if ($LASTEXITCODE -ne 0) {
         throw ($output -join [Environment]::NewLine)
     }
 
     $packageVersion = Get-LabeledValue -Output $output -Label "PackageVersion"
+    $fileVersion = Get-LabeledValue -Output $output -Label "FileVersion"
     $publishedVersion = Get-LabeledValue -Output $output -Label "PublishedVersion"
     if ([string]::IsNullOrWhiteSpace($packageVersion)) {
         throw "Failed to extract PackageVersion for ${Label}.`n$($output -join [Environment]::NewLine)"
     }
+    if ([string]::IsNullOrWhiteSpace($fileVersion)) {
+        throw "Failed to extract FileVersion for ${Label}.`n$($output -join [Environment]::NewLine)"
+    }
 
     [pscustomobject]@{
         PackageVersion = $packageVersion
+        FileVersion = $fileVersion
         PublishedVersion = $publishedVersion
     }
-}
-
-<#
-.SYNOPSIS
-    Inserts a numeric revision before a package version's prerelease suffix.
-
-.PARAMETER Version
-    Package version with a three-part numeric base and optional prerelease suffix.
-
-.PARAMETER Revision
-    Revision in the unsigned 16-bit file-version range.
-
-.OUTPUTS
-    A four-part package version preserving the original prerelease suffix.
-#>
-function Add-VersionRevision {
-    param(
-        [string]$Version,
-        [ValidateRange(1, 65535)]
-        [int]$Revision
-    )
-
-    $parts = $Version -split "-", 2
-    if ($parts[0] -notmatch "^\d+\.\d+\.\d+$") {
-        throw "Expected a three-part numeric version base, but received '$Version'."
-    }
-
-    $versionWithRevision = "$($parts[0]).$Revision"
-    if ($parts.Count -eq 2) {
-        return "$versionWithRevision-$($parts[1])"
-    }
-
-    return $versionWithRevision
-}
-
-<#
-.SYNOPSIS
-    Appends a pipeline build number to a prerelease package version.
-
-.DESCRIPTION
-    Reproduces the version shape used by earlier previews, where the build number follows the
-    prerelease suffix, such as 7.1.0-preview3.26238.3. Stable versions are returned unchanged
-    because released packages are not stamped with a build number.
-
-.PARAMETER Version
-    Package version with a three-part numeric base and optional prerelease suffix.
-
-.PARAMETER BuildNumber
-    Pipeline build number to append.
-
-.OUTPUTS
-    The package version with the build number appended to its prerelease suffix, or the original
-    version when it carries no prerelease suffix.
-#>
-function Add-VersionBuildNumber {
-    param(
-        [string]$Version,
-        [string]$BuildNumber
-    )
-
-    $parts = $Version -split "-", 2
-    if ($parts[0] -notmatch "^\d+\.\d+\.\d+$") {
-        throw "Expected a three-part numeric version base, but received '$Version'."
-    }
-
-    if ($parts.Count -eq 2) {
-        return "$($parts[0])-$($parts[1]).$BuildNumber"
-    }
-
-    return $Version
 }
 
 <#
@@ -316,14 +201,18 @@ function Set-PipelineOutputVariable {
     Write-Host "##vso[task.setvariable variable=${Name};isOutput=true]$Value"
 }
 
-Write-Host "Extracting versions with revision=$Revision (wrapped=$wrappedRevision)..."
+Write-Host "Extracting versions with build number $BuildNumber..."
 $sqlClientVersions = Get-CanonicalVersions -Label "SqlClient"
 $sqlServerVersions = Get-CanonicalVersions -Label "SqlServer"
 
-Write-Host "  SqlClient: pkg=$($sqlClientVersions.PackageVersion)"
-Write-Host "  SqlServer: pkg=$($sqlServerVersions.PackageVersion) pub=$($sqlServerVersions.PublishedVersion)"
+Write-Host "  SqlClient: pkg=$($sqlClientVersions.PackageVersion) file=$($sqlClientVersions.FileVersion)"
+Write-Host "  SqlServer: pkg=$($sqlServerVersions.PackageVersion) file=$($sqlServerVersions.FileVersion) pub=$($sqlServerVersions.PublishedVersion)"
 
 $sqlClientPackageVersion = $sqlClientVersions.PackageVersion
+$sqlClientFileVersion = $sqlClientVersions.FileVersion
+
+# An unbuilt SqlServer resolves to its published version, which no build job stamps, so it has no
+# effective file version.
 $sqlServerPackageVersion = if ($BuildSqlServer) {
     $sqlServerVersions.PackageVersion
 } else {
@@ -332,46 +221,11 @@ $sqlServerPackageVersion = if ($BuildSqlServer) {
     }
     $sqlServerVersions.PublishedVersion
 }
-
-$fileVersionBuildNumber = $null
-
-if ($AddRevision) {
-    $sqlClientPackageVersion = Add-VersionRevision `
-        -Version $sqlClientPackageVersion `
-        -Revision $wrappedRevision
-    if ($BuildSqlServer) {
-        $sqlServerPackageVersion = Add-VersionRevision `
-            -Version $sqlServerPackageVersion `
-            -Revision $wrappedRevision
-    }
-
-    # The revision is already the fourth component of the package version, so it is also the
-    # file-version build number.
-    $fileVersionBuildNumber = $wrappedRevision
-    Write-Host "Version revision: $wrappedRevision (input=$Revision)"
-}
-else {
-    if ([string]::IsNullOrWhiteSpace($BuildNumber)) {
-        throw "BuildNumber is required when AddRevision is false."
-    }
-
-    $fileVersionBuildNumber = $BuildNumber.Split(".")[0]
-
-    $sqlClientPackageVersion = Add-VersionBuildNumber `
-        -Version $sqlClientPackageVersion `
-        -BuildNumber $BuildNumber
-    if ($BuildSqlServer) {
-        $sqlServerPackageVersion = Add-VersionBuildNumber `
-            -Version $sqlServerPackageVersion `
-            -BuildNumber $BuildNumber
-    }
-
-    Write-Host "Version build number: $BuildNumber (file version build number=$fileVersionBuildNumber)"
-}
+$sqlServerFileVersion = if ($BuildSqlServer) { $sqlServerVersions.FileVersion } else { "" }
 
 Write-Host "Effective versions:"
-Write-Host "  SqlClient (family): $sqlClientPackageVersion"
-Write-Host "  SqlServer:          $sqlServerPackageVersion"
+Write-Host "  SqlClient (family): $sqlClientPackageVersion (file $sqlClientFileVersion)"
+Write-Host "  SqlServer:          $sqlServerPackageVersion (file $sqlServerFileVersion)"
 
 $sqlClientApiScanVersion = Get-MajorMinorVersion -Version $sqlClientPackageVersion
 $sqlServerApiScanVersion = Get-MajorMinorVersion -Version $sqlServerPackageVersion
@@ -381,7 +235,8 @@ Write-Host "  SqlClient (family): $sqlClientApiScanVersion"
 Write-Host "  SqlServer:          $sqlServerApiScanVersion"
 
 Set-PipelineOutputVariable -Name "SqlClientPackageVersion" -Value $sqlClientPackageVersion
+Set-PipelineOutputVariable -Name "SqlClientFileVersion" -Value $sqlClientFileVersion
 Set-PipelineOutputVariable -Name "SqlServerPackageVersion" -Value $sqlServerPackageVersion
+Set-PipelineOutputVariable -Name "SqlServerFileVersion" -Value $sqlServerFileVersion
 Set-PipelineOutputVariable -Name "SqlClientApiScanVersion" -Value $sqlClientApiScanVersion
 Set-PipelineOutputVariable -Name "SqlServerApiScanVersion" -Value $sqlServerApiScanVersion
-Set-PipelineOutputVariable -Name "VersionRevision" -Value $fileVersionBuildNumber

--- a/eng/pipelines/onebranch/scripts/tests/README.md
+++ b/eng/pipelines/onebranch/scripts/tests/README.md
@@ -31,7 +31,7 @@ Invoke-Pester ./publish-symbols.Tests.ps1 -Output Detailed
 
 | Area                  | What's tested                                                    |
 | --------------------- | ---------------------------------------------------------------- |
-| Version computation   | Canonical output parsing, revisions, wrapping, effective package selection, and failures |
+| Version computation   | Canonical output parsing, effective package selection, target version composition, and failures |
 | Parameter validation  | Empty strings rejected for all mandatory parameters              |
 | URL construction      | Base URL, register URL, request URL built from parameters        |
 | Request bodies        | Registration body, default publish flags, flag overrides         |

--- a/eng/pipelines/onebranch/scripts/tests/README.md
+++ b/eng/pipelines/onebranch/scripts/tests/README.md
@@ -41,5 +41,6 @@ Invoke-Pester ./publish-symbols.Tests.ps1 -Output Detailed
 ## Notes
 
 - All external calls (`az`, `Invoke-RestMethod`) are mocked — no network access or Azure credentials are required.
-- Version tests mock `dotnet`, so they do not invoke MSBuild or require a restored repository.
+- Script-level version tests mock `dotnet`; package-composition tests invoke the real MSBuild
+  `GetVersionsSqlClient` and `GetVersionsSqlServer` targets.
 - Tests validate scripts in the parent directory relative to this directory.

--- a/eng/pipelines/onebranch/scripts/tests/compute-versions.Tests.ps1
+++ b/eng/pipelines/onebranch/scripts/tests/compute-versions.Tests.ps1
@@ -127,6 +127,26 @@ BeforeAll {
         $output = & dotnet @arguments 2>&1 | Out-String
         [pscustomobject]@{ ExitCode = $LASTEXITCODE; Output = $output }
     }
+
+    function Invoke-BuildProjTarget {
+        param(
+            [Parameter(Mandatory)]
+            [string]$Target,
+
+            [string[]]$Properties = @()
+        )
+
+        $arguments = @(
+            'build'
+            $buildProjectPath
+            "-t:$Target"
+            '-v:m'
+            '-nologo'
+        ) + $Properties
+
+        $output = & dotnet @arguments 2>&1 | Out-String
+        [pscustomobject]@{ ExitCode = $LASTEXITCODE; Output = $output }
+    }
 }
 
 AfterAll {
@@ -269,7 +289,42 @@ Describe 'File version component validation' {
             -Properties $Properties
 
         $result.ExitCode | Should -Not -Be 0
-        $result.Output | Should -Match ([regex]::Escape("${Product}FileVersion '$ExpectedFileVersion' has more than four components"))
+        $result.Output | Should -Match ([regex]::Escape("${Product}FileVersion '$ExpectedFileVersion' is not a four-part numeric version"))
+    }
+
+    It 'rejects an externally supplied <Description> file version for <Product>' -ForEach @(
+        @{
+            Product = 'SqlClient'; Description = 'short'
+            RelativeProject = 'src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.csproj'
+            TargetFramework = 'net8.0'
+            FileVersion = '1.2'
+        }
+        @{
+            Product = 'SqlClient'; Description = 'non-numeric'
+            RelativeProject = 'src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.csproj'
+            TargetFramework = 'net8.0'
+            FileVersion = 'abc'
+        }
+        @{
+            Product = 'SqlServer'; Description = 'short'
+            RelativeProject = 'src/Microsoft.SqlServer.Server/Microsoft.SqlServer.Server.csproj'
+            TargetFramework = 'netstandard2.0'
+            FileVersion = '1.2'
+        }
+        @{
+            Product = 'SqlServer'; Description = 'non-numeric'
+            RelativeProject = 'src/Microsoft.SqlServer.Server/Microsoft.SqlServer.Server.csproj'
+            TargetFramework = 'netstandard2.0'
+            FileVersion = 'abc'
+        }
+    ) {
+        $result = Invoke-VersionValidation `
+            -ProjectPath (Join-Path $script:repoRoot $RelativeProject) `
+            -TargetFramework $TargetFramework `
+            -Properties @("-p:${Product}FileVersion=$FileVersion")
+
+        $result.ExitCode | Should -Not -Be 0
+        $result.Output | Should -Match ([regex]::Escape("${Product}FileVersion '$FileVersion' is not a four-part numeric version"))
     }
 
     It 'accepts the declared <Product> version' -ForEach @(
@@ -290,6 +345,20 @@ Describe 'File version component validation' {
             -Properties @("-p:BuildNumber=$script:testBuildNumber")
 
         $result.ExitCode | Should -Be 0
+    }
+}
+
+Describe 'build.proj file version wrappers' {
+    # A malformed value is used so the leaf project reports it by name, which proves the wrapper
+    # forwarded it verbatim without paying for a full compile.
+    It 'forwards <Wrapper> through <Target>' -ForEach @(
+        @{ Product = 'SqlClient'; Wrapper = 'FileVersionSqlClient'; Target = 'BuildLogging' }
+        @{ Product = 'SqlServer'; Wrapper = 'FileVersionSqlServer'; Target = 'BuildSqlServer' }
+    ) {
+        $result = Invoke-BuildProjTarget -Target $Target -Properties @("-p:$Wrapper=1.2")
+
+        $result.ExitCode | Should -Not -Be 0
+        $result.Output | Should -Match ([regex]::Escape("${Product}FileVersion '1.2' is not a four-part numeric version"))
     }
 }
 

--- a/eng/pipelines/onebranch/scripts/tests/compute-versions.Tests.ps1
+++ b/eng/pipelines/onebranch/scripts/tests/compute-versions.Tests.ps1
@@ -4,8 +4,9 @@
 #>
 
 BeforeAll {
+    $script:repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..' '..' '..')
     $scriptPath = Join-Path $PSScriptRoot '..' 'compute-versions.ps1'
-    $buildProjectPath = Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'build.proj')
+    $buildProjectPath = Resolve-Path (Join-Path $script:repoRoot 'build.proj')
     $projectPath = Join-Path $TestDrive 'build.proj'
     Set-Content -LiteralPath $projectPath -Value '<Project />'
 
@@ -96,6 +97,35 @@ BeforeAll {
         }
 
         $output
+    }
+
+    # Drives PrepareForBuild rather than the validation target directly, because the hook point is
+    # itself the thing under test: a check wired after the compile would pass a direct invocation.
+    # An explicit target framework is required, as PrepareForBuild is not valid on the outer
+    # cross-targeting build.
+    function Invoke-VersionValidation {
+        param(
+            [Parameter(Mandatory)]
+            [string]$ProjectPath,
+
+            [Parameter(Mandatory)]
+            [string]$TargetFramework,
+
+            [string[]]$Properties = @()
+        )
+
+        $arguments = @(
+            'build'
+            $ProjectPath
+            '-f'
+            $TargetFramework
+            '-t:PrepareForBuild'
+            '-v:m'
+            '-nologo'
+        ) + $Properties
+
+        $output = & dotnet @arguments 2>&1 | Out-String
+        [pscustomobject]@{ ExitCode = $LASTEXITCODE; Output = $output }
     }
 }
 
@@ -199,6 +229,67 @@ Describe 'GetVersions target package composition' {
 
         $output | Should -Match "PackageVersion:\s+$([regex]::Escape($ExpectedPackageVersion))(\r?\n|$)"
         $output | Should -Match "FileVersion:\s+$([regex]::Escape($ExpectedFileVersion))(\r?\n|$)"
+    }
+}
+
+Describe 'File version component validation' {
+    It 'rejects a four-part <Property>' -ForEach @(
+        @{
+            Product = 'SqlClient'; Property = 'SqlClientPackageVersion'
+            RelativeProject = 'src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.csproj'
+            TargetFramework = 'net8.0'
+            Properties = @('-p:SqlClientPackageVersion=7.1.0.123')
+            ExpectedFileVersion = '7.1.0.123.0'
+        }
+        @{
+            Product = 'SqlClient'; Property = 'SqlClientNextVersion'
+            RelativeProject = 'src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.csproj'
+            TargetFramework = 'net8.0'
+            Properties = @('-p:SqlClientNextVersion=7.1.0.123', '-p:BuildNumber=1234')
+            ExpectedFileVersion = '7.1.0.123.1234'
+        }
+        @{
+            Product = 'SqlServer'; Property = 'SqlServerPackageVersion'
+            RelativeProject = 'src/Microsoft.SqlServer.Server/Microsoft.SqlServer.Server.csproj'
+            TargetFramework = 'netstandard2.0'
+            Properties = @('-p:SqlServerPackageVersion=1.1.0.123')
+            ExpectedFileVersion = '1.1.0.123.0'
+        }
+        @{
+            Product = 'SqlServer'; Property = 'SqlServerNextVersion'
+            RelativeProject = 'src/Microsoft.SqlServer.Server/Microsoft.SqlServer.Server.csproj'
+            TargetFramework = 'netstandard2.0'
+            Properties = @('-p:SqlServerNextVersion=1.1.0.123', '-p:BuildNumber=1234')
+            ExpectedFileVersion = '1.1.0.123.1234'
+        }
+    ) {
+        $result = Invoke-VersionValidation `
+            -ProjectPath (Join-Path $script:repoRoot $RelativeProject) `
+            -TargetFramework $TargetFramework `
+            -Properties $Properties
+
+        $result.ExitCode | Should -Not -Be 0
+        $result.Output | Should -Match ([regex]::Escape("${Product}FileVersion '$ExpectedFileVersion' has more than four components"))
+    }
+
+    It 'accepts the declared <Product> version' -ForEach @(
+        @{
+            Product = 'SqlClient'
+            RelativeProject = 'src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.csproj'
+            TargetFramework = 'net8.0'
+        }
+        @{
+            Product = 'SqlServer'
+            RelativeProject = 'src/Microsoft.SqlServer.Server/Microsoft.SqlServer.Server.csproj'
+            TargetFramework = 'netstandard2.0'
+        }
+    ) {
+        $result = Invoke-VersionValidation `
+            -ProjectPath (Join-Path $script:repoRoot $RelativeProject) `
+            -TargetFramework $TargetFramework `
+            -Properties @("-p:BuildNumber=$script:testBuildNumber")
+
+        $result.ExitCode | Should -Be 0
     }
 }
 

--- a/eng/pipelines/onebranch/scripts/tests/compute-versions.Tests.ps1
+++ b/eng/pipelines/onebranch/scripts/tests/compute-versions.Tests.ps1
@@ -5,6 +5,7 @@
 
 BeforeAll {
     $scriptPath = Join-Path $PSScriptRoot '..' 'compute-versions.ps1'
+    $buildProjectPath = Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..' '..' '..' 'build.proj')
     $projectPath = Join-Path $TestDrive 'build.proj'
     Set-Content -LiteralPath $projectPath -Value '<Project />'
 
@@ -61,6 +62,41 @@ BeforeAll {
     function Set-SuccessfulDotnetMock {
         Set-DotnetMock
     }
+
+    function Invoke-VersionTarget {
+        param(
+            [Parameter(Mandatory)]
+            [string]$Target,
+
+            [Parameter(Mandatory)]
+            [string]$NextVersionProperty,
+
+            [Parameter(Mandatory)]
+            [string]$BaseVersion,
+
+            [string]$BuildSuffix
+        )
+
+        $arguments = @(
+            'build'
+            $buildProjectPath
+            "-t:$Target"
+            '-v:m'
+            '-nologo'
+            "-p:BuildNumber=$script:testBuildNumber"
+            "-p:$NextVersionProperty=$BaseVersion"
+        )
+        if ($BuildSuffix) {
+            $arguments += "-p:BuildSuffix=$BuildSuffix"
+        }
+
+        $output = & dotnet @arguments 2>&1 | Out-String
+        if ($LASTEXITCODE -ne 0) {
+            throw "$Target failed with exit code ${LASTEXITCODE}:`n$output"
+        }
+
+        $output
+    }
 }
 
 AfterAll {
@@ -109,6 +145,60 @@ Describe 'compute-versions.ps1 Effective Versions' {
         # The file version is still stamped so every build produces a date-encoded file version even
         # for non-preview releases.
         $output | Should -Match 'SqlClientFileVersion;isOutput=true]7\.1\.0\.26238'
+    }
+}
+
+Describe 'GetVersions target package composition' {
+    It '<Target> composes <Case> package and file versions' -ForEach @(
+        @{
+            Target = 'GetVersionsSqlClient'; NextVersionProperty = 'SqlClientNextVersion'
+            BaseVersion = '7.1.0'; BuildSuffix = ''; ExpectedPackageVersion = '7.1.0'
+            ExpectedFileVersion = '7.1.0.26238'; Case = 'a stable base without a suffix'
+        }
+        @{
+            Target = 'GetVersionsSqlClient'; NextVersionProperty = 'SqlClientNextVersion'
+            BaseVersion = '7.1.0'; BuildSuffix = 'ci'; ExpectedPackageVersion = '7.1.0-ci.26238.3'
+            ExpectedFileVersion = '7.1.0.26238'; Case = 'a stable base with a suffix'
+        }
+        @{
+            Target = 'GetVersionsSqlClient'; NextVersionProperty = 'SqlClientNextVersion'
+            BaseVersion = '7.1.0-preview3'; BuildSuffix = ''; ExpectedPackageVersion = '7.1.0-preview3.26238.3'
+            ExpectedFileVersion = '7.1.0.26238'; Case = 'a prerelease base without a suffix'
+        }
+        @{
+            Target = 'GetVersionsSqlClient'; NextVersionProperty = 'SqlClientNextVersion'
+            BaseVersion = '7.1.0-preview3'; BuildSuffix = 'ci'; ExpectedPackageVersion = '7.1.0-preview3-ci.26238.3'
+            ExpectedFileVersion = '7.1.0.26238'; Case = 'a prerelease base with a suffix'
+        }
+        @{
+            Target = 'GetVersionsSqlServer'; NextVersionProperty = 'SqlServerNextVersion'
+            BaseVersion = '1.1.0'; BuildSuffix = ''; ExpectedPackageVersion = '1.1.0'
+            ExpectedFileVersion = '1.1.0.26238'; Case = 'a stable base without a suffix'
+        }
+        @{
+            Target = 'GetVersionsSqlServer'; NextVersionProperty = 'SqlServerNextVersion'
+            BaseVersion = '1.1.0'; BuildSuffix = 'ci'; ExpectedPackageVersion = '1.1.0-ci.26238.3'
+            ExpectedFileVersion = '1.1.0.26238'; Case = 'a stable base with a suffix'
+        }
+        @{
+            Target = 'GetVersionsSqlServer'; NextVersionProperty = 'SqlServerNextVersion'
+            BaseVersion = '1.1.0-preview1'; BuildSuffix = ''; ExpectedPackageVersion = '1.1.0-preview1.26238.3'
+            ExpectedFileVersion = '1.1.0.26238'; Case = 'a prerelease base without a suffix'
+        }
+        @{
+            Target = 'GetVersionsSqlServer'; NextVersionProperty = 'SqlServerNextVersion'
+            BaseVersion = '1.1.0-preview1'; BuildSuffix = 'ci'; ExpectedPackageVersion = '1.1.0-preview1-ci.26238.3'
+            ExpectedFileVersion = '1.1.0.26238'; Case = 'a prerelease base with a suffix'
+        }
+    ) {
+        $output = Invoke-VersionTarget `
+            -Target $Target `
+            -NextVersionProperty $NextVersionProperty `
+            -BaseVersion $BaseVersion `
+            -BuildSuffix $BuildSuffix
+
+        $output | Should -Match "PackageVersion:\s+$([regex]::Escape($ExpectedPackageVersion))(\r?\n|$)"
+        $output | Should -Match "FileVersion:\s+$([regex]::Escape($ExpectedFileVersion))(\r?\n|$)"
     }
 }
 

--- a/eng/pipelines/onebranch/scripts/tests/compute-versions.Tests.ps1
+++ b/eng/pipelines/onebranch/scripts/tests/compute-versions.Tests.ps1
@@ -19,26 +19,23 @@ BeforeAll {
 
     function Invoke-ComputeVersions {
         param(
-            [long]$Revision = 42,
-            [string]$BuildNumber = '',
-            [bool]$BuildSqlServer = $true,
-            [bool]$AddRevision = $true
+            [string]$BuildNumber = $script:testBuildNumber,
+            [bool]$BuildSqlServer = $true
         )
 
         & $scriptPath `
             -ProjectPath $projectPath `
-            -Revision $Revision `
             -BuildNumber $BuildNumber `
-            -BuildSqlServer $BuildSqlServer `
-            -AddRevision $AddRevision *>&1 | Out-String
+            -BuildSqlServer $BuildSqlServer *>&1 | Out-String
     }
 
     # Alternates between the SqlClient and SqlServer GetVersions targets, which the script always
-    # invokes in that order.
+    # invokes in that order.  The versions returned here are already stamped, because Versions.props
+    # applies the build number before the script ever sees them.
     function Set-DotnetMock {
         param(
-            [string]$SqlClientPackageVersion = '7.1.0-preview3',
-            [string]$SqlServerPackageVersion = '1.1.0-preview1'
+            [string]$SqlClientPackageVersion = "7.1.0-preview3.$script:testBuildNumber",
+            [string]$SqlServerPackageVersion = "1.1.0-preview1.$script:testBuildNumber"
         )
 
         $global:computeVersionsDotnetCallCount = 0
@@ -48,12 +45,14 @@ BeforeAll {
             if ($global:computeVersionsDotnetCallCount % 2 -eq 1) {
                 return @(
                     "  PackageVersion: $SqlClientPackageVersion"
+                    '  FileVersion: 7.1.0.26238'
                     '  PublishedVersion: 7.0.0'
                 )
             }
 
             return @(
                 "  PackageVersion: $SqlServerPackageVersion"
+                '  FileVersion: 1.1.0.26238'
                 '  PublishedVersion: 1.0.0'
             )
         }.GetNewClosure()
@@ -73,101 +72,54 @@ Describe 'compute-versions.ps1 Effective Versions' {
         Set-SuccessfulDotnetMock
     }
 
-    It 'appends the build number after the prerelease suffix when package revisioning is disabled' {
-        $output = Invoke-ComputeVersions -AddRevision $false -BuildNumber $script:testBuildNumber
+    It 'forwards the stamped prerelease versions from Versions.props' {
+        $output = Invoke-ComputeVersions
 
         $output | Should -Match "SqlClientPackageVersion;isOutput=true]7\.1\.0-preview3\.$script:testBuildNumberPattern"
         $output | Should -Match "SqlServerPackageVersion;isOutput=true]1\.1\.0-preview1\.$script:testBuildNumberPattern"
         $output | Should -Match 'SqlClientApiScanVersion;isOutput=true]7\.1'
         $output | Should -Match 'SqlServerApiScanVersion;isOutput=true]1\.1'
         $output | Should -Match 'APIScan registration versions:\s+SqlClient \(family\): 7\.1\s+SqlServer:\s+1\.1'
-        $output | Should -Match "VersionRevision;isOutput=true]$script:testFileVersionBuildNumber"
-    }
-
-    It 'inserts the revision before prerelease suffixes for built packages' {
-        $output = Invoke-ComputeVersions
-
-        $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0\.42-preview3'
-        $output | Should -Match 'SqlServerPackageVersion;isOutput=true]1\.1\.0\.42-preview1'
+        $output | Should -Match 'SqlClientFileVersion;isOutput=true]7\.1\.0\.26238'
+        $output | Should -Match 'SqlServerFileVersion;isOutput=true]1\.1\.0\.26238'
     }
 
     It 'retains the published SqlServer package when SqlServer is not built' {
         $output = Invoke-ComputeVersions -BuildSqlServer $false
 
-        $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0\.42-preview3'
+        $output | Should -Match "SqlClientPackageVersion;isOutput=true]7\.1\.0-preview3\.$script:testBuildNumberPattern"
         $output | Should -Match 'SqlServerPackageVersion;isOutput=true]1\.0\.0'
         $output | Should -Match 'SqlServerApiScanVersion;isOutput=true]1\.0'
-        $output | Should -Not -Match 'SqlServerPackageVersion;isOutput=true]1\.0\.0\.42'
+        $output | Should -Not -Match "SqlServerPackageVersion;isOutput=true]1\.0\.0[\.-]$script:testFileVersionBuildNumber"
+
+        # An unbuilt SqlServer is never stamped, so it has no effective file version.
+        $output | Should -Match 'SqlServerFileVersion;isOutput=true](\r?\n|$)'
     }
 
-    It 'wraps revisions above 65535 and logs the mapping as information' {
-        $output = Invoke-ComputeVersions -Revision 65536
-
-        $output | Should -Match 'Revision 65536.*wrapped to 1'
-        $output | Should -Not -Match 'task\.logissue type=warning'
-        $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0\.1-preview3'
-        $output | Should -Match 'SqlServerPackageVersion;isOutput=true]1\.1\.0\.1-preview1'
-        $output | Should -Match 'VersionRevision;isOutput=true]1'
-    }
-
-    It 'emits the build number rather than the wrapped revision when package revisioning is disabled' {
-        $output = Invoke-ComputeVersions -Revision 65536 -AddRevision $false -BuildNumber $script:testBuildNumber
-
-        $output | Should -Not -Match 'task\.logissue type=warning'
-        $output | Should -Not -Match 'wrapped to'
-        $output | Should -Match "SqlClientPackageVersion;isOutput=true]7\.1\.0-preview3\.$script:testBuildNumberPattern"
-        $output | Should -Match "SqlServerPackageVersion;isOutput=true]1\.1\.0-preview1\.$script:testBuildNumberPattern"
-        $output | Should -Match "VersionRevision;isOutput=true]$script:testFileVersionBuildNumber"
-    }
-
-    It 'retains the published SqlServer package unstamped when SqlServer is not built' {
-        $output = Invoke-ComputeVersions -BuildSqlServer $false -AddRevision $false -BuildNumber $script:testBuildNumber
-
-        $output | Should -Match "SqlClientPackageVersion;isOutput=true]7\.1\.0-preview3\.$script:testBuildNumberPattern"
-        $output | Should -Match 'SqlServerPackageVersion;isOutput=true]1\.0\.0'
-        $output | Should -Not -Match "SqlServerPackageVersion;isOutput=true]1\.0\.0\.$script:testFileVersionBuildNumber"
-    }
-
-    It 'omits the build number from non-preview package versions when package revisioning is disabled' {
+    It 'forwards unstamped non-preview package versions' {
         Set-DotnetMock -SqlClientPackageVersion '7.1.0' -SqlServerPackageVersion '1.1.0'
 
-        $output = Invoke-ComputeVersions -AddRevision $false -BuildNumber $script:testBuildNumber
+        $output = Invoke-ComputeVersions
 
         $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0(\r?\n|$)'
         $output | Should -Match 'SqlServerPackageVersion;isOutput=true]1\.1\.0(\r?\n|$)'
         $output | Should -Not -Match "SqlClientPackageVersion;isOutput=true]7\.1\.0[\.-]$script:testFileVersionBuildNumber"
         $output | Should -Not -Match "SqlServerPackageVersion;isOutput=true]1\.1\.0[\.-]$script:testFileVersionBuildNumber"
 
-        # The file version is still stamped so every build produces a distinct, date-encoded
-        # file version even for non-preview releases.
-        $output | Should -Match "VersionRevision;isOutput=true]$script:testFileVersionBuildNumber"
-    }
-
-    It 'revises non-preview package versions when package revisioning is enabled' {
-        Set-DotnetMock -SqlClientPackageVersion '7.1.0' -SqlServerPackageVersion '1.1.0'
-
-        $output = Invoke-ComputeVersions
-
-        $output | Should -Match 'SqlClientPackageVersion;isOutput=true]7\.1\.0\.42'
-        $output | Should -Match 'SqlServerPackageVersion;isOutput=true]1\.1\.0\.42'
-        $output | Should -Match 'VersionRevision;isOutput=true]42'
+        # The file version is still stamped so every build produces a date-encoded file version even
+        # for non-preview releases.
+        $output | Should -Match 'SqlClientFileVersion;isOutput=true]7\.1\.0\.26238'
     }
 }
 
 Describe 'compute-versions.ps1 Error Handling' {
-    It 'rejects a non-positive revision' {
-        { Invoke-ComputeVersions -Revision 0 } | Should -Throw
-    }
-
-    It 'requires a build number when package revisioning is disabled' {
-        Set-SuccessfulDotnetMock
-
-        { Invoke-ComputeVersions -AddRevision $false } |
-            Should -Throw '*BuildNumber is required when AddRevision is false*'
-    }
-
     It 'rejects a malformed build number' {
-        { Invoke-ComputeVersions -AddRevision $false -BuildNumber 'not-a-build-number' } | Should -Throw
+        { Invoke-ComputeVersions -BuildNumber 'not-a-build-number' } | Should -Throw
+    }
+
+    It 'requires a build number' {
+        # Bound as empty rather than omitted; omitting a mandatory parameter prompts interactively.
+        { Invoke-ComputeVersions -BuildNumber '' } | Should -Throw
     }
 
     It 'throws when a GetVersions target fails' {
@@ -188,18 +140,12 @@ Describe 'compute-versions.ps1 Error Handling' {
         { Invoke-ComputeVersions } | Should -Throw '*Failed to extract PackageVersion*'
     }
 
-    It 'throws when a revised package does not have a three-part numeric base' {
-        $global:computeVersionsDotnetCallCount = 0
+    It 'throws when a FileVersion label is absent' {
         Mock -CommandName 'dotnet' -MockWith {
             $global:LASTEXITCODE = 0
-            $global:computeVersionsDotnetCallCount++
-            if ($global:computeVersionsDotnetCallCount -eq 1) {
-                return @('PackageVersion: 7.1-preview3')
-            }
-
-            return @('PackageVersion: 1.1.0-preview1', 'PublishedVersion: 1.0.0')
+            return 'PackageVersion: 7.1.0-preview3.26238.3'
         }
 
-        { Invoke-ComputeVersions } | Should -Throw "*Expected a three-part numeric version base*"
+        { Invoke-ComputeVersions } | Should -Throw '*Failed to extract FileVersion*'
     }
 }

--- a/eng/pipelines/onebranch/sqlclient-non-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-non-official.yml
@@ -28,13 +28,6 @@ parameters:
     type: boolean
     default: false
 
-  # Append the Build.BuildId revision to package and file versions to reduce collisions when
-  # repeatedly publishing tests to symbol servers or the NuGet test feed.
-  - name: addRevision
-    displayName: Use the build ID as the revision version
-    type: boolean
-    default: false
-
   # True to publish symbols to private and public servers.
   - name: publishSymbols
     displayName: Publish symbols
@@ -256,8 +249,12 @@ extends:
 
       sbom:
         enabled: true
-        packageName: 'Microsoft.Data.SqlClient'
-        packageVersion: '$(Build.BuildNumber)'
+        # OneBranch resolves these from globalSdl only -- there is no per-job form -- so they
+        # indirect through variables that each build job sets to the package it produces.  Jobs
+        # that publish no packages disable SBOM via ob_sdl_sbom_enabled rather than defaulting
+        # these.  See build-buildproj-job.yml.
+        packageName: '$(sbomPackageName)'
+        packageVersion: '$(sbomPackageVersion)'
 
       tsa:
         # TSA (Trust Services Automation) files SDL analysis findings as Azure DevOps bug work
@@ -297,7 +294,6 @@ extends:
 
       - template: /eng/pipelines/onebranch/stages/compute-versions-stage.yml@self
         parameters:
-          addRevision: ${{ parameters.addRevision }}
           buildSqlServer: ${{ parameters.buildSqlServer }}
 
       - template: /eng/pipelines/onebranch/stages/build-stages.yml@self

--- a/eng/pipelines/onebranch/sqlclient-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-official.yml
@@ -37,12 +37,6 @@ parameters:
     type: boolean
     default: false
 
-  # Append the Build.BuildId revision to package and file versions.
-  - name: addRevision
-    displayName: Use the build ID as the revision version
-    type: boolean
-    default: false
-
   # True to publish symbols to private and public servers.
   - name: publishSymbols
     displayName: Publish symbols
@@ -270,8 +264,12 @@ extends:
 
       sbom:
         enabled: true
-        packageName: 'Microsoft.Data.SqlClient'
-        packageVersion: '$(Build.BuildNumber)'
+        # OneBranch resolves these from globalSdl only -- there is no per-job form -- so they
+        # indirect through variables that each build job sets to the package it produces.  Jobs
+        # that publish no packages disable SBOM via ob_sdl_sbom_enabled rather than defaulting
+        # these.  See build-buildproj-job.yml.
+        packageName: '$(sbomPackageName)'
+        packageVersion: '$(sbomPackageVersion)'
 
       tsa:
         # TSA (Trust Services Automation) files SDL analysis findings as Azure DevOps bug work
@@ -306,7 +304,6 @@ extends:
 
       - template: /eng/pipelines/onebranch/stages/compute-versions-stage.yml@self
         parameters:
-          addRevision: ${{ parameters.addRevision }}
           buildSqlServer: ${{ parameters.buildSqlServer }}
 
       - template: /eng/pipelines/onebranch/stages/build-stages.yml@self

--- a/eng/pipelines/onebranch/stages/build-stages.yml
+++ b/eng/pipelines/onebranch/stages/build-stages.yml
@@ -80,8 +80,10 @@ stages:
     dependsOn: compute_versions
 
     variables:
-      - name: versionRevision
-        value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.VersionRevision'] ]
+      - name: sqlClientFileVersion
+        value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.SqlClientFileVersion'] ]
+      - name: sqlServerFileVersion
+        value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.SqlServerFileVersion'] ]
       - name: sqlClientPackageVersion
         value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.SqlClientPackageVersion'] ]
       - name: sqlServerPackageVersion
@@ -107,7 +109,7 @@ stages:
           signingEsrpConnectedServiceName: '${{ parameters.signingEsrpConnectedServiceName }}'
 
           dependencies: []
-          revision: '$(versionRevision)'
+          fileVersion: '$(sqlClientFileVersion)'
           packageFullName: 'Microsoft.Data.SqlClient.Internal.Logging'
           packageShortName: 'Logging'
           versionPropertySuffix: 'SqlClient'
@@ -130,7 +132,7 @@ stages:
             signingEsrpConnectedServiceName: '${{ parameters.signingEsrpConnectedServiceName }}'
 
             dependencies: []
-            revision: '$(versionRevision)'
+            fileVersion: '$(sqlServerFileVersion)'
             packageFullName: 'Microsoft.SqlServer.Server'
             packageShortName: 'SqlServer'
             versionPropertySuffix: 'SqlServer'
@@ -148,8 +150,8 @@ stages:
       - build_independent
 
     variables:
-      - name: versionRevision
-        value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.VersionRevision'] ]
+      - name: sqlClientFileVersion
+        value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.SqlClientFileVersion'] ]
       - name: sqlClientPackageVersion
         value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.SqlClientPackageVersion'] ]
       - name: sqlClientApiScanVersion
@@ -174,7 +176,7 @@ stages:
             - artifactName: '${{ parameters.loggingArtifactsName }}'
               shortName: 'Logging'
               version: '$(sqlClientPackageVersion)'
-          revision: '$(versionRevision)'
+          fileVersion: '$(sqlClientFileVersion)'
           packageFullName: 'Microsoft.Data.SqlClient.Extensions.Abstractions'
           packageShortName: 'Abstractions'
           versionPropertySuffix: 'SqlClient'
@@ -192,8 +194,8 @@ stages:
       - build_abstractions
 
     variables:
-      - name: versionRevision
-        value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.VersionRevision'] ]
+      - name: sqlClientFileVersion
+        value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.SqlClientFileVersion'] ]
       - name: sqlClientPackageVersion
         value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.SqlClientPackageVersion'] ]
       - name: sqlServerPackageVersion
@@ -234,7 +236,7 @@ stages:
               - artifactName: ''
                 shortName: 'SqlServer'
                 version: '$(sqlServerPackageVersion)'
-          revision: '$(versionRevision)'
+          fileVersion: '$(sqlClientFileVersion)'
           packageFullName: 'Microsoft.Data.SqlClient'
           packageShortName: 'SqlClient'
           versionPropertySuffix: 'SqlClient'
@@ -261,7 +263,7 @@ stages:
             - artifactName: '${{ parameters.loggingArtifactsName }}'
               shortName: 'Logging'
               version: '$(sqlClientPackageVersion)'
-          revision: '$(versionRevision)'
+          fileVersion: '$(sqlClientFileVersion)'
           packageFullName: 'Microsoft.Data.SqlClient.Extensions.Azure'
           packageShortName: 'Azure'
           versionPropertySuffix: 'SqlClient'
@@ -278,8 +280,8 @@ stages:
       - build_dependent
 
     variables:
-      - name: versionRevision
-        value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.VersionRevision'] ]
+      - name: sqlClientFileVersion
+        value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.SqlClientFileVersion'] ]
       - name: sqlClientPackageVersion
         value: $[ stageDependencies.compute_versions.compute_versions_job.outputs['versions.SqlClientPackageVersion'] ]
       - name: sqlServerPackageVersion
@@ -322,7 +324,7 @@ stages:
               - artifactName: ''
                 shortName: 'SqlServer'
                 version: '$(sqlServerPackageVersion)'
-          revision: '$(versionRevision)'
+          fileVersion: '$(sqlClientFileVersion)'
           packageFullName: 'Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider'
           packageShortName: 'AkvProvider'
           versionPropertySuffix: 'SqlClient'

--- a/eng/pipelines/onebranch/stages/compute-versions-stage.yml
+++ b/eng/pipelines/onebranch/stages/compute-versions-stage.yml
@@ -17,20 +17,14 @@
 #   - Microsoft.SqlServer.Server is versioned separately: it uses its "next" version when it is
 #     being built this run, or its "published" (last shipped to NuGet) version when it is not built
 #     (so the SqlClient family depends on the most recently published SqlServer package).
-#   - Runs use their "next" version from Versions.props. By default the pipeline build number is
-#     appended to prerelease package versions (7.1.0-preview3.26238.3) and its date segment becomes
-#     the file-version build number (7.1.0.26238), matching the shape shipped by earlier previews.
-#     Runs can instead append the Build.BuildId revision, reducing collisions when repeatedly
-#     publishing the same base version for testing.
+#   - Runs use their "next" version from Versions.props. The pipeline build number is appended to
+#     prerelease package versions (7.1.0-preview3.26238.3) and its date segment becomes the
+#     file-version build number (7.1.0.26238), matching the shape shipped by earlier previews.
 #   - Versions are extracted via build.proj GetVersions* targets by parsing stdout.
 #
 # This stage MUST run before all build stages so they can consume computed versions.
 
 parameters:
-  # Whether to append the Build.BuildId revision to package and file versions.
-  - name: addRevision
-    type: boolean
-
   # Whether Microsoft.SqlServer.Server is being built this run.  This drives the SqlServer version
   # selection (next when built, published when not); the SqlClient family always uses its next
   # version.  When SqlServer is not built, the SqlClient family depends on the published SqlServer
@@ -54,6 +48,8 @@ stages:
           ob_sdl_apiscan_enabled: false
           ob_sdl_binskim_break: false
           ob_sdl_binskim_enabled: false
+          # No packages are published here, so there is nothing to describe in an SBOM.
+          ob_sdl_sbom_enabled: false
 
         steps:
           - pwsh: |
@@ -69,8 +65,8 @@ stages:
           # may run during the GetVersions* evaluation.
           - template: /eng/pipelines/common/steps/restore-dotnet-tools.yml@self
 
-          # Extract canonical versions, resolve the effective built/published values, optionally
-          # add the run revision, and publish the downstream stage output variables.
+          # Extract canonical versions, resolve the effective built/published values, and publish
+          # the downstream stage output variables.
           - task: PowerShell@2
             displayName: "Compute Effective Versions"
             name: "versions"
@@ -80,7 +76,5 @@ stages:
               filePath: $(Build.SourcesDirectory)/eng/pipelines/onebranch/scripts/compute-versions.ps1
               arguments: >-
                 -ProjectPath "$(Build.SourcesDirectory)/build.proj"
-                -Revision "$(Build.BuildId)"
                 -BuildNumber "$(Build.BuildNumber)"
                 -BuildSqlServer $${{ parameters.buildSqlServer }}
-                -AddRevision $${{ parameters.addRevision }}

--- a/eng/pipelines/onebranch/steps/build-buildproj-step.yml
+++ b/eng/pipelines/onebranch/steps/build-buildproj-step.yml
@@ -37,8 +37,8 @@ parameters:
       - SqlClient
       - SqlServer
 
-  # Version revision translated to build.proj's BuildNumber property at this boundary.
-  - name: revision
+  # Pre-computed assembly file version, translated to build.proj's FileVersion* property here.
+  - name: fileVersion
     type: string
 
   #  Suffix appended to "PackageVersion" to form the build.proj msbuild property that stamps this
@@ -75,7 +75,7 @@ steps:
         -p:ReferenceType=Package
         -p:SkipDependencyPack=true
         -p:SigningKeyPath="$(keyFile.secureFilePath)"
-        -p:BuildNumber="${{ parameters.revision }}"
+        -p:FileVersion${{ parameters.versionPropertySuffix }}="${{ parameters.fileVersion }}"
         -p:PackageVersion${{ parameters.versionPropertySuffix }}="${{ parameters.packageVersion }}"
         ${{ parameters.dependencyArguments }}
 

--- a/eng/pipelines/onebranch/steps/pack-buildproj-step.yml
+++ b/eng/pipelines/onebranch/steps/pack-buildproj-step.yml
@@ -49,8 +49,8 @@ parameters:
       - SqlClient
       - SqlServer
 
-  # Version revision translated to build.proj's BuildNumber property at this boundary.
-  - name: revision
+  # Pre-computed assembly file version, translated to build.proj's FileVersion* property here.
+  - name: fileVersion
     type: string
 
   #  Suffix appended to "PackageVersion" to form the build.proj msbuild property that stamps this
@@ -79,7 +79,7 @@ steps:
         -p:Configuration=${{ parameters.buildConfiguration }}
         -p:PackBuild=false
         -p:ReferenceType=Package
-        -p:BuildNumber="${{ parameters.revision }}"
+        -p:FileVersion${{ parameters.versionPropertySuffix }}="${{ parameters.fileVersion }}"
         -p:PackageVersion${{ parameters.versionPropertySuffix }}="${{ parameters.packageVersion }}"
         ${{ parameters.dependencyArguments }}
 

--- a/eng/pipelines/onebranch/steps/roslyn-analyzers-buildproj-step.yml
+++ b/eng/pipelines/onebranch/steps/roslyn-analyzers-buildproj-step.yml
@@ -129,11 +129,8 @@ parameters:
       - SqlClient
       - SqlServer
 
-  # The three parameters below mirror build-buildproj-step.yml so the analysis build resolves the
-  # same package versions as the real build.
-  #
-  # Version revision translated to build.proj's BuildNumber property at this boundary.
-  - name: revision
+  # Pre-computed assembly file version, translated to build.proj's FileVersion* property here.
+  - name: fileVersion
     type: string
 
   #  Suffix appended to "PackageVersion" to form the build.proj msbuild property that stamps this
@@ -165,7 +162,7 @@ steps:
         -p:Configuration=Release
         -p:ReferenceType=Package
         -p:SkipDependencyPack=true
-        -p:BuildNumber="${{ parameters.revision }}"
+        -p:FileVersion${{ parameters.versionPropertySuffix }}="${{ parameters.fileVersion }}"
         -p:PackageVersion${{ parameters.versionPropertySuffix }}="${{ parameters.packageVersion }}"
         -p:IsolatedBuildPath="$(Agent.TempDirectory)/roslyn"
         -p:EnableAnalyzers=true

--- a/eng/pipelines/onebranch/variables/package-variables.yml
+++ b/eng/pipelines/onebranch/variables/package-variables.yml
@@ -7,23 +7,6 @@
 # This file contains variables that relate to the various packages that are produced via the
 # OneBranch official/non-official pipelines. They are grouped by the packages they represent.
 #
-# VERSION STRATEGY
-# ================
-# Package versions are computed by Versions.props using one input:
-#   - BuildNumber   ($(Build.BuildNumber), provided by ADO)
-#
-# The SqlClient *family* (Internal.Logging, Extensions.Abstractions, Microsoft.Data.SqlClient,
-# Extensions.Azure, and the AlwaysEncrypted.AzureKeyVaultProvider) shares a single version defined
-# by SqlClientNextVersion in src/Microsoft.Data.SqlClient/Versions.props.  Microsoft.SqlServer.Server
-# is versioned separately by SqlServerNextVersion.
-#
-# The *NextVersion properties define the base version:
-#   - On main:           X.Y.Z-preview1  → official produces "X.Y.Z-preview1"
-#   - On release/X.Y:    X.Y.Z           → official produces "X.Y.Z"
-#
-# No per-package version variables are needed here — Versions.props is the single source.
-# Downstream stages obtain the computed versions via the compute-versions stage.
-#
 # ARTIFACT NAMING
 # ===============
 # OneBranch automatically publishes pipeline artifacts from all jobs named as:

--- a/src/Microsoft.Data.SqlClient/Versions.props
+++ b/src/Microsoft.Data.SqlClient/Versions.props
@@ -106,10 +106,10 @@
     <SqlClientAssemblyVersion>$(SqlClientFileVersion.Split('.')[0]).0.0.0</SqlClientAssemblyVersion>
   </PropertyGroup>
 
-  <!-- Any version input with a four-part core pushes this past four components, failing later as CS7035. -->
+  <!-- FileVersionSqlClient overrides everything computed above, so validate the final value. -->
   <Target Name="ValidateSqlClientFileVersion" BeforeTargets="PrepareForBuild">
     <Error
-      Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(SqlClientFileVersion)', '^\d+\.\d+\.\d+\.\d+\.'))"
-      Text="SqlClientFileVersion '$(SqlClientFileVersion)' has more than four components. SqlClientPackageVersion ('$(SqlClientPackageVersion)') and SqlClientNextVersion ('$(SqlClientNextVersion)') must use a three-part core (major.minor.patch)." />
+      Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('$(SqlClientFileVersion)', '^\d+\.\d+\.\d+\.\d+$'))"
+      Text="SqlClientFileVersion '$(SqlClientFileVersion)' is not a four-part numeric version (major.minor.build.revision). Check FileVersionSqlClient, SqlClientPackageVersion ('$(SqlClientPackageVersion)') and SqlClientNextVersion ('$(SqlClientNextVersion)')." />
   </Target>
 </Project>

--- a/src/Microsoft.Data.SqlClient/Versions.props
+++ b/src/Microsoft.Data.SqlClient/Versions.props
@@ -105,4 +105,11 @@
   <PropertyGroup>
     <SqlClientAssemblyVersion>$(SqlClientFileVersion.Split('.')[0]).0.0.0</SqlClientAssemblyVersion>
   </PropertyGroup>
+
+  <!-- Any version input with a four-part core pushes this past four components, failing later as CS7035. -->
+  <Target Name="ValidateSqlClientFileVersion" BeforeTargets="PrepareForBuild">
+    <Error
+      Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(SqlClientFileVersion)', '^\d+\.\d+\.\d+\.\d+\.'))"
+      Text="SqlClientFileVersion '$(SqlClientFileVersion)' has more than four components. SqlClientPackageVersion ('$(SqlClientPackageVersion)') and SqlClientNextVersion ('$(SqlClientNextVersion)') must use a three-part core (major.minor.patch)." />
+  </Target>
 </Project>

--- a/src/Microsoft.Data.SqlClient/Versions.props
+++ b/src/Microsoft.Data.SqlClient/Versions.props
@@ -31,7 +31,6 @@
     <!--
       This is the *next* version to release of the SqlClient family.  Update this after a version
       is released.  Every SqlClient family package uses this version.
-      @TODO: Determine how versions should be updated in release branches vs main
     -->
     <SqlClientNextVersion>7.1.0-preview3</SqlClientNextVersion>
   </PropertyGroup>
@@ -50,13 +49,8 @@
           not valid in a file version. Start with the suffix-free package base and append the
           configured file-version build number, which converts a three-part package version such as
           1.2.3-preview1 to 1.2.3.42.
-
-          A revision-enabled pipeline supplies a four-part package base such as 1.2.3.42. That base
-          is already a complete file version, so the following conditional assignment overrides the
-          fallback instead of producing an invalid five-part version.
         -->
         <SqlClientFileVersion>$(SqlClientPackageVersionBase).$(FileVersionBuildNumber)</SqlClientFileVersion>
-        <SqlClientFileVersion Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(SqlClientPackageVersionBase)', '^\d+\.\d+\.\d+\.\d+$'))">$(SqlClientPackageVersionBase)</SqlClientFileVersion>
       </PropertyGroup>
     </When>
 
@@ -65,18 +59,24 @@
         When a build number is provided, the default version is used as the base of the package and
         file versions.
 
-        If a build suffix is provided, this is appended to the package version. This is meant to be
-        used by automated pre-release systems to indicate the source of the build.
+        If a build suffix is provided, it is appended as a prerelease tag. This is meant to be used
+        by automated pre-release systems to indicate the source of the build.
 
-        If a build suffix is not provided, no pre-release tag will be added to package version. If
-        the default version already has a pre-release tag added to it (eg, "7.0.0-preview1") this
-        will be retained for the package version, but will be stripped off for the file version
-        (letters are not allowed in file/assembly versions). This is meant to be used by official
-        build pipelines to generate production-ready builds.
+        The build number is then appended to any version carrying a prerelease tag — whether that
+        tag came from the declared version or from the build suffix — so every automated run
+        produces a distinct package version (eg, "7.0.0-preview1" becomes
+        "7.0.0-preview1.26238.3"). A version with no prerelease tag is left exactly as declared,
+        because released packages are not stamped with a build number. The tag is always stripped
+        for the file version (letters are not allowed in file/assembly versions). This is meant to
+        be used by official build pipelines to generate production-ready builds.
       -->
       <PropertyGroup>
-        <SqlClientPackageVersion Condition="'$(BuildSuffix)' != ''">$(SqlClientNextVersion)-$(BuildSuffix)$(BuildNumber)</SqlClientPackageVersion>
-        <SqlClientPackageVersion Condition="'$(BuildSuffix)' == ''">$(SqlClientNextVersion)</SqlClientPackageVersion>
+        <_SqlClientCandidateVersion>$(SqlClientNextVersion)</_SqlClientCandidateVersion>
+        <_SqlClientCandidateVersion Condition="'$(BuildSuffix)' != ''">$(SqlClientNextVersion)-$(BuildSuffix)</_SqlClientCandidateVersion>
+
+        <!-- A dash means a prerelease tag is present, from either source. -->
+        <SqlClientPackageVersion Condition="$(_SqlClientCandidateVersion.Contains('-'))">$(_SqlClientCandidateVersion).$(BuildNumber)</SqlClientPackageVersion>
+        <SqlClientPackageVersion Condition="!$(_SqlClientCandidateVersion.Contains('-'))">$(_SqlClientCandidateVersion)</SqlClientPackageVersion>
 
         <SqlClientFileVersion>$(SqlClientNextVersion.Split('-')[0]).$(FileVersionBuildNumber)</SqlClientFileVersion>
       </PropertyGroup>

--- a/src/Microsoft.SqlServer.Server/Versions.props
+++ b/src/Microsoft.SqlServer.Server/Versions.props
@@ -45,13 +45,8 @@
           not valid in a file version. Start with the suffix-free package base and append the
           configured file-version build number, which converts a three-part package version such as
           1.2.3-preview1 to 1.2.3.42.
-
-          A revision-enabled pipeline supplies a four-part package base such as 1.2.3.42. That base
-          is already a complete file version, so the following conditional assignment overrides the
-          fallback instead of producing an invalid five-part version.
         -->
         <SqlServerFileVersion>$(SqlServerPackageVersionBase).$(FileVersionBuildNumber)</SqlServerFileVersion>
-        <SqlServerFileVersion Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(SqlServerPackageVersionBase)', '^\d+\.\d+\.\d+\.\d+$'))">$(SqlServerPackageVersionBase)</SqlServerFileVersion>
       </PropertyGroup>
     </When>
 
@@ -60,18 +55,24 @@
         When a build number is provided, the default version is used as the base of the package and
         file versions.
 
-        If a build suffix is provided, this is appended to the package version. This is meant to be
-        used by automated pre-release systems to indicate the source of the build.
+        If a build suffix is provided, it is appended as a prerelease tag. This is meant to be used
+        by automated pre-release systems to indicate the source of the build.
 
-        If a build suffix is not provided, no pre-release tag will be added to package version. If
-        the default version already has a pre-release tag added to it (eg, "7.0.0-preview1") this
-        will be retained for the package version, but will be stripped off for the file version
-        (letters are not allowed in file/assembly versions). This is meant to be used by official
-        build pipelines to generate production-ready builds.
+        The build number is then appended to any version carrying a prerelease tag — whether that
+        tag came from the declared version or from the build suffix — so every automated run
+        produces a distinct package version (eg, "1.1.0-preview1" becomes
+        "1.1.0-preview1.26238.3"). A version with no prerelease tag is left exactly as declared,
+        because released packages are not stamped with a build number. The tag is always stripped
+        for the file version (letters are not allowed in file/assembly versions). This is meant to
+        be used by official build pipelines to generate production-ready builds.
       -->
       <PropertyGroup>
-        <SqlServerPackageVersion Condition="'$(BuildSuffix)' != ''">$(SqlServerNextVersion)-$(BuildSuffix)$(BuildNumber)</SqlServerPackageVersion>
-        <SqlServerPackageVersion Condition="'$(BuildSuffix)' == ''">$(SqlServerNextVersion)</SqlServerPackageVersion>
+        <_SqlServerCandidateVersion>$(SqlServerNextVersion)</_SqlServerCandidateVersion>
+        <_SqlServerCandidateVersion Condition="'$(BuildSuffix)' != ''">$(SqlServerNextVersion)-$(BuildSuffix)</_SqlServerCandidateVersion>
+
+        <!-- A dash means a prerelease tag is present, from either source. -->
+        <SqlServerPackageVersion Condition="$(_SqlServerCandidateVersion.Contains('-'))">$(_SqlServerCandidateVersion).$(BuildNumber)</SqlServerPackageVersion>
+        <SqlServerPackageVersion Condition="!$(_SqlServerCandidateVersion.Contains('-'))">$(_SqlServerCandidateVersion)</SqlServerPackageVersion>
 
         <SqlServerFileVersion>$(SqlServerNextVersion.Split('-')[0]).$(FileVersionBuildNumber)</SqlServerFileVersion>
       </PropertyGroup>

--- a/src/Microsoft.SqlServer.Server/Versions.props
+++ b/src/Microsoft.SqlServer.Server/Versions.props
@@ -102,10 +102,10 @@
     <SqlServerAssemblyVersion>$(SqlServerFileVersion.Split('.')[0]).0.0.0</SqlServerAssemblyVersion>
   </PropertyGroup>
 
-  <!-- Any version input with a four-part core pushes this past four components, failing later as CS7035. -->
+  <!-- FileVersionSqlServer overrides everything computed above, so validate the final value. -->
   <Target Name="ValidateSqlServerFileVersion" BeforeTargets="PrepareForBuild">
     <Error
-      Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(SqlServerFileVersion)', '^\d+\.\d+\.\d+\.\d+\.'))"
-      Text="SqlServerFileVersion '$(SqlServerFileVersion)' has more than four components. SqlServerPackageVersion ('$(SqlServerPackageVersion)') and SqlServerNextVersion ('$(SqlServerNextVersion)') must use a three-part core (major.minor.patch)." />
+      Condition="!$([System.Text.RegularExpressions.Regex]::IsMatch('$(SqlServerFileVersion)', '^\d+\.\d+\.\d+\.\d+$'))"
+      Text="SqlServerFileVersion '$(SqlServerFileVersion)' is not a four-part numeric version (major.minor.build.revision). Check FileVersionSqlServer, SqlServerPackageVersion ('$(SqlServerPackageVersion)') and SqlServerNextVersion ('$(SqlServerNextVersion)')." />
   </Target>
 </Project>

--- a/src/Microsoft.SqlServer.Server/Versions.props
+++ b/src/Microsoft.SqlServer.Server/Versions.props
@@ -101,4 +101,11 @@
   <PropertyGroup>
     <SqlServerAssemblyVersion>$(SqlServerFileVersion.Split('.')[0]).0.0.0</SqlServerAssemblyVersion>
   </PropertyGroup>
+
+  <!-- Any version input with a four-part core pushes this past four components, failing later as CS7035. -->
+  <Target Name="ValidateSqlServerFileVersion" BeforeTargets="PrepareForBuild">
+    <Error
+      Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(SqlServerFileVersion)', '^\d+\.\d+\.\d+\.\d+\.'))"
+      Text="SqlServerFileVersion '$(SqlServerFileVersion)' has more than four components. SqlServerPackageVersion ('$(SqlServerPackageVersion)') and SqlServerNextVersion ('$(SqlServerNextVersion)') must use a three-part core (major.minor.patch)." />
+  </Target>
 </Project>


### PR DESCRIPTION
Makes the `compute_versions` stage the single source of every version the OneBranch build jobs consume, so nothing is re-derived downstream.

### Remove the `addRevision` mode

Package versions had two mutually exclusive shapes. The revision shape (`7.1.0.34430-preview1`) is gone, along with the 16-bit wrapping of `Build.BuildId`, the four-part package base special case in both `Versions.props` files, and the `addRevision` queue-time parameter.

Worth noting the shape it removes was also a versioning hazard: a four-part core sorts *above* the stable release, so `7.1.0.34430-preview1` outranked `7.1.0` on the feed, and a four-part core with a prerelease tag isn't valid SemVer 2.0.

### Move package version stamping into `Versions.props`

`BuildSuffix` now does what it always documented — it turns a stable base into a prerelease. Any version carrying a prerelease tag, from either the declared version or the suffix, is stamped with the build number; released versions are left exactly as declared.

| `NextVersion` | `BuildSuffix` | Package version |
| --- | --- | --- |
| `7.1.0-preview3` | — (OneBranch) | `7.1.0-preview3.26238.3` |
| `7.1.0` | — (release branch) | `7.1.0` |
| `7.1.0-preview3` | `ci` | `7.1.0-preview3-ci.26238.3` |
| `7.1.0` | `ci` | `7.1.0-ci.26238.3` |
| — | — (local dev) | `7.1.0-preview3-dev` |

⚠️ **PR/CI package versions gain a dot** before the build number (`-ci26238.3` → `-ci.26238.3`), because the old suffix path fused them. This is a deliberate improvement: SemVer splits the prerelease on dots, so the build number now compares numerically instead of lexically (previously `…ci9` sorted above `…ci10`). No in-repo consumer string-matches the old form.

### Pass pre-computed file versions into the build jobs

Build jobs received a raw build number and re-derived the file version through MSBuild. They now receive the file version the `compute_versions` stage already computed. `build.proj` gains opt-in `FileVersionSqlClient` / `FileVersionSqlServer` arguments, which emit nothing unless set — so PR/CI and local builds are unchanged.

This also fixes a latent bug: `compute-versions.ps1` invoked the `GetVersions*` targets with a *different* build number than the build jobs used, then discarded the result and re-derived it in PowerShell.

Assembly version stays derived from the file version, as it's always `major.0.0.0`.

### Fix SBOM metadata

`globalSdl.sbom` reported `$(Build.BuildNumber)` (e.g. `26238.3`) as the version of a single hardcoded package name — a version matching no package produced, and used a single name for six different packages.  Now it expands the SDL template with macro-expansion variables `$(...)` whose values are defined by each package's build job, and then interpolated for SBOM use.  We are now using consistent package name/version values in each package's SBOM.

## Testing

- [Non-official OneBranch run 26250.2](https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=173089&view=results) succeeded; all build/pack stages consumed the expected package and file versions
