### PR TITLE
Remove RID-specific SqlClient DLLs

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.nuspec
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.nuspec
@@ -134,11 +134,11 @@
       should be packaged.
     -->
 
-    <!-- Lib Binaries ================================================== -->
+    <!-- Lib and Runtime Binaries ================================================== -->
     <!-- lib/net462 - These contain the implementation -->
     <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net462\Microsoft.Data.SqlClient.dll" target="lib\net462\" exclude="" />
     <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net462\Microsoft.Data.SqlClient.pdb" target="lib\net462\" exclude="" />
-    <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net462\Microsoft.Data.SqlClient.xml" target="lib\net462\" exclude="" />
+    <file src="Microsoft.Data.SqlClient.ref\$ReferenceType$-$Configuration$\net462\Microsoft.Data.SqlClient.xml" target="lib\net462\" exclude="" />
 
     <!-- lib/net462 Localized Resources -->
     <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net462\cs\Microsoft.Data.SqlClient.resources.dll" target="lib\net462\cs\" exclude="" />
@@ -155,9 +155,9 @@
     <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net462\zh-Hans\Microsoft.Data.SqlClient.resources.dll" target="lib\net462\zh-Hans\" exclude="" />
     <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net462\zh-Hant\Microsoft.Data.SqlClient.resources.dll" target="lib\net462\zh-Hant\" exclude="" />
 
-    <!-- lib/net8.0 - These are PlatformNotSupportedException assemblies -->
-    <file src="Microsoft.Data.SqlClient.notsupported\$ReferenceType$-$Configuration$\net8.0\Microsoft.Data.SqlClient.dll" target="lib\net8.0\" exclude="" />
-    <file src="Microsoft.Data.SqlClient.notsupported\$ReferenceType$-$Configuration$\net8.0\Microsoft.Data.SqlClient.pdb" target="lib\net8.0\" exclude="" />
+    <!-- lib/net8.0 - These contain the implementation -->
+    <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net8.0\Microsoft.Data.SqlClient.dll" target="lib\net8.0\" exclude="" />
+    <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net8.0\Microsoft.Data.SqlClient.pdb" target="lib\net8.0\" exclude="" />
     <file src="Microsoft.Data.SqlClient.ref\$ReferenceType$-$Configuration$\net8.0\Microsoft.Data.SqlClient.xml" target="lib\net8.0\" exclude="" />
 
     <!-- lib/net8.0 Localized Resources -->
@@ -175,9 +175,9 @@
     <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net8.0\zh-Hans\Microsoft.Data.SqlClient.resources.dll" target="lib\net8.0\zh-Hans\" exclude="" />
     <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net8.0\zh-Hant\Microsoft.Data.SqlClient.resources.dll" target="lib\net8.0\zh-Hant\" exclude="" />
 
-    <!-- lib/net9.0 - These are PlatformNotSupportedException assemblies -->
-    <file src="Microsoft.Data.SqlClient.notsupported\$ReferenceType$-$Configuration$\net9.0\Microsoft.Data.SqlClient.dll" target="lib\net9.0\" exclude="" />
-    <file src="Microsoft.Data.SqlClient.notsupported\$ReferenceType$-$Configuration$\net9.0\Microsoft.Data.SqlClient.pdb" target="lib\net9.0\" exclude="" />
+    <!-- lib/net9.0 - These contain the implementation -->
+    <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net9.0\Microsoft.Data.SqlClient.dll" target="lib\net9.0\" exclude="" />
+    <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net9.0\Microsoft.Data.SqlClient.pdb" target="lib\net9.0\" exclude="" />
     <file src="Microsoft.Data.SqlClient.ref\$ReferenceType$-$Configuration$\net9.0\Microsoft.Data.SqlClient.xml" target="lib\net9.0\" exclude="" />
 
     <!-- lib/net9.0 Localized Resources -->
@@ -195,6 +195,7 @@
     <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net9.0\zh-Hans\Microsoft.Data.SqlClient.resources.dll" target="lib\net9.0\zh-Hans\" exclude="" />
     <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net9.0\zh-Hant\Microsoft.Data.SqlClient.resources.dll" target="lib\net9.0\zh-Hant\" exclude="" />
 
+    <!-- @TODO: This is a temporary measure - removing the notsupported DLLs will come next -->
     <!-- lib/netstandard2.0 - These are PlatformNotSupportedException assemblies -->
     <file src="Microsoft.Data.SqlClient.notsupported\$ReferenceType$-$Configuration$\netstandard2.0\Microsoft.Data.SqlClient.dll" target="lib\netstandard2.0\" exclude="" />
     <file src="Microsoft.Data.SqlClient.notsupported\$ReferenceType$-$Configuration$\netstandard2.0\Microsoft.Data.SqlClient.pdb" target="lib\netstandard2.0\" exclude="" />
@@ -216,29 +217,5 @@
     <!-- ref/netstandard2.0 -->
     <file src="Microsoft.Data.SqlClient.ref\$ReferenceType$-$Configuration$\netstandard2.0\Microsoft.Data.SqlClient.dll" target="ref\netstandard2.0\" exclude="" />
     <file src="Microsoft.Data.SqlClient.ref\$ReferenceType$-$Configuration$\netstandard2.0\Microsoft.Data.SqlClient.xml" target="ref\netstandard2.0\" exclude="" />
