### PR TITLE
Fix | GetSchema("DataTypes") does not report json type on Azure SQL (…

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlMetaDataFactory.DataTypes.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlMetaDataFactory.DataTypes.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Data.SqlClient;
 
 internal sealed partial class SqlMetaDataFactory
 {
-    private static void LoadDataTypesDataTables(DataSet metaDataCollectionsDataSet)
+    private static void LoadDataTypesDataTables(DataSet metaDataCollectionsDataSet, bool jsonTypeSupported)
     {
         DataTable dataTypesDataTable = CreateDataTypesDataTable();
 
@@ -58,8 +58,10 @@ internal sealed partial class SqlMetaDataFactory
             minimumVersion: "10.00.000.0");
 
         AddLongStringOrBinaryType(SqlDbType.Xml);
-        AddLongStringOrBinaryType(SqlDbTypeExtensions.Json, literalPrefix: "'", literalSuffix: "'",
-            minimumVersion: "17.00.000.0");
+        if (jsonTypeSupported)
+        {
+            AddLongStringOrBinaryType(SqlDbTypeExtensions.Json, literalPrefix: "'", literalSuffix: "'");
+        }
         AddLongStringOrBinaryType(SqlDbType.Text, literalPrefix: "'", literalSuffix: "'");
         AddLongStringOrBinaryType(SqlDbType.NText, literalPrefix: "N'", literalSuffix: "'");
         AddLongStringOrBinaryType(SqlDbType.Image, literalPrefix: "0x");

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlMetaDataFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlMetaDataFactory.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Data.SqlClient
 
         private readonly DataSet _collectionDataSet;
         private readonly string _serverVersion;
+        private readonly bool _jsonTypeSupported;
 
         public SqlMetaDataFactory(Stream xmlStream, ConnectionCapabilities connectionCapabilities)
         {
@@ -47,6 +48,7 @@ namespace Microsoft.Data.SqlClient
             ADP.CheckArgumentNull(connectionCapabilities.ServerVersion, nameof(connectionCapabilities.ServerVersion));
 
             _serverVersion = connectionCapabilities.ServerVersion;
+            _jsonTypeSupported = connectionCapabilities.JsonType;
 
             _collectionDataSet = LoadDataSetFromXml(xmlStream);
         }
@@ -711,7 +713,7 @@ namespace Microsoft.Data.SqlClient
                 Locale = CultureInfo.InvariantCulture
             };
 
-            LoadDataTypesDataTables(metaDataCollectionsDataSet);
+            LoadDataTypesDataTables(metaDataCollectionsDataSet, _jsonTypeSupported);
 
             XmlReaderSettings settings = new()
             {

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlMetaDataFactoryDataTypesTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlMetaDataFactoryDataTypesTest.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Data;
+using System.Data.Common;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests;
+
+/// <summary>
+/// Tests that <see cref="SqlMetaDataFactory"/> correctly reports the <c>json</c> data type
+/// in the <c>DataTypes</c> schema collection based on <see cref="ConnectionCapabilities.JsonType"/>.
+/// </summary>
+public sealed class SqlMetaDataFactoryDataTypesTest
+{
+    private static Stream GetMetaDataXmlStream()
+    {
+        Assembly assembly = typeof(SqlConnection).Assembly;
+        Stream? stream = assembly.GetManifestResourceStream("Microsoft.Data.SqlClient.SqlMetaData.xml");
+        Assert.NotNull(stream);
+        return stream;
+    }
+
+    private static SqlMetaDataFactory CreateFactory(bool jsonTypeSupported)
+    {
+        Stream stream = GetMetaDataXmlStream();
+        ConnectionCapabilities capabilities = new()
+        {
+            TdsVersion = TdsEnums.TDS7X_VERSION,
+            ServerMajorVersion = 12,
+            ServerMinorVersion = 0,
+            ServerBuildNumber = 0,
+            JsonType = jsonTypeSupported
+        };
+        return new SqlMetaDataFactory(stream, capabilities);
+    }
+
+    private static bool DataTypesContainsJson(SqlMetaDataFactory factory)
+    {
+        FieldInfo? field = typeof(SqlMetaDataFactory)
+            .GetField("_collectionDataSet", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(field);
+
+        DataSet? dataSet = (DataSet?)field.GetValue(factory);
+        Assert.NotNull(dataSet);
+
+        DataTable? dataTypes = dataSet.Tables[DbMetaDataCollectionNames.DataTypes];
+        Assert.NotNull(dataTypes);
+
+        DataColumn? typeNameColumn = dataTypes.Columns[DbMetaDataColumnNames.TypeName];
+        Assert.NotNull(typeNameColumn);
+
+        return dataTypes.Rows
+            .Cast<DataRow>()
+            .Any(row => (string)row[typeNameColumn] == "json");
+    }
+
+    /// <summary>
+    /// Verifies that <c>json</c> appears in the DataTypes schema collection when
+    /// <see cref="ConnectionCapabilities.JsonType"/> is <see langword="true"/>.
+    /// </summary>
+    [Fact]
+    public void DataTypesTable_ContainsJson_WhenJsonTypeSupported()
+    {
+        using SqlMetaDataFactory factory = CreateFactory(jsonTypeSupported: true);
+
+        Assert.True(DataTypesContainsJson(factory));
+    }
+
+    /// <summary>
+    /// Verifies that <c>json</c> does not appear in the DataTypes schema collection when
+    /// <see cref="ConnectionCapabilities.JsonType"/> is <see langword="false"/>, covering
+    /// Azure SQL which always reports version 12.x regardless of json support.
+    /// </summary>
+    [Fact]
+    public void DataTypesTable_DoesNotContainJson_WhenJsonTypeNotSupported()
+    {
+        using SqlMetaDataFactory factory = CreateFactory(jsonTypeSupported: false);
+
+        Assert.False(DataTypesContainsJson(factory));
+    }
+}


### PR DESCRIPTION
## Description

`SqlMetaDataFactory` previously determined whether to include the `json` data type
in the `GetSchema("DataTypes")` result by comparing the server version string against
a minimum version of `"17.00.000.0"`. This check fails for Azure SQL because Azure SQL
always reports version `12.00.xxxx` in the LoginAck response, regardless of which
features it actually supports.

The fix replaces the version-based check with `ConnectionCapabilities.JsonType`, a
boolean flag that is set to `true` when the server sends a FEATUREEXTACK token `0x0D`
during login. This token is already parsed and stored for other json-related features
and accurately reflects json support on both on-premises SQL Server 2025+ and Azure SQL.

No API changes. No backwards compatibility concerns. No localization changes.

## Issues

Fixes #4592

## Testing

**Unit tests added** in
`tests/UnitTests/Microsoft/Data/SqlClient/SqlMetaDataFactoryDataTypesTest.cs`:

- `DataTypesTable_ContainsJson_WhenJsonTypeSupported` — verifies that `json` appears
  in the `DataTypes` collection when `ConnectionCapabilities.JsonType` is `true`.
- `DataTypesTable_DoesNotContainJson_WhenJsonTypeNotSupported` — verifies that `json`
  does not appear when `ConnectionCapabilities.JsonType` is `false`, covering the Azure
  SQL scenario where the server version is always `12.x`.

Both tests construct a `SqlMetaDataFactory` directly using the production XML metadata
resource and a `ConnectionCapabilities` instance with the relevant flag set.

Integration testing against a live Azure SQL instance with json support enabled would
confirm the end-to-end behavior but was not performed in this contribution. The unit
tests cover the decision logic that was broken.