### PR TITLE
Backport PoliCheck severity 2 remediations to 7.1

### DIFF
--- a/.config/PolicheckExclusions.xml
+++ b/.config/PolicheckExclusions.xml
@@ -1,5 +1,5 @@
 <PoliCheckExclusions>
     <Exclusion Type="FolderPathStart">SRC/MICROSOFT.DATA.SQLCLIENT/TESTS</Exclusion>
     <Exclusion Type="FileType">.YML|.MD|.SQL</Exclusion>
-    <Exclusion Type="FileName">NOTICE.TXT|SQLDATAADAPTER.CS</Exclusion>
+    <Exclusion Type="FileName">NOTICE.TXT|SQLDATAADAPTER.CS|SQLDATAADAPTER.XML</Exclusion>
 </PoliCheckExclusions>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -1306,7 +1306,7 @@ namespace Microsoft.Data.SqlClient
         #region Internal Methods
 
         // @TODO: This is only called by SqlCommandBuilder, it should live there. EXCEPT for the one call to ValidateCommand and setting _parameters at the end. Is that really necessary?
-        // @TODO: This also an crazy long method.
+        // @TODO: This method is also excessively long.
         internal void DeriveParameters()
         {
             switch (CommandType)


### PR DESCRIPTION
## Summary  - add the exact `SQLDATAADAPTER.XML` PoliCheck filename exclusion used by #4658 - replace the inappropriate `SqlCommand.cs` comment with the neutral wording from #4658 - provide the `release/7.1-staging` counterpart of #4658 without source behavior or public API changes  Azure DevOps task: [45859](https://sqlclientdrivers.visualstudio.com/ADO.Net/_workitems/edit/45859) Source PR: #4658
Milestone: `7.1.0`  ## Validation  - confirmed the backport has the same stable patch ID as commit `4a4b9cfb98c53bab04e67beab26c1d28d4c80260` - parsed `.config/PolicheckExclusions.xml` and confirmed exactly one `SQLDATAADAPTER.XML` filename exclusion - confirmed the diff contains only the two requested one-line remediations  - [x] Tests added or updated — not applicable; source behavior is unchanged - [x] Public API changes documented — not applicable - [x] Verified against customer repro — not applicable - [x] Ensure no breaking changes introduced