### PR TITLE
Resolve PoliCheck severity 2 findings

### DIFF
--- a/.config/PolicheckExclusions.xml
+++ b/.config/PolicheckExclusions.xml
@@ -1,5 +1,5 @@
 <PoliCheckExclusions>
     <Exclusion Type="FolderPathStart">SRC/MICROSOFT.DATA.SQLCLIENT/TESTS</Exclusion>
     <Exclusion Type="FileType">.YML|.MD|.SQL</Exclusion>
-    <Exclusion Type="FileName">NOTICE.TXT|SQLDATAADAPTER.CS</Exclusion>
+    <Exclusion Type="FileName">NOTICE.TXT|SQLDATAADAPTER.CS|SQLDATAADAPTER.XML</Exclusion>
 </PoliCheckExclusions>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -1306,7 +1306,7 @@ namespace Microsoft.Data.SqlClient
         #region Internal Methods
 
         // @TODO: This is only called by SqlCommandBuilder, it should live there. EXCEPT for the one call to ValidateCommand and setting _parameters at the end. Is that really necessary?
-        // @TODO: This also an crazy long method.
+        // @TODO: This method is also excessively long.
         internal void DeriveParameters()
         {
             switch (CommandType)


### PR DESCRIPTION
## Summary

- replace inaccessible wording in an internal `SqlCommand` comment
- exclude the generated Northwind `SqlDataAdapter.xml` snippet, where `Country` is a required schema identifier and a contextual false positive
- retain the existing exact-file PoliCheck exclusion pattern

Azure DevOps task: [45859](https://sqlclientdrivers.visualstudio.com/ADO.Net/_workitems/edit/45859)

## Validation

OneBranch non-official build [26251.1 / 173251](https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=173251&view=results) scanned commit `4a4b9cfb98c53bab04e67beab26c1d28d4c80260` with PoliCheck. The published `policheck.xml` reports 1,008 files scanned and zero Sev 1, Sev 2, Sev 3, or Sev 4 occurrences.

The overall build remains failed because of the existing Abstractions APIScan `documentationnotfound` result; the `SDLSources` PoliCheck task, post-analysis, and artifact publication succeeded.

- [x] Tests added or updated — not applicable; source behavior is unchanged
- [x] Public API changes documented — not applicable
- [x] Verified against customer repro — not applicable
- [x] Ensure no breaking changes introduced