### PR TITLE
Feature, Public API | Enable SqlDataRecord support for TVPs with computed columns

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml
@@ -1,4 +1,4 @@
-﻿<docs>
+<docs>
   <members name="SqlMetaData">
     <SqlMetaData>
       <summary>
@@ -1490,6 +1490,22 @@
         The <paramref name="value" /> is <see langword="null" />.
       </exception>
     </InferFromValue>
+    <IsComputed>
+      <summary>
+        Indicates if this column is computed by the server.
+      </summary>
+      <value>
+        A <see cref="T:System.Boolean" /> value.
+      </value>
+      <remarks>
+        <para>
+          The default is <see langword="false" />.
+        </para>
+        <para>
+          This property can only be set from an object initializer immediately after construction of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+        </para>
+      </remarks>
+    </IsComputed>
     <IsUniqueKey>
       <summary>
         Indicates if the column in the table-valued parameter is unique.

--- a/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.Server.cs
+++ b/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.Server.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -215,6 +215,8 @@ public sealed class SqlMetaData
     public System.Data.SqlTypes.SqlCompareOptions CompareOptions { get { throw null; } }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/DbType/*' />
     public System.Data.DbType DbType { get { throw null; } }
+    /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/IsComputed/*' />
+    public bool IsComputed { get { throw null; } init { } }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/IsUniqueKey/*' />
     public bool IsUniqueKey { get { throw null; } }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/LocaleId/*' />

--- a/src/Microsoft.Data.SqlClient/ref/System.Runtime.CompilerServices.cs
+++ b/src/Microsoft.Data.SqlClient/ref/System.Runtime.CompilerServices.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if !NET
+
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Reserved to be used by the compiler for tracking metadata.
+/// This class should not be used by developers in source code.
+/// </summary>
+[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+internal static class IsExternalInit
+{
+}
+
+#endif

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiMetaData.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiMetaData.cs
@@ -349,6 +349,7 @@ namespace Microsoft.Data.SqlClient.Server
             ((SmiDefaultFieldsProperty)_extendedProperties[SmiPropertySelector.DefaultFields]).CheckCount(_fieldMetaData.Count);
             ((SmiOrderProperty)_extendedProperties[SmiPropertySelector.SortOrder]).CheckCount(_fieldMetaData.Count);
             ((SmiUniqueKeyProperty)_extendedProperties[SmiPropertySelector.UniqueKey]).CheckCount(_fieldMetaData.Count);
+            ((SmiComputedFieldsProperty)_extendedProperties[SmiPropertySelector.ComputedFields]).CheckCount(_fieldMetaData.Count);
 #endif
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiMetaDataProperty.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiMetaDataProperty.cs
@@ -18,12 +18,13 @@ namespace Microsoft.Data.SqlClient.Server
         DefaultFields = 0x0,
         SortOrder = 0x1,
         UniqueKey = 0x2,
+        ComputedFields = 0x3,
     }
 
     // Simple collection for properties.  Could extend to IDictionary support if needed in future.
     internal class SmiMetaDataPropertyCollection
     {
-        private const int SelectorCount = 3;  // number of elements in SmiPropertySelector
+        private const int SelectorCount = 4;  // number of elements in SmiPropertySelector
 
         private readonly SmiMetaDataProperty[] _properties;
         private bool _isReadOnly;
@@ -32,6 +33,7 @@ namespace Microsoft.Data.SqlClient.Server
         private static readonly SmiDefaultFieldsProperty s_emptyDefaultFields = new SmiDefaultFieldsProperty(new List<bool>());
         private static readonly SmiOrderProperty s_emptySortOrder = new SmiOrderProperty(new List<SmiOrderProperty.SmiColumnOrder>());
         private static readonly SmiUniqueKeyProperty s_emptyUniqueKey = new SmiUniqueKeyProperty(new List<bool>());
+        private static readonly SmiComputedFieldsProperty s_emptyIsComputedField = new SmiComputedFieldsProperty(new List<bool>());
 
         internal static readonly SmiMetaDataPropertyCollection s_emptyInstance = CreateEmptyInstance();
 
@@ -49,6 +51,7 @@ namespace Microsoft.Data.SqlClient.Server
             _properties[(int)SmiPropertySelector.DefaultFields] = s_emptyDefaultFields;
             _properties[(int)SmiPropertySelector.SortOrder] = s_emptySortOrder;
             _properties[(int)SmiPropertySelector.UniqueKey] = s_emptyUniqueKey;
+            _properties[(int)SmiPropertySelector.ComputedFields] = s_emptyIsComputedField;
         }
 
         internal SmiMetaDataProperty this[SmiPropertySelector key]
@@ -264,6 +267,69 @@ namespace Microsoft.Data.SqlClient.Server
                 }
 
                 if (_defaults[columnOrd])
+                {
+                    returnValue += columnOrd;
+                }
+            }
+            returnValue += ")";
+
+            return returnValue;
+        }
+
+        #endregion
+    }
+
+    internal class SmiComputedFieldsProperty : SmiMetaDataProperty
+    {
+        #region private fields
+
+        private readonly IList<bool> _computed;
+
+        #endregion
+
+        #region internal interface
+
+        internal SmiComputedFieldsProperty(IList<bool> computedFields) => _computed = new System.Collections.ObjectModel.ReadOnlyCollection<bool>(computedFields);
+
+        internal bool this[int ordinal]
+        {
+            get
+            {
+                if (_computed.Count <= ordinal)
+                {
+                    return false;
+                }
+                else
+                {
+                    return _computed[ordinal];
+                }
+            }
+        }
+
+        [Conditional("DEBUG")]
+        internal void CheckCount(int countToMatch)
+        {
+            Debug.Assert(0 == _computed.Count || countToMatch == _computed.Count,
+                    "SmiComputedFieldsProperty.CheckCount: ComputedFieldsProperty size (" + _computed.Count +
+                    ") not equal to checked size (" + countToMatch + ")");
+        }
+
+        internal override string TraceString()
+        {
+            string returnValue = "ComputedFields(";
+            bool delimit = false;
+            for (int columnOrd = 0; columnOrd < _computed.Count; columnOrd++)
+            {
+                if (delimit)
+                {
+                    returnValue += ",";
+                }
+                else
+                {
+                    delimit = true;
+                }
+
+                if (_computed[columnOrd])
                 {
                     returnValue += columnOrd;
                 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlMetaData.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlMetaData.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -504,6 +504,9 @@ namespace Microsoft.Data.SqlClient.Server
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/UseServerDefault/*' />
         public bool UseServerDefault => _useServerDefault;
+
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/IsComputed/*' />
+        public bool IsComputed { get; init; }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/XmlSchemaCollectionDatabase/*' />
         public string XmlSchemaCollectionDatabase => _xmlSchemaCollectionDatabase;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlParameter.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlParameter.cs
@@ -1334,9 +1334,11 @@ namespace Microsoft.Data.SqlClient
                             bool[] keyCols = new bool[fieldCount];
                             bool[] defaultFields = new bool[fieldCount];
                             bool[] sortOrdinalSpecified = new bool[fieldCount];
+                            bool[] computedFields = new bool[fieldCount];
                             int maxSortOrdinal = -1;  // largest sort ordinal seen, used to optimize locating holes in the list
                             bool hasKey = false;
                             bool hasDefault = false;
+                            bool hasComputedFields = false;
                             int sortCount = 0;
                             SmiOrderProperty.SmiColumnOrder[] sort = new SmiOrderProperty.SmiColumnOrder[fieldCount];
                             fields = new List<SmiExtendedMetaData>(fieldCount);
@@ -1354,6 +1356,16 @@ namespace Microsoft.Data.SqlClient
                                 {
                                     defaultFields[i] = true;
                                     hasDefault = true;
+                                }
+
+                                if (colMeta.IsComputed)
+                                {
+                                    // A computed column will always have a default value, so skip writing
+                                    // its values out to the TDS stream.
+                                    defaultFields[i] = true;
+                                    computedFields[i] = true;
+                                    hasDefault = true;
+                                    hasComputedFields = true;
                                 }
 
                                 sort[i]._order = colMeta.SortOrder;
@@ -1398,6 +1410,14 @@ namespace Microsoft.Data.SqlClient
                                 }
 
                                 props[SmiPropertySelector.DefaultFields] = new SmiDefaultFieldsProperty(new List<bool>(defaultFields));
+                            }
+
+                            if (hasComputedFields)
+                            {
+                                // We've already created props list in default value handling
+                                Debug.Assert(props is not null);
+
+                                props[SmiPropertySelector.ComputedFields] = new SmiComputedFieldsProperty(new List<bool>(computedFields));
                             }
 
                             if (0 < sortCount)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -445,6 +445,7 @@ namespace Microsoft.Data.SqlClient
         public const byte TVP_ORDER_UNIQUE_TOKEN = 0x10;
 
         // TvpColumnMetaData flags
+        public const int TVP_COMPUTED_COLUMN = 0x20;
         public const int TVP_DEFAULT_COLUMN = 0x200;
 
         // TVP_ORDER_UNIQUE_TOKEN flags

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -11261,9 +11261,10 @@ namespace Microsoft.Data.SqlClient
 
                 // TvpColumnMetaData for each column (look for defaults in this loop
                 SmiDefaultFieldsProperty defaults = (SmiDefaultFieldsProperty)metaData.ExtendedProperties[SmiPropertySelector.DefaultFields];
+                SmiComputedFieldsProperty computedFields = (SmiComputedFieldsProperty)metaData.ExtendedProperties[SmiPropertySelector.ComputedFields];
                 for (int i = 0; i < metaData.FieldMetaData.Count; i++)
                 {
-                    WriteTvpColumnMetaData(metaData.FieldMetaData[i], defaults[i], stateObj);
+                    WriteTvpColumnMetaData(metaData.FieldMetaData[i], defaults[i], computedFields[i], stateObj);
                 }
 
                 // optional OrderUnique metadata
@@ -11275,7 +11276,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         // Write a single TvpColumnMetaData stream to the server
-        private void WriteTvpColumnMetaData(SmiExtendedMetaData md, bool isDefault, TdsParserStateObject stateObj)
+        private void WriteTvpColumnMetaData(SmiExtendedMetaData md, bool isDefault, bool isComputed, TdsParserStateObject stateObj)
         {
             // User Type
             if (SqlDbType.Timestamp == md.SqlDbType)
@@ -11292,6 +11293,10 @@ namespace Microsoft.Data.SqlClient
             if (isDefault)
             {
                 status |= TdsEnums.TVP_DEFAULT_COLUMN;
+            }
+            if (isComputed)
+            {
+                status |= TdsEnums.TVP_COMPUTED_COLUMN;
             }
             WriteUnsignedShort(status, stateObj);
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TableValuedParameter/ComputedFieldTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TableValuedParameter/ComputedFieldTests.cs
@@ -1,0 +1,140 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Runtime.CompilerServices;
+using Microsoft.Data.SqlClient.Server;
+using Microsoft.Data.SqlClient.Tests.Common.Fixtures.DatabaseObjects;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.ManualTesting.Tests.TableValuedParameter;
+
+[Trait("Set", "3")]
+public class ComputedFieldTests
+{
+    [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ComputedFieldValues_ReturnedByServer(bool explicitlySpecifyValue) =>
+        SendComputedFieldsAndAssert(explicitlySpecifyValue, recordCount: 20, markFieldAsComputed: true);
+
+    [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+    public void UnmarkedComputedFieldValues_RejectedByServer()
+    {
+        Action sendTVP = () => SendComputedFieldsAndAssert(explicitlySpecifyValue: false, recordCount: 20, markFieldAsComputed: false);
+
+        SqlException serverException = Assert.Throws<SqlException>(sendTVP);
+
+        Assert.Equal(271, serverException.Number);
+        Assert.Equal(1, serverException.State);
+        Assert.Contains("The column \"Sum\" cannot be modified because it is either a computed column or is the result of a UNION operator.", serverException.Message);
+        Assert.Contains("The column \"CastSum\" cannot be modified because it is either a computed column or is the result of a UNION operator.", serverException.Message);
+    }
+
+    [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+    public void MismatchedComputedFieldLength_IgnoredByServer() =>
+        SendComputedFieldsAndAssert(explicitlySpecifyValue: false, recordCount: 20, markFieldAsComputed: true, nvarcharMaxLength: 1);
+
+    private void SendComputedFieldsAndAssert(
+        bool explicitlySpecifyValue,
+        int recordCount,
+        bool markFieldAsComputed,
+        int nvarcharMaxLength = 50,
+        [CallerMemberName] string callerName = nameof(SendComputedFieldsAndAssert))
+    {
+        // TombstoneValue must always be a value which is never equal to [i + i + 1] for any "i" value
+        // between 0 and recordCount - 1. This is to ensure that the computed column value is not equal
+        // to the tombstone value when explicitly specified.
+        const int TombstoneValue = 0;
+
+        // Arrange
+        using SqlConnection conn = new(DataTestUtility.TCPConnectionString);
+        using UserDefinedType udt = new(conn, callerName, @"
+            TABLE
+            (
+                Value1 INT NOT NULL,
+                Sum AS (Value1 + Value2),
+                Value2 INT NOT NULL,
+                CastSum AS (CAST((Value1 + Value2) AS NVARCHAR(50)))
+            )");
+        using StoredProcedure sp = new(conn, callerName, $@"
+            @PrecedingValue INT,
+            @tvp {udt.Name} READONLY,
+            @SubsequentValue INT
+            AS
+            BEGIN
+                SELECT Value1, Value2, Sum, CastSum FROM @tvp;
+                SELECT @PrecedingValue AS PrecedingValue, @SubsequentValue AS SubsequentValue;
+            END");
+        SqlMetaData[] metaDatas = [
+            new SqlMetaData("Value1", SqlDbType.Int),
+            new SqlMetaData("Sum", SqlDbType.Int) { IsComputed = markFieldAsComputed },
+            new SqlMetaData("Value2", SqlDbType.Int),
+            new SqlMetaData("CastSum", SqlDbType.NVarChar, maxLength: nvarcharMaxLength) { IsComputed = markFieldAsComputed }
+        ];
+        List<SqlDataRecord> records = [];
+
+        for (int i = 0; i < recordCount; i++)
+        {
+            SqlDataRecord record = new(metaDatas);
+            record.SetInt32(0, i);
+            record.SetInt32(2, i + 1);
+
+            if (explicitlySpecifyValue)
+            {
+                record.SetInt32(1, TombstoneValue);
+                record.SetString(3, TombstoneValue.ToString());
+            }
+
+            records.Add(record);
+        }
+
+        using SqlCommand cmd = new(sp.Name, conn) { CommandType = CommandType.StoredProcedure };
+        cmd.Parameters.AddWithValue("@PrecedingValue", 50);
+
+        SqlParameter tvpParam = cmd.Parameters.Add("@tvp", SqlDbType.Structured);
+        tvpParam.TypeName = udt.Name;
+        tvpParam.Value = records;
+
+        cmd.Parameters.AddWithValue("@SubsequentValue", 100);
+
+        // Act
+        using SqlDataReader reader = cmd.ExecuteReader();
+        int returnedRecordCount = 0;
+
+        // Assert
+        while (reader.Read())
+        {
+            int value1 = reader.GetInt32(0);
+            int value2 = reader.GetInt32(1);
+            int sum = reader.GetInt32(2);
+            string castSum = reader.GetString(3);
+
+            Assert.Equal(value1 + value2, sum);
+            Assert.Equal((value1 + value2).ToString(), castSum);
+
+            if (explicitlySpecifyValue)
+            {
+                Assert.NotEqual(TombstoneValue, sum);
+                Assert.NotEqual(TombstoneValue.ToString(), castSum);
+            }
+            returnedRecordCount++;
+        }
+
+        bool nextResult = reader.NextResult();
+        Assert.True(nextResult);
+
+        nextResult = reader.Read();
+        Assert.True(nextResult);
+
+        Assert.Equal(cmd.Parameters["@PrecedingValue"].Value, reader.GetInt32(0));
+        Assert.Equal(cmd.Parameters["@SubsequentValue"].Value, reader.GetInt32(1));
+
+        Assert.Equal(recordCount, returnedRecordCount);
+    }
+}


### PR DESCRIPTION
## Description

The MS-TDS spec supports a client recognising that a field in a table-valued parameter might well be computed by the server. An example of a TVP which does this is:
```sql
CREATE TYPE [dbo].[MyType] AS TABLE
(
    [Value1] INT NOT NULL,
    [Value2] INT NOT NULL,
    [Added] AS ([Value1] + [Value2])
)
```

Under such circumstances, the client can set the `fComputed` bit in the [`TVP_COLMETADATA`](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/0dfc5367-a388-4c92-9ba4-4d28e775acbc) definition. We also need to set the `fDefault` bit - without setting this, SQL Server expects the client to send a value for the computed column, and throws an exception indicating that I'm trying to overwrite a computed column with a value when we send one.

Once the `fComputed` bit is set, the computed columns in the TVP are populated by SQL Server as we'd expect.

Enabling the client to set this necessitates a public API change of some form. In this case, I've added an `IsComputed` property to `SqlMetaData`:
```cs
public sealed class SqlMetaData
{
    public bool IsComputed { get; init; }
}
```

This is a slightly different approach to the public API than the current set of constructors, but I think it's the most practical one - I think most of the constructors would want to be able to specify whether the field is computed, and we'd essentially double the number of constructors if adding a separate parameter to all of them.

I'm leaving this PR in draft until there's time for the public API to be reviewed. Once we're happy with it, I'll adjust the API surface accordingly.

@mdaigle - this intersects with some of the work you'd been doing on the issue and provides a fix for `SqlDataRecord`.

## Issues

Fixes #3242. It doesn't introduce anything to enable `DataTable`- or `DbDataReader`-based support, but I don't think there's a way to enable that support client-side.

## Testing

New manual tests have been added, and all pass.