-
-    <!-- Runtime Binaries ============================================== -->
-    <!-- @TODO: This is a temporary measure - removing the not support DLLs will come next -->
-
-    <!-- runtimes/win/lib/net462 -->
-    <!-- @TODO: We include the impl version in the lib folder - is the runtimes version necessary? -->
-    <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net462\Microsoft.Data.SqlClient.dll" target="runtimes\win\lib\net462\" exclude="" />
-    <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net462\Microsoft.Data.SqlClient.pdb" target="runtimes\win\lib\net462\" exclude="" />
-
-    <!-- runtimes/unix/lib/net8.0 -->
-    <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net8.0\Microsoft.Data.SqlClient.dll" target="runtimes\unix\lib\net8.0\" exclude="" />
-    <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net8.0\Microsoft.Data.SqlClient.pdb" target="runtimes\unix\lib\net8.0\" exclude="" />
-
-    <!-- runtimes/win/lib/net8.0 -->
-    <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net8.0\Microsoft.Data.SqlClient.dll" target="runtimes\win\lib\net8.0\" exclude="" />
-    <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net8.0\Microsoft.Data.SqlClient.pdb" target="runtimes\win\lib\net8.0\" exclude="" />
-
-    <!-- runtimes/unix/lib/net9.0 -->
-    <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net9.0\Microsoft.Data.SqlClient.dll" target="runtimes\unix\lib\net9.0\" exclude="" />
-    <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net9.0\Microsoft.Data.SqlClient.pdb" target="runtimes\unix\lib\net9.0\" exclude="" />
-
-    <!-- runtimes/win/lib/net9.0 -->
-    <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net9.0\Microsoft.Data.SqlClient.dll" target="runtimes\win\lib\net9.0\" exclude="" />
-    <file src="Microsoft.Data.SqlClient\$ReferenceType$-$Configuration$\net9.0\Microsoft.Data.SqlClient.pdb" target="runtimes\win\lib\net9.0\" exclude="" />
   </files>
 </package>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft.Data.SqlClient.UnitTests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft.Data.SqlClient.UnitTests.csproj
@@ -46,17 +46,13 @@
 
   <!--
     Package mode: Unit tests exercise internal types that only exist in the implementation assembly
-    (runtimes/{rid}/lib/{tfm}/), not in the ref assembly (ref/{tfm}/).  We exclude the ref
-    compile asset and reference the runtime DLL directly so the compiler can see internals.
+    (lib/{tfm}/), not in the ref assembly (ref/{tfm}/).  We exclude the ref compile asset and reference
+    the runtime DLL directly so the compiler can see internals.
 
     TODO: This is fragile, depending on our SqlClient NuGet package layout and supported TFMs.  It
         is only necessary because we produce ref and not-supported assemblies and package them.  By
         default, the compiler will use the ref assemblies if present, which we must explicitly override
         as explained above.
-  -->
-  <!--
-    @TODO: This is a hack for now, the windows and unix nuget files are the same, so we just pick
-        one and use it for all scenarios. Remove this silliness when unsupported binaries are removed
   -->
   <PropertyGroup Condition="'$(ReferenceType)' == 'Package'">
     <!-- Map test TFM to the closest available package TFM (package ships net8.0/net9.0/net462) -->
@@ -76,7 +72,7 @@
          exposed via InternalsVisibleTo.  The path uses $(PkgMicrosoft_Data_SqlClient) generated
          above to locate the runtime DLL inside the NuGet package layout. -->
     <Reference Include="Microsoft.Data.SqlClient"
-               HintPath="$(PkgMicrosoft_Data_SqlClient)/runtimes/win/lib/$(_SqlClientPackageTfm)/Microsoft.Data.SqlClient.dll" />
+               HintPath="$(PkgMicrosoft_Data_SqlClient)/lib/$(_SqlClientPackageTfm)/Microsoft.Data.SqlClient.dll" />
     <PackageReference Include="Microsoft.SqlServer.Server" />
   </ItemGroup>
 

--- a/tools/PackageValidator/src/SymbolResolver.cs
+++ b/tools/PackageValidator/src/SymbolResolver.cs
@@ -169,7 +169,7 @@ internal static class SymbolResolver
         }
 
         // A package may legitimately ship the same assembly (identical debug GUID) at more than one
-        // path — e.g. .NET Framework SqlClient appears in both lib/net462 and
+        // path — e.g. older versions of .NET Framework SqlClient appeared in both lib/net462 and
         // runtimes/win/lib/net462, and the symbol package mirrors it with an identical PDB in each
         // spot. Only the first PDB per GUID is indexed above, so every co-located assembly resolves
         // to that single PDB and the identical duplicate is never consumed, which would misreport it


### PR DESCRIPTION
## Description

In this PR, I'm removing the now-vestigial `runtimes/[rid]/lib/[tfm]` package paths. The binaries are always identical, so having one copy per RID no longer adds any value. A follow-up PR will deal with the `notsupported` project - that's probably going to be much larger, and I don't want the user-facing impact to get lost. Since that project is going to be removed anyway, I've also left its unnecessary TFM targets in situ.

I'm pushing this fix early to make sure it lands in 8.0.0 preview 1 and gets as much testing exposure as possible.

One other change appears in this: note that the XML documentation for net462 now comes from the ref project, rather than from the implementation project. This is deliberate, and it ensures that we no longer ship XML documentation for internal types. Note that `lib/net462/Microsoft.Data.SqlClient.xml` in v7.0.2 [currently includes these](https://nuget.info/packages/Microsoft.Data.SqlClient/7.0.2) and doing so makes net462 consistent with net8.0 and net9.0.

## Issues

Contributes to #4239.
Fixes #903.
Fixes #3006.
Fixes #3577.

## Testing

Unit tests run locally. I can reference the output nupkg via a netfx project which still uses packages.config, and by loading the DLL in `lib/net462` in PowerShell.