### PR TITLE
Backport official US English locale name to 7.1

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml
@@ -505,7 +505,7 @@ The following example creates multiple instances of <xref:Microsoft.Data.SqlClie
           {
               SqlParameter parameter = new SqlParameter("pName", SqlDbType.VarChar);
               parameter.LocaleId = 1033;
-              // English - United States
+              // English (United States)
           }
         </code>
       </remarks>


### PR DESCRIPTION
Backports #4646 for Azure DevOps task 45863. This is a docs-only, one-line correction that uses the official US English locale name